### PR TITLE
12 fix cp command

### DIFF
--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -167,7 +167,6 @@ func DownloadFile(ac *client.AlpaconClient, src, dest, username, groupname strin
 		maxAttempts := 100
 		var resp *http.Response
 		for count := 0; count < maxAttempts; count++ {
-			//resp, err = ac.SendGetRequestForDownload(utils.RemovePrefixBeforeAPI(downloadResponse.DownloadURL))
 			resp, err = http.Get(downloadResponse.DownloadURL)
 			if err != nil {
 				return err

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -164,7 +164,6 @@ func DownloadFile(ac *client.AlpaconClient, src, dest, username, groupname strin
 		}
 		utils.CliWarning("File Transfer Status: '%s'. Attempting to transfer '%s' from the Alpacon server. Note: Transfer may timeout after 100 seconds.", status.Result, path)
 
-		fmt.Println(downloadResponse.DownloadURL)
 		maxAttempts := 100
 		var resp *http.Response
 		for count := 0; count < maxAttempts; count++ {

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -24,7 +24,7 @@ const (
 )
 
 func uploadToS3(uploadUrl string, file io.Reader) error {
-	req, err := http.NewRequest("PUT", uploadUrl, file)
+	req, err := http.NewRequest(http.MethodPut, uploadUrl, file)
 	if err != nil {
 		return err
 	}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -70,16 +70,16 @@ func UploadFile(ac *client.AlpaconClient, src []string, dest, username, groupnam
 		}
 		_ = writer.Close()
 
-		body := map[string]string{
-			"id":        uuid.New().String(),
-			"name":      filepath.Base(filePath),
-			"path":      remotePath,
-			"server":    serverID,
-			"username":  username,
-			"groupname": groupname,
+		uploadRequest := &UploadRequest{
+			Id:        uuid.New().String(),
+			Name:      filepath.Base(filePath),
+			Path:      remotePath,
+			Server:    serverID,
+			Username:  username,
+			Groupname: groupname,
 		}
 
-		respBody, err := ac.SendPostRequest(uploadAPIURL, body)
+		respBody, err := ac.SendPostRequest(uploadAPIURL, uploadRequest)
 		if err != nil {
 			return nil, err
 		}
@@ -146,17 +146,17 @@ func UploadFolder(ac *client.AlpaconClient, src []string, dest, username, groupn
 		}
 		_ = writer.Close()
 
-		body := map[string]string{
-			"id":          uuid.New().String(),
-			"allow_unzip": "true",
-			"name":        zipName,
-			"path":        remotePath,
-			"server":      serverID,
-			"username":    username,
-			"groupname":   groupname,
+		uploadRequest := &UploadRequest{
+			Id:         uuid.New().String(),
+			AllowUnzip: "true",
+			Name:       zipName,
+			Path:       remotePath,
+			Server:     serverID,
+			Username:   username,
+			Groupname:  groupname,
 		}
 
-		respBody, err := ac.SendPostRequest(uploadAPIURL, body)
+		respBody, err := ac.SendPostRequest(uploadAPIURL, uploadRequest)
 		if err != nil {
 			return nil, err
 		}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -286,6 +286,9 @@ func DownloadFile(ac *client.AlpaconClient, src, dest, username, groupname strin
 			return err
 		}
 		err = utils.DeleteFile(filepath.Join(dest, fileName))
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -25,8 +25,7 @@ const (
 func uploadToS3(uploadUrl string, file io.Reader) error {
 	req, err := http.NewRequest("PUT", uploadUrl, file)
 	if err != nil {
-		utils.CliError("Failed to create PUT request: %w", err)
-		return nil
+		return err
 	}
 
 	req.Header.Set("Content-Type", "application/octet-stream")
@@ -34,13 +33,12 @@ func uploadToS3(uploadUrl string, file io.Reader) error {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		utils.CliError("Failed to execute PUT request: %w", err)
-		return nil
+		return err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("upload failed, status: %s", resp.Status)
+		return err
 	}
 	return nil
 }
@@ -96,7 +94,7 @@ func UploadFile(ac *client.AlpaconClient, src []string, dest, username, groupnam
 		if response.UploadUrl != "" {
 			err = uploadToS3(response.UploadUrl, bytes.NewReader(file))
 			if err != nil {
-				return nil, fmt.Errorf("failed to upload to S3: %w", err)
+				return nil, err
 			}
 		}
 

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -132,10 +132,12 @@ func DownloadFile(ac *client.AlpaconClient, src, dest, username, groupname strin
 
 	for _, path := range remotePaths {
 		downloadRequest := &DownloadRequest{
-			Path:      path,
-			Server:    serverID,
-			Username:  username,
-			Groupname: groupname,
+			Path:         path,
+			Name:         filepath.Base(path),
+			Server:       serverID,
+			Username:     username,
+			Groupname:    groupname,
+			ResourceType: "file",
 		}
 
 		postBody, err := ac.SendPostRequest(downloadAPIURL, downloadRequest)
@@ -162,10 +164,12 @@ func DownloadFile(ac *client.AlpaconClient, src, dest, username, groupname strin
 		}
 		utils.CliWarning("File Transfer Status: '%s'. Attempting to transfer '%s' from the Alpacon server. Note: Transfer may timeout after 100 seconds.", status.Result, path)
 
+		fmt.Println(downloadResponse.DownloadURL)
 		maxAttempts := 100
 		var resp *http.Response
 		for count := 0; count < maxAttempts; count++ {
-			resp, err = ac.SendGetRequestForDownload(utils.RemovePrefixBeforeAPI(downloadResponse.DownloadURL))
+			//resp, err = ac.SendGetRequestForDownload(utils.RemovePrefixBeforeAPI(downloadResponse.DownloadURL))
+			resp, err = http.Get(downloadResponse.DownloadURL)
 			if err != nil {
 				return err
 			}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -25,15 +25,17 @@ const (
 func uploadToS3(uploadUrl string, file io.Reader) error {
 	req, err := http.NewRequest("PUT", uploadUrl, file)
 	if err != nil {
-		return fmt.Errorf("failed to create PUT request: %w", err)
+		utils.CliError("Failed to create PUT request: %w", err)
+		return nil
 	}
-	// 필요에 따라 적절한 Content-Type을 설정하세요.
+
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to execute PUT request: %w", err)
+		utils.CliError("Failed to execute PUT request: %w", err)
+		return nil
 	}
 	defer resp.Body.Close()
 

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -96,7 +97,8 @@ func UploadFile(ac *client.AlpaconClient, src []string, dest, username, groupnam
 			}
 		}
 
-		_, err = ac.SendGetRequest(uploadAPIURL + response.Id + "/upload")
+		fullURL := utils.BuildURL(uploadAPIURL, path.Join(response.Id, "upload"), nil)
+		_, err = ac.SendGetRequest(fullURL)
 		if err != nil {
 			return nil, err
 		}

--- a/api/ftp/types.go
+++ b/api/ftp/types.go
@@ -3,17 +3,19 @@ package ftp
 import "time"
 
 type DownloadRequest struct {
-	Path      string `json:"path"`
-	Server    string `json:"server"`
-	Username  string `json:"username"`
-	Groupname string `json:"groupname"`
+	Path         string `json:"path"`
+	Name         string `json:"name"`
+	Server       string `json:"server"`
+	Username     string `json:"username"`
+	Groupname    string `json:"groupname"`
+	ResourceType string `json:"resource_type"`
 }
 
 type DownloadResponse struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Path        string `json:"path"`
-	Size        string `json:"size"`
+	Size        int    `json:"size"`
 	Server      string `json:"server"`
 	User        string `json:"user"`
 	Username    string `json:"username"`

--- a/api/ftp/types.go
+++ b/api/ftp/types.go
@@ -26,6 +26,16 @@ type DownloadResponse struct {
 	Command     string `json:"command"`
 }
 
+type UploadRequest struct {
+	Id         string `json:"id"`
+	Name       string `json:"name"`
+	Path       string `json:"path"`
+	Server     string `json:"server"`
+	Username   string `json:"username"`
+	Groupname  string `json:"groupname"`
+	AllowUnzip string `json:"allow_unzip"`
+}
+
 type UploadResponse struct {
 	Id        string    `json:"id"`
 	Name      string    `json:"name"`

--- a/api/ftp/types.go
+++ b/api/ftp/types.go
@@ -25,15 +25,15 @@ type DownloadResponse struct {
 }
 
 type UploadResponse struct {
-	Id          string    `json:"id"`
-	Name        string    `json:"name"`
-	Path        string    `json:"path"`
-	Size        int       `json:"size"`
-	Server      string    `json:"server"`
-	User        string    `json:"user"`
-	Username    string    `json:"username"`
-	Groupname   string    `json:"groupname"`
-	ExpiresAt   time.Time `json:"expires_at"`
-	DownloadUrl string    `json:"download_url"`
-	Command     string    `json:"command"`
+	Id        string    `json:"id"`
+	Name      string    `json:"name"`
+	Path      string    `json:"path"`
+	Size      int       `json:"size"`
+	Server    string    `json:"server"`
+	User      string    `json:"user"`
+	Username  string    `json:"username"`
+	Groupname string    `json:"groupname"`
+	ExpiresAt time.Time `json:"expires_at"`
+	UploadUrl string    `json:"upload_url"`
+	Command   string    `json:"command"`
 }

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -98,7 +98,6 @@ func uploadObject(client *client.AlpaconClient, src []string, dest, username, gr
 	}
 	if err != nil {
 		utils.CliError("Failed to upload the file to server: %s.", err)
-		return
 	}
 	utils.CliInfo("Upload request for %s to %s successful.", src, dest)
 	fmt.Printf("Result: %s.\n", result)

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -20,7 +20,11 @@ var CpCmd = &cobra.Command{
 	Example usages:
 	- To upload multiple files to a remote server:
 	  alpacon cp /local/path/file1.txt /local/path/file2.txt [SERVER_NAME]:/remote/path/
-	
+
+	- To upload or download directory:
+      alpacon cp -r /local/path/directory [SERVER_NAME]:/remote/path/
+      alpacon cp -r [SERVER_NAME]:/remote/path/directory /local/path/
+
 	- To download files from a remote server to a local destination:
 	  alpacon cp [SERVER_NAME]:/remote/path1 /remote/path2 /local/destination/path
 	
@@ -30,14 +34,15 @@ var CpCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		username, _ := cmd.Flags().GetString("username")
 		groupname, _ := cmd.Flags().GetString("groupname")
+		recursive, _ := cmd.Flags().GetBool("recursive")
 
 		if len(args) < 2 {
 			utils.CliError("You must specify at least two arguments.")
 			return
 		}
 
-		dest := args[len(args)-1]
 		sources := args[:len(args)-1]
+		dest := args[len(args)-1]
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
@@ -46,7 +51,7 @@ var CpCmd = &cobra.Command{
 		}
 
 		if isLocalPaths(sources) && isRemotePath(dest) {
-			uploadFile(alpaconClient, sources, dest, username, groupname)
+			uploadObject(alpaconClient, sources, dest, username, groupname, recursive)
 		} else if isRemotePath(sources[0]) && isLocalPath(dest) {
 			downloadFile(alpaconClient, sources[0], dest, username, groupname)
 		} else {
@@ -58,6 +63,7 @@ var CpCmd = &cobra.Command{
 func init() {
 	var username, groupname string
 
+	CpCmd.Flags().BoolP("recursive", "r", false, "Recursively copy directories")
 	CpCmd.Flags().StringVarP(&username, "username", "u", "", "Specify username")
 	CpCmd.Flags().StringVarP(&groupname, "groupname", "g", "", "Specify groupname")
 }
@@ -81,6 +87,23 @@ func isLocalPaths(paths []string) bool {
 	return true
 }
 
+func uploadObject(client *client.AlpaconClient, src []string, dest, username, groupname string, recursive bool) {
+	var result []string
+	var err error
+
+	if recursive {
+		result, err = ftp.UploadFolder(client, src, dest, username, groupname)
+	} else {
+		result, err = ftp.UploadFile(client, src, dest, username, groupname)
+	}
+	if err != nil {
+		utils.CliError("Failed to upload the file to server: %s.", err)
+		return
+	}
+	utils.CliInfo("Upload request for %s to %s successful.", src, dest)
+	fmt.Printf("Result: %s.\n", result)
+}
+
 func downloadFile(client *client.AlpaconClient, src, dest, username, groupname string) {
 	err := ftp.DownloadFile(client, src, dest, username, groupname)
 	if err != nil {
@@ -88,13 +111,4 @@ func downloadFile(client *client.AlpaconClient, src, dest, username, groupname s
 		return
 	}
 	utils.CliInfo("Download request for %s to server %s successful.", src, dest)
-}
-
-func uploadFile(client *client.AlpaconClient, src []string, dest, username, groupname string) {
-	result, err := ftp.UploadFile(client, src, dest, username, groupname)
-	if err != nil {
-		utils.CliError("Failed to upload the file to server: %s.", err)
-	}
-	utils.CliInfo("Upload request for %s to %s successful.", src, dest)
-	fmt.Printf("Result: %s.\n", result)
 }

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -53,7 +53,7 @@ var CpCmd = &cobra.Command{
 		if isLocalPaths(sources) && isRemotePath(dest) {
 			uploadObject(alpaconClient, sources, dest, username, groupname, recursive)
 		} else if isRemotePath(sources[0]) && isLocalPath(dest) {
-			downloadFile(alpaconClient, sources[0], dest, username, groupname)
+			downloadObject(alpaconClient, sources[0], dest, username, groupname, recursive)
 		} else {
 			utils.CliError("Invalid combination of source and destination paths.")
 		}
@@ -104,8 +104,10 @@ func uploadObject(client *client.AlpaconClient, src []string, dest, username, gr
 	fmt.Printf("Result: %s.\n", result)
 }
 
-func downloadFile(client *client.AlpaconClient, src, dest, username, groupname string) {
-	err := ftp.DownloadFile(client, src, dest, username, groupname)
+func downloadObject(client *client.AlpaconClient, src, dest, username, groupname string, recursive bool) {
+	var err error
+	err = ftp.DownloadFile(client, src, dest, username, groupname, recursive)
+
 	if err != nil {
 		utils.CliError("Failed to download the file from server: %s.", err)
 		return

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -109,7 +109,6 @@ func downloadObject(client *client.AlpaconClient, src, dest, username, groupname
 
 	if err != nil {
 		utils.CliError("Failed to download the file from server: %s.", err)
-		return
 	}
 	utils.CliInfo("Download request for %s to server %s successful.", src, dest)
 }

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -99,7 +99,8 @@ func uploadObject(client *client.AlpaconClient, src []string, dest, username, gr
 	if err != nil {
 		utils.CliError("Failed to upload the file to server: %s.", err)
 	}
-	utils.CliInfo("Upload request for %s to %s successful.", src, dest)
+	wrappedSrc := fmt.Sprintf("[%s]", strings.Join(src, ", "))
+	utils.CliInfo("Upload request for %s to %s successful.", wrappedSrc, dest)
 	fmt.Printf("Result: %s.\n", result)
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -244,7 +244,10 @@ func Unzip(src string, dest string) error {
 	for _, f := range r.File {
 		fpath := filepath.Join(dest, f.Name)
 		if f.FileInfo().IsDir() {
-			os.MkdirAll(fpath, os.ModePerm)
+			err := os.MkdirAll(fpath, os.ModePerm)
+			if err != nil {
+				return err
+			}
 			continue
 		}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -267,12 +267,16 @@ func Unzip(src string, dest string) error {
 
 		_, err = io.Copy(outFile, rc)
 
-		outFile.Close()
-		rc.Close()
-
+		err = outFile.Close()
 		if err != nil {
 			return err
 		}
+
+		err = rc.Close()
+		if err != nil {
+			return err
+		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
1. Fixed an issue where the `cp` command was not working properly due to changes in the backend API.
2. Added support for the `-r` option in the `cp` command to enable uploading and downloading folders.
