### PR TITLE
Add support for specifying username via SCP-style syntax in cp command

### DIFF
--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -22,15 +22,15 @@ var CpCmd = &cobra.Command{
 	  alpacon cp /local/path/file1.txt /local/path/file2.txt [SERVER_NAME]:/remote/path/
 
 	- To upload or download directory:
-      alpacon cp -r /local/path/directory [SERVER_NAME]:/remote/path/
-      alpacon cp -r [SERVER_NAME]:/remote/path/directory /local/path/
+	  alpacon cp -r /local/path/directory [SERVER_NAME]:/remote/path/
+	  alpacon cp -r [SERVER_NAME]:/remote/path/directory /local/path/
 
 	- To download files from a remote server to a local destination:
 	  alpacon cp [SERVER_NAME]:/remote/path1 /remote/path2 /local/destination/path
 
 	- To specify username:
 	  alpacon cp /local/path/file.txt [USER_NAME]@[SERVER_NAME]:/remote/path/
-      alpacon cp -u [USER_NAME] /local/path/file.txt [SERVER_NAME]:/remote/path/
+	  alpacon cp -u [USER_NAME] /local/path/file.txt [SERVER_NAME]:/remote/path/
 
 	- To specify groupname:
 	  alpacon cp -g [GROUP_NAME] /local/path/file.txt [SERVER_NAME]:/remote/path/

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -30,9 +30,10 @@ var CpCmd = &cobra.Command{
 
 	- To specify username:
 	  alpacon cp /local/path/file.txt [USER_NAME]@[SERVER_NAME]:/remote/path/
+      alpacon cp -u [USER_NAME] /local/path/file.txt [SERVER_NAME]:/remote/path/
 
-	- To specify username and groupname:
-	  alpacon cp -u [USER_NAME] -g [GROUP_NAME] /local/path/file.txt [SERVER_NAME]:/remote/path/
+	- To specify groupname:
+	  alpacon cp -g [GROUP_NAME] /local/path/file.txt [SERVER_NAME]:/remote/path/
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		username, _ := cmd.Flags().GetString("username")
@@ -44,9 +45,9 @@ var CpCmd = &cobra.Command{
 			return
 		}
 
-		for i := range args {
-			if strings.Contains(args[i], "@") && strings.Contains(args[i], ":") {
-				parts := strings.SplitN(args[i], "@", 2)
+		for i, arg := range args {
+			if strings.Contains(arg, "@") && strings.Contains(arg, ":") {
+				parts := strings.SplitN(arg, "@", 2)
 				if username == "" {
 					username = parts[0]
 				}

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -27,7 +27,10 @@ var CpCmd = &cobra.Command{
 
 	- To download files from a remote server to a local destination:
 	  alpacon cp [SERVER_NAME]:/remote/path1 /remote/path2 /local/destination/path
-	
+
+	- To specify username:
+	  alpacon cp /local/path/file.txt [USER_NAME]@[SERVER_NAME]:/remote/path/
+
 	- To specify username and groupname:
 	  alpacon cp -u [USER_NAME] -g [GROUP_NAME] /local/path/file.txt [SERVER_NAME]:/remote/path/
 	`,

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -44,6 +44,17 @@ var CpCmd = &cobra.Command{
 			return
 		}
 
+		for i := range args {
+			if strings.Contains(args[i], "@") && strings.Contains(args[i], ":") {
+				parts := strings.SplitN(args[i], "@", 2)
+				if username == "" {
+					username = parts[0]
+				}
+				// Remove the username@ part from the argument
+				args[i] = parts[1]
+			}
+		}
+
 		sources := args[:len(args)-1]
 		dest := args[len(args)-1]
 


### PR DESCRIPTION
This update enhances the cp command by allowing the username to be specified using the SCP-style syntax (e.g. `username@host:path`) in addition to the existing method.   

This provides greater flexibility and compatibility with standard SCP usage patterns.

related issue : #15 