### PR TITLE
ci(release): use github.token for GoReleaser, pin version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v1"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Strip "v" prefix from tag
         run: echo "TAG_NAME=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
Fixes the 403 error when GoReleaser updates GitHub Releases. The release workflow now uses the workflow’s `github.token` instead of a PAT, and the GoReleaser action version is pinned.

## Changes
- **Run GoReleaser** step: set `GITHUB_TOKEN` from `secrets.GORELEASER_GITHUB_TOKEN` to `github.token`
- Job `permissions: contents: write` now applies, so the workflow can create/update releases
- goreleaser-action `version`: `latest` → `"~> v1"` to remove the version warning

## Testing
- [ ] Release workflow runs only on “release published” in GitHub; to be verified on the next release after merge
- [ ] No breaking changes

## Checklist
- [x] Conventional commit format used
- [x] No secrets or credentials in the diff

## Related Files
**Modified:**
- `.github/workflows/release.yml`: GoReleaser step `env` and `version` updated