### PR TITLE
ci(release): restore GORELEASER_GITHUB_TOKEN for cross-repo Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           version: "~> v1"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
       - name: Strip "v" prefix from tag
         run: echo "TAG_NAME=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
Restore `GORELEASER_GITHUB_TOKEN` (PAT) for the GoReleaser step so that it can push the Homebrew formula to the `alpacax/homebrew-alpacon` repository. The default `GITHUB_TOKEN` only has access to the current repo and cannot write to other repos, which caused a 403 when updating the tap.

## Changes
- **Run GoReleaser** step: `GITHUB_TOKEN` from `github.token` back to `secrets.GORELEASER_GITHUB_TOKEN`
- Keeps `version: "~> v1"` (no change)

## Requirements
- `GORELEASER_GITHUB_TOKEN` must have write access to:
  - `alpacax/alpacon-cli` (releases and assets)
  - `alpacax/homebrew-alpacon` (formula push)

## Testing
- [ ] To be verified on next release publish
- [ ] No breaking changes

## Checklist
- [x] Conventional commit format
- [x] No secrets in diff (uses existing secret)

Made with [Cursor](https://cursor.com)