### PR TITLE
fix: correct wrong argument name in authority delete Use string

### DIFF
--- a/cmd/authority/authority_delete.go
+++ b/cmd/authority/authority_delete.go
@@ -8,16 +8,17 @@ import (
 )
 
 var authorityDeleteCmd = &cobra.Command{
-	Use:     "delete [CSR ID]",
+	Use:     "delete AUTHORITY_ID",
 	Aliases: []string{"rm"},
 	Short:   "Delete a CA along with its certificate and CSR",
 	Long: `
     This command removes a Certificate Authority (CA) from the system, including its certificate and CSR. 
 	Note that this action requires manual configuration adjustments to alpamon-cert-authority.
 	`,
-	Example: ` 
-	alpacon authority delete [AUTHORITY ID]	
-	alpacon authority rm [AUTHORITY_ID]
+	Example: `
+	alpacon authority delete 550e8400-e29b-41d4-a716-446655440000
+	alpacon authority rm 550e8400-e29b-41d4-a716-446655440000
+	alpacon authority delete 550e8400-e29b-41d4-a716-446655440000 -y
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Summary
- The `authority delete` command's `Use` field showed `delete [CSR ID]` but the command deletes an authority, not a CSR
- Fixed to `delete AUTHORITY_ID` per POSIX/Cobra conventions
- Updated examples with realistic UUID values

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Verify `alpacon authority delete --help` shows correct usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)