### PR TITLE
fix: replace redundant return err with return nil

### DIFF
--- a/api/cert/cert.go
+++ b/api/cert/cert.go
@@ -176,7 +176,7 @@ func DeleteCSR(ac *client.AlpaconClient, csrId string) error {
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func DeleteCA(ac *client.AlpaconClient, authorityId string) error {
@@ -185,7 +185,7 @@ func DeleteCA(ac *client.AlpaconClient, authorityId string) error {
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func GetCertificateList(ac *client.AlpaconClient) ([]CertificateAttributes, error) {

--- a/api/iam/iam.go
+++ b/api/iam/iam.go
@@ -108,7 +108,7 @@ func DeleteUser(ac *client.AlpaconClient, userName string) error {
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func DeleteGroup(ac *client.AlpaconClient, groupName string) error {
@@ -122,7 +122,7 @@ func DeleteGroup(ac *client.AlpaconClient, groupName string) error {
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func AddMember(ac *client.AlpaconClient, memberRequest MemberAddRequest) error {
@@ -176,7 +176,7 @@ func DeleteMember(ac *client.AlpaconClient, memberDeleteRequest MemberDeleteRequ
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func GetUserIDByName(ac *client.AlpaconClient, userName string) (string, error) {

--- a/api/note/note.go
+++ b/api/note/note.go
@@ -106,5 +106,5 @@ func DeleteNote(ac *client.AlpaconClient, noteID string) error {
 		return err
 	}
 
-	return err
+	return nil
 }


### PR DESCRIPTION
## Summary
- Several API delete functions returned `err` after `if err != nil { return err }`, where `err` is guaranteed to be `nil` at that point
- Replaced with explicit `return nil` for clarity and consistency with other functions (e.g., `DeleteServer`, `DeleteWebhook`) that already use `return nil`

**Affected functions** (3 files, 6 occurrences):
- `api/note/note.go` — `DeleteNote`
- `api/iam/iam.go` — `DeleteUser`, `DeleteGroup`, `DeleteMember`
- `api/cert/cert.go` — `DeleteCSR`, `DeleteCA`

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)