### PR TITLE
refactor: remove "all" alias from list commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ utils/               # Shared utilities (output, prompts, errors, SSH parsing)
 - **CLI output helpers**: `utils.CliError*/CliInfo*/CliWarning` all write to stderr. stdout is reserved for data output (tables, JSON)
 - **Group commands**: Use `RunE` (not `Run`) to show help + return error when no subcommand is given
 - **Version injection**: `utils.Version` is set via `-ldflags` at build time by GoReleaser. Local builds default to `"dev"`
-- **Subcommand aliases**: list → `["list", "all"]`, delete → `["rm"]`, describe → `["desc"]`, group → semantic alias (e.g., `workspace` → `ws`)
+- **Subcommand aliases**: list → `["list"]`, delete → `["rm"]`, describe → `["desc"]`, group → semantic alias (e.g., `workspace` → `ws`)
 
 ## Code Style Guidelines
 

--- a/cmd/authority/authority_list.go
+++ b/cmd/authority/authority_list.go
@@ -9,7 +9,7 @@ import (
 
 var authorityListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all certificate authorities",
 	Long: `
  	Displays a comprehensive list of all certificate authorities that have been initialized within the system, 
@@ -18,7 +18,6 @@ var authorityListCmd = &cobra.Command{
 	Example: `
 	alpacon authority ls
 	alpacon authority list
-	alpacon authority all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/cert/cert_list.go
+++ b/cmd/cert/cert_list.go
@@ -9,7 +9,7 @@ import (
 
 var certListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all certificates",
 	Long: `
 	Retrieves and shows a detailed list of all the SSL/TLS certificates currently managed by the system, 
@@ -18,7 +18,6 @@ var certListCmd = &cobra.Command{
 	Example: `
 	alpacon cert ls
 	alpacon cert list
-	alpacon cert all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/csr/csr_list.go
+++ b/cmd/csr/csr_list.go
@@ -9,7 +9,7 @@ import (
 
 var csrListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all certificate signing requests",
 	Long: `
 	Display CSRs, optionally filtered by status ('requested', 'processing', 'signed',
@@ -18,7 +18,6 @@ var csrListCmd = &cobra.Command{
 	Example: `
 	alpacon csr ls
 	alpacon csr list
-	alpacon csr all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		status, _ := cmd.Flags().GetString("status")

--- a/cmd/csr/csr_test.go
+++ b/cmd/csr/csr_test.go
@@ -26,7 +26,7 @@ func TestCsrSubcommands(t *testing.T) {
 		{
 			name:    "ls subcommand",
 			cmdName: "ls",
-			aliases: []string{"list", "all"},
+			aliases: []string{"list"},
 		},
 		{
 			name:    "approve subcommand",
@@ -86,7 +86,6 @@ func TestSubcommandAliases(t *testing.T) {
 		expectCmd string
 	}{
 		{name: "ls via list", alias: "list", expectCmd: "ls"},
-		{name: "ls via all", alias: "all", expectCmd: "ls"},
 		{name: "delete via rm", alias: "rm", expectCmd: "delete"},
 		{name: "describe via desc", alias: "desc", expectCmd: "describe"},
 	}

--- a/cmd/iam/group_list.go
+++ b/cmd/iam/group_list.go
@@ -9,7 +9,7 @@ import (
 
 var groupListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all groups",
 	Long: `
 	Display a detailed list of all groups registered in the Alpacon.
@@ -19,7 +19,6 @@ var groupListCmd = &cobra.Command{
 	alpacon group ls
 	alpacon groups
 	alpacon group list
-	alpacon group all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/iam/user_list.go
+++ b/cmd/iam/user_list.go
@@ -9,7 +9,7 @@ import (
 
 var userListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all users",
 	Long: `
 	Display a detailed list of all users registered in the Alpacon.
@@ -18,7 +18,6 @@ var userListCmd = &cobra.Command{
 	Example: `
 	alpacon user ls
 	alpacon user list
-	alpacon user all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/note/note_list.go
+++ b/cmd/note/note_list.go
@@ -9,7 +9,7 @@ import (
 
 var noteListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all notes",
 	Long: `
 	This command displays a comprehensive list of all notes stored on the Alpacon. 
@@ -19,7 +19,6 @@ var noteListCmd = &cobra.Command{
 	Example: `
 	alpacon note ls
 	alpacon note list
-	alpacon note all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/packages/python_list.go
+++ b/cmd/packages/python_list.go
@@ -9,7 +9,7 @@ import (
 
 var pythonPackageListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all python packages",
 	Long: `
 	Display a detailed list of all python packages registered in the Alpacon.
@@ -18,7 +18,6 @@ var pythonPackageListCmd = &cobra.Command{
 	Example: `
 	alpacon package python ls
 	alpacon package python list
-	alpacon package python all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/packages/system_list.go
+++ b/cmd/packages/system_list.go
@@ -9,7 +9,7 @@ import (
 
 var systemPackageListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all system packages",
 	Long: `
 	Display a detailed list of all python packages registered in the Alpacon.
@@ -18,7 +18,6 @@ var systemPackageListCmd = &cobra.Command{
 	Example: `
 	alpacon package system ls
 	alpacon package system list
-	alpacon package system all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/revoke/revoke_list.go
+++ b/cmd/revoke/revoke_list.go
@@ -9,7 +9,7 @@ import (
 
 var revokeListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "List certificate revoke requests",
 	Long: `
 	List all certificate revoke requests with optional filtering by status or certificate.

--- a/cmd/server/server_list.go
+++ b/cmd/server/server_list.go
@@ -9,7 +9,7 @@ import (
 
 var serverListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all servers",
 	Long: `
 	Display a detailed list of all servers registered in the Alpacon.
@@ -18,7 +18,6 @@ var serverListCmd = &cobra.Command{
 	Example: `
 	alpacon server ls
 	alpacon server list
-	alpacon server all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/token/acl_list.go
+++ b/cmd/token/acl_list.go
@@ -10,16 +10,15 @@ import (
 
 var aclListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display all command ACLs for an API token.",
 	Long: `
 	This command displays all command access control lists (ACLs) registered to an API token. 
 	It shows details such as the token name and the commands associated with each ACL.
 	`,
 	Example: `
-	alpacon token acl ls [TOKEN_ID_OR_NAME] 
+	alpacon token acl ls [TOKEN_ID_OR_NAME]
 	alpacon token acl list [TOKEN_ID_OR_NAME]
-	alpacon token acl all [TOKEN_ID_OR_NAME]  
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/token/token_list.go
+++ b/cmd/token/token_list.go
@@ -9,7 +9,7 @@ import (
 
 var tokenListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "Display a list of all api tokens",
 	Long: `
 	Displays a list of all API tokens issued. 
@@ -18,7 +18,6 @@ var tokenListCmd = &cobra.Command{
 	Example: `
 	alpacon token ls
 	alpacon token list
-	alpacon token all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/webhook/webhook_list.go
+++ b/cmd/webhook/webhook_list.go
@@ -9,7 +9,7 @@ import (
 
 var webhookListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "List all webhooks",
 	Long: `
 	List all configured webhooks with their name, URL, status, and owner information.

--- a/cmd/workspace/workspace_list.go
+++ b/cmd/workspace/workspace_list.go
@@ -9,13 +9,12 @@ import (
 
 var workspaceListCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list", "all"},
+	Aliases: []string{"list"},
 	Short:   "List available workspaces",
 	Long:    "Display all workspaces associated with your account.",
 	Example: `
 	alpacon workspace ls
 	alpacon ws list
-	alpacon workspace all
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := config.LoadConfig()


### PR DESCRIPTION
## Summary
- Remove the `"all"` alias from all 14 list subcommands across the codebase
- In standard CLIs (kubectl, docker, helm), `all` is a `--all` **flag** that widens scope (e.g., include inactive items), not a synonym for `list`. Keeping `ls`/`list` is sufficient
- Updated examples, tests, and CLAUDE.md accordingly

**Supersedes #85** — that PR added `"all"` to workspace for consistency, but the correct fix is to remove it everywhere.

## Changed files (16)
- 14 list command files: removed `"all"` from `Aliases` and `Example`
- `cmd/csr/csr_test.go`: updated alias assertions
- `CLAUDE.md`: updated subcommand aliases documentation

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)