### PR TITLE
fix: correct various documentation bugs in command definitions

### DIFF
--- a/cmd/cert/cert.go
+++ b/cmd/cert/cert.go
@@ -14,7 +14,7 @@ var CertCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon cert list', 'alpacon cert detail', or 'alpacon cert download' to manage SSL/TLS certificates. Run 'alpacon cert --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon cert ls', 'alpacon cert describe', or 'alpacon cert download' to manage SSL/TLS certificates. Run 'alpacon cert --help' for more information")
 	},
 }
 

--- a/cmd/iam/group_delete.go
+++ b/cmd/iam/group_delete.go
@@ -13,7 +13,7 @@ var groupDeleteCmd = &cobra.Command{
 	Short:   "Delete a specified group",
 	Long: `
 	This command is used to permanently delete a specified group from the Alpacon. 
-	The command requires the exact username as an argument.
+	The command requires the exact group name as an argument.
 	NOTE : alpacon(Alpacon users) group cannot delete or update memberships
 	`,
 	Example: ` 

--- a/cmd/iam/user.go
+++ b/cmd/iam/user.go
@@ -17,7 +17,7 @@ var UserCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon user list', 'alpacon user create', 'alpacon user detail', 'alpacon user update', or 'alpacon user delete'. Run 'alpacon user --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon user ls', 'alpacon user create', 'alpacon user describe', 'alpacon user update', or 'alpacon user delete'. Run 'alpacon user --help' for more information")
 	},
 }
 

--- a/cmd/note/note_create.go
+++ b/cmd/note/note_create.go
@@ -16,7 +16,7 @@ var noteCreateCmd = &cobra.Command{
 	Short: "Create a note on the specified server.",
 	Long: `
 	This command allows you to create a new note on a server. 
-	You can specify the server name, note content, and privacy settings.",
+	You can specify the server name, note content, and privacy settings.
 	`,
 	Example: `
 	alpacon note create 

--- a/cmd/packages/system_list.go
+++ b/cmd/packages/system_list.go
@@ -12,7 +12,7 @@ var systemPackageListCmd = &cobra.Command{
 	Aliases: []string{"list"},
 	Short:   "Display a list of all system packages",
 	Long: `
-	Display a detailed list of all python packages registered in the Alpacon.
+	Display a detailed list of all system packages registered in the Alpacon.
 	This command provides information such as name, version, platform and other relevant details.
 	`,
 	Example: `

--- a/cmd/server/server_create.go
+++ b/cmd/server/server_create.go
@@ -19,7 +19,7 @@ var serverCreateCmd = &cobra.Command{
 	Create a new server with specific configurations. This command allows you to set up a server with a unique name, 
 	choose a platform, and define access permissions for different groups. 
 	`,
-	Example: `alpacon create server`,
+	Example: `alpacon server create`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/token/acl_delete.go
+++ b/cmd/token/acl_delete.go
@@ -16,9 +16,8 @@ var aclDeleteCmd = &cobra.Command{
 	This command requires the command acl id to identify the command acl to be deleted.
 	`,
 	Example: `
-	alpacon token acl delete [COMMAND_ACL_ID]
-	alpacon token acl rm [COMMAND_ACL_ID]
-	alpacon token acl rm --token=[TOKEN_ID_OR_NAME] --command=[COMMAND]
+	alpacon token acl delete 550e8400-e29b-41d4-a716-446655440000
+	alpacon token acl rm 550e8400-e29b-41d4-a716-446655440000
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/token/token_create.go
+++ b/cmd/token/token_create.go
@@ -14,7 +14,7 @@ var tokenCreateCmd = &cobra.Command{
 	Generates a new API token for accessing the server. 
 	This command allows you to create a token by specifying options such as token name, expiration, and limits
 	`,
-	Example: `alpacon create token`,
+	Example: `alpacon token create`,
 	Run: func(cmd *cobra.Command, args []string) {
 		name, _ := cmd.Flags().GetString("name")
 		limit, _ := cmd.Flags().GetBool("limit")


### PR DESCRIPTION
## Summary

Fixes 8 documentation bugs across command definitions:

| File | Bug | Fix |
|------|-----|-----|
| `server/server_create.go` | `Example: alpacon create server` | → `alpacon server create` |
| `token/token_create.go` | `Example: alpacon create token` | → `alpacon token create` |
| `iam/user.go` | Error message says `user detail` and `user list` | → `user describe`, `user ls` |
| `cert/cert.go` | Error message says `cert detail`, `cert list` | → `cert describe`, `cert ls` |
| `packages/system_list.go` | Long description says "python packages" | → "system packages" |
| `note/note_create.go` | Stray `"` at end of Long description sentence | Removed |
| `token/acl_delete.go` | Example shows `--token`/`--command` flags that don't exist | Removed |
| `iam/group_delete.go` | Long says "exact username" in a group delete command | → "group name" |

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)