### PR TITLE
fix: remove brackets from required args in Use strings

### DIFF
--- a/cmd/agent/restart.go
+++ b/cmd/agent/restart.go
@@ -8,7 +8,7 @@ import (
 )
 
 var restartAgentCmd = &cobra.Command{
-	Use:     "restart [SERVER NAME]",
+	Use:     "restart SERVER",
 	Short:   "Restart server's agent(alpamon)",
 	Example: `alpacon agent restart myserver`,
 	Args:    cobra.ExactArgs(1),

--- a/cmd/agent/shutdown.go
+++ b/cmd/agent/shutdown.go
@@ -8,7 +8,7 @@ import (
 )
 
 var shutdownAgentCmd = &cobra.Command{
-	Use:     "shutdown [SERVER NAME]",
+	Use:     "shutdown SERVER",
 	Short:   "Shutdown server's agent(alpamon)",
 	Example: `alpacon agent shutdown myserver`,
 	Args:    cobra.ExactArgs(1),

--- a/cmd/agent/upgrade.go
+++ b/cmd/agent/upgrade.go
@@ -8,7 +8,7 @@ import (
 )
 
 var upgradeAgentCmd = &cobra.Command{
-	Use:     "upgrade [SERVER NAME]",
+	Use:     "upgrade SERVER",
 	Short:   "Upgrade server's agent(alpamon)",
 	Example: `alpacon agent upgrade myserver`,
 	Args:    cobra.ExactArgs(1),

--- a/cmd/authority/authority_detail.go
+++ b/cmd/authority/authority_detail.go
@@ -8,7 +8,7 @@ import (
 )
 
 var authorityDetailCmd = &cobra.Command{
-	Use:     "describe [AUTHORITY ID]",
+	Use:     "describe AUTHORITY_ID",
 	Aliases: []string{"desc"},
 	Short:   "Display detailed information about a specific Certificate Authority",
 	Long: `

--- a/cmd/authority/authority_download.go
+++ b/cmd/authority/authority_download.go
@@ -8,7 +8,7 @@ import (
 )
 
 var authorityDownloadCmd = &cobra.Command{
-	Use:     "download-crt [AUTHORITY ID]",
+	Use:     "download-crt AUTHORITY_ID",
 	Aliases: []string{"download-cert"},
 	Short:   "Download a root certificate",
 	Long: `

--- a/cmd/cert/cert_detail.go
+++ b/cmd/cert/cert_detail.go
@@ -8,7 +8,7 @@ import (
 )
 
 var certDetailCmd = &cobra.Command{
-	Use:     "describe [CERT ID]",
+	Use:     "describe CERT_ID",
 	Aliases: []string{"desc"},
 	Short:   "Display detailed information about a specific Certificate",
 	Long: `

--- a/cmd/cert/cert_download.go
+++ b/cmd/cert/cert_download.go
@@ -8,7 +8,7 @@ import (
 )
 
 var certDownloadCmd = &cobra.Command{
-	Use:   "download [CERT ID]",
+	Use:   "download CERT_ID",
 	Short: "Download a certificate",
 	Long: `
 	Download a certificate from the server and save it to a specified file path. 

--- a/cmd/csr/csr_delete.go
+++ b/cmd/csr/csr_delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 var csrDeleteCmd = &cobra.Command{
-	Use:     "delete [CSR ID]",
+	Use:     "delete CSR_ID",
 	Aliases: []string{"rm"},
 	Short:   "Delete a CSR",
 	Long: `

--- a/cmd/csr/csr_detail.go
+++ b/cmd/csr/csr_detail.go
@@ -8,7 +8,7 @@ import (
 )
 
 var csrDetailCmd = &cobra.Command{
-	Use:     "describe [CSR ID]",
+	Use:     "describe CSR_ID",
 	Aliases: []string{"desc"},
 	Short:   "Display detailed information about a specific Certificate Signing Request",
 	Long: `

--- a/cmd/csr/csr_download_crt.go
+++ b/cmd/csr/csr_download_crt.go
@@ -8,7 +8,7 @@ import (
 )
 
 var csrDownloadCrtCmd = &cobra.Command{
-	Use:   "download-crt [CSR ID]",
+	Use:   "download-crt CSR_ID",
 	Short: "Download the certificate for a CSR",
 	Long: `
 	Download the signed certificate associated with a CSR.

--- a/cmd/iam/group_delete.go
+++ b/cmd/iam/group_delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 var groupDeleteCmd = &cobra.Command{
-	Use:     "delete [GROUP NAME]",
+	Use:     "delete GROUP",
 	Aliases: []string{"rm"},
 	Short:   "Delete a specified group",
 	Long: `

--- a/cmd/iam/group_detail.go
+++ b/cmd/iam/group_detail.go
@@ -8,7 +8,7 @@ import (
 )
 
 var groupDetailCmd = &cobra.Command{
-	Use:     "describe [GROUP NAME]",
+	Use:     "describe GROUP",
 	Aliases: []string{"desc"},
 	Short:   "Display detailed information about a specific group",
 	Long: `

--- a/cmd/iam/user_delete.go
+++ b/cmd/iam/user_delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 var userDeleteCmd = &cobra.Command{
-	Use:     "delete [USER NAME]",
+	Use:     "delete USER",
 	Aliases: []string{"rm"},
 	Short:   "Delete a specified user",
 	Long: `

--- a/cmd/iam/user_detail.go
+++ b/cmd/iam/user_detail.go
@@ -8,7 +8,7 @@ import (
 )
 
 var userDetailCmd = &cobra.Command{
-	Use:     "describe [USER NAME]",
+	Use:     "describe USER",
 	Aliases: []string{"desc"},
 	Short:   "Display detailed information about a specific user",
 	Long: `

--- a/cmd/iam/user_update.go
+++ b/cmd/iam/user_update.go
@@ -8,7 +8,7 @@ import (
 )
 
 var userUpdateCmd = &cobra.Command{
-	Use:   "update [USER NAME]",
+	Use:   "update USER",
 	Short: "Update the user information",
 	Long: `
 	Update the user information in the Alpacon.

--- a/cmd/log/log.go
+++ b/cmd/log/log.go
@@ -8,7 +8,7 @@ import (
 )
 
 var LogCmd = &cobra.Command{
-	Use:     "log [SERVER NAME]",
+	Use:     "log SERVER",
 	Aliases: []string{"logs"},
 	Short:   "Retrieve and display server logs",
 	Long: `Retrieve and display logs for a specified server. This command allows you 

--- a/cmd/note/note_delete.go
+++ b/cmd/note/note_delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 var noteDeleteCmd = &cobra.Command{
-	Use:     "delete [NOTE ID]",
+	Use:     "delete NOTE_ID",
 	Aliases: []string{"rm"},
 	Short:   "Delete a specified note",
 	Long: `

--- a/cmd/packages/python_download.go
+++ b/cmd/packages/python_download.go
@@ -8,7 +8,7 @@ import (
 )
 
 var pythonPackageDownloadCmd = &cobra.Command{
-	Use:   "download [PACKAGE NAME] [FILE PATH]",
+	Use:   "download PACKAGE FILE",
 	Short: "Download a python package from alpacon",
 	Long: `
 	The 'download' command allows users to download a Python package from the alpacon.

--- a/cmd/packages/python_upload.go
+++ b/cmd/packages/python_upload.go
@@ -8,7 +8,7 @@ import (
 )
 
 var pythonPackageUploadCmd = &cobra.Command{
-	Use:   "upload [FILE PATH]",
+	Use:   "upload FILE",
 	Short: "Upload a python package to alpacon",
 	Long: `
 	The 'upload' command allows users to upload a Python package to the alpacon. 

--- a/cmd/packages/system_download.go
+++ b/cmd/packages/system_download.go
@@ -8,7 +8,7 @@ import (
 )
 
 var systemPackageDownloadCmd = &cobra.Command{
-	Use:   "download [PACKAGE NAME] [FILE PATH]",
+	Use:   "download PACKAGE FILE",
 	Short: "Download a system package from alpacon",
 	Long: `
 	The 'download' command allows users to download a System package from the alpacon.

--- a/cmd/packages/system_upload.go
+++ b/cmd/packages/system_upload.go
@@ -8,7 +8,7 @@ import (
 )
 
 var systemPackageUploadCmd = &cobra.Command{
-	Use:   "upload [FILE PATH]",
+	Use:   "upload FILE",
 	Short: "Upload a system package to alpacon",
 	Long: `
 	The 'upload' command allows users to upload a System package to the alpacon. 

--- a/cmd/server/server_delete.go
+++ b/cmd/server/server_delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 var serverDeleteCmd = &cobra.Command{
-	Use:     "delete [SERVER NAME]",
+	Use:     "delete SERVER",
 	Aliases: []string{"rm"},
 	Short:   "Delete a specified server",
 	Long: `

--- a/cmd/server/server_detail.go
+++ b/cmd/server/server_detail.go
@@ -8,7 +8,7 @@ import (
 )
 
 var serverDetailCmd = &cobra.Command{
-	Use:     "describe [SERVER NAME]",
+	Use:     "describe SERVER",
 	Aliases: []string{"desc"},
 	Short:   "Display detailed information about a specific server",
 	Long: `

--- a/cmd/token/token_delete.go
+++ b/cmd/token/token_delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 var tokenDeleteCmd = &cobra.Command{
-	Use:     "delete [TOKEN NAME]",
+	Use:     "delete TOKEN",
 	Aliases: []string{"rm"},
 	Short:   "Delete a specified api token",
 	Long: `

--- a/cmd/tunnel/tunnel.go
+++ b/cmd/tunnel/tunnel.go
@@ -48,7 +48,7 @@ type streamSession interface {
 }
 
 var TunnelCmd = &cobra.Command{
-	Use:   "tunnel [SERVER NAME]",
+	Use:   "tunnel SERVER",
 	Short: "Create a TCP tunnel to a remote server",
 	Long: `
 	This command creates a TCP tunnel that forwards local port traffic to a remote server's port.

--- a/cmd/workspace/workspace_switch.go
+++ b/cmd/workspace/workspace_switch.go
@@ -9,7 +9,7 @@ import (
 )
 
 var workspaceSwitchCmd = &cobra.Command{
-	Use:   "switch <workspace-name>",
+	Use:   "switch WORKSPACE",
 	Short: "Switch to a different workspace",
 	Long:  "Switch to another workspace in your account. The workspace must exist in your JWT token.",
 	Example: `


### PR DESCRIPTION
## Summary

Per POSIX/Cobra convention documented in CLAUDE.md, `[]` denotes **optional** arguments. Required positional arguments must not be wrapped in brackets.

Fixed 26 commands across 26 files:

| Before | After |
|--------|-------|
| `delete [SERVER NAME]` | `delete SERVER` |
| `describe [SERVER NAME]` | `describe SERVER` |
| `delete [USER NAME]` | `delete USER` |
| `describe [USER NAME]` | `describe USER` |
| `update [USER NAME]` | `update USER` |
| `delete [GROUP NAME]` | `delete GROUP` |
| `describe [GROUP NAME]` | `describe GROUP` |
| `delete [NOTE ID]` | `delete NOTE_ID` |
| `delete [CSR ID]` | `delete CSR_ID` |
| `describe [CSR ID]` | `describe CSR_ID` |
| `download-crt [CSR ID]` | `download-crt CSR_ID` |
| `describe [CERT ID]` | `describe CERT_ID` |
| `download [CERT ID]` | `download CERT_ID` |
| `describe [AUTHORITY ID]` | `describe AUTHORITY_ID` |
| `download-crt [AUTHORITY ID]` | `download-crt AUTHORITY_ID` |
| `delete [TOKEN NAME]` | `delete TOKEN` |
| `upgrade/shutdown/restart [SERVER NAME]` | `upgrade/shutdown/restart SERVER` |
| `log [SERVER NAME]` | `log SERVER` |
| `tunnel [SERVER NAME]` | `tunnel SERVER` |
| `upload [FILE PATH]` | `upload FILE` |
| `download [PACKAGE NAME] [FILE PATH]` | `download PACKAGE FILE` |
| `switch <workspace-name>` | `switch WORKSPACE` |

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)