### PR TITLE
fix: replace placeholder values in Example sections with realistic values

### DIFF
--- a/cmd/authority/authority_detail.go
+++ b/cmd/authority/authority_detail.go
@@ -15,8 +15,9 @@ var authorityDetailCmd = &cobra.Command{
 	The describe command fetches and displays detailed information about a specific certificate authority, 
 	including its crt text, organization and other relevant attributes. 
 	`,
-	Example: ` 
-	alpacon authority describe [AUTHORITY ID]
+	Example: `
+	alpacon authority describe 550e8400-e29b-41d4-a716-446655440000
+	alpacon authority desc 550e8400-e29b-41d4-a716-446655440000
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/authority/authority_download.go
+++ b/cmd/authority/authority_download.go
@@ -16,7 +16,7 @@ var authorityDownloadCmd = &cobra.Command{
 	The path argument should include the file name and extension where the certificate will be stored. 
 	For example, '/path/to/root.crt'. The recommended file extension for certificates is '.crt'.`,
 	Example: `
-	alpacon authority download-crt [AUTHORITY ID] --out=/path/to/root.crt
+	alpacon authority download-crt 550e8400-e29b-41d4-a716-446655440000 --out=/path/to/root.crt
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cert/cert_detail.go
+++ b/cmd/cert/cert_detail.go
@@ -15,8 +15,9 @@ var certDetailCmd = &cobra.Command{
 	The describe command fetches and displays detailed information about a specific certificate, 
 	including its crt text, certificate authority and other relevant attributes. 
 	`,
-	Example: ` 
-	alpacon cert describe [CERT ID]
+	Example: `
+	alpacon cert describe 550e8400-e29b-41d4-a716-446655440000
+	alpacon cert desc 550e8400-e29b-41d4-a716-446655440000
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cert/cert_download.go
+++ b/cmd/cert/cert_download.go
@@ -15,7 +15,7 @@ var certDownloadCmd = &cobra.Command{
 	The path argument should include the file name and extension where the certificate will be stored. 
 	For example, '/path/to/certificate.crt'. The recommended file extension for certificates is '.crt'.`,
 	Example: `
-	alpacon cert download [CERT ID] --out=/path/to/certificate.crt
+	alpacon cert download 550e8400-e29b-41d4-a716-446655440000 --out=/path/to/certificate.crt
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/csr/csr_approve.go
+++ b/cmd/csr/csr_approve.go
@@ -14,7 +14,7 @@ var csrApproveCmd = &cobra.Command{
 	Reviews and approves a pending Certificate Signing Request, 
 	moving it forward in the signing process to eventually be issued as a valid certificate.
 	`,
-	Example: `alpacon csr approve [CSR ID] `,
+	Example: `alpacon csr approve 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		csrId := args[0]

--- a/cmd/csr/csr_delete.go
+++ b/cmd/csr/csr_delete.go
@@ -15,9 +15,10 @@ var csrDeleteCmd = &cobra.Command{
  	Removes a Certificate Signing Request from the system, 
 	effectively canceling the request and any associated processing.
 	`,
-	Example: ` 
-	alpacon csr delete [CSR ID]	
-	alpacon csr rm [CSR ID]
+	Example: `
+	alpacon csr delete 550e8400-e29b-41d4-a716-446655440000
+	alpacon csr rm 550e8400-e29b-41d4-a716-446655440000
+	alpacon csr delete 550e8400-e29b-41d4-a716-446655440000 -y
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/csr/csr_deny.go
+++ b/cmd/csr/csr_deny.go
@@ -14,7 +14,7 @@ var csrDenyCmd = &cobra.Command{
 	Rejects a Certificate Signing Request, marking it as denied and stopping any further processing 
 	or signing activities for that request
 	`,
-	Example: `alpacon csr deny [CSR ID] `,
+	Example: `alpacon csr deny 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		csrId := args[0]

--- a/cmd/csr/csr_detail.go
+++ b/cmd/csr/csr_detail.go
@@ -15,8 +15,9 @@ var csrDetailCmd = &cobra.Command{
 	The describe command fetches and displays detailed information about a specific certificate signing request, 
 	including its csr text, certificate authority and other relevant attributes. 
 	`,
-	Example: ` 
-	alpacon csr describe [CSR ID]
+	Example: `
+	alpacon csr describe 550e8400-e29b-41d4-a716-446655440000
+	alpacon csr desc 550e8400-e29b-41d4-a716-446655440000
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/csr/csr_download_crt.go
+++ b/cmd/csr/csr_download_crt.go
@@ -15,7 +15,7 @@ var csrDownloadCrtCmd = &cobra.Command{
 	The CSR must be in 'signed' status for the certificate to be available.
 	Use 'alpacon csr ls' to check the status of your CSRs.`,
 	Example: `
-	alpacon csr download-crt [CSR ID] --out=/path/to/certificate.crt`,
+	alpacon csr download-crt 550e8400-e29b-41d4-a716-446655440000 --out=/path/to/certificate.crt`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		csrId := args[0]

--- a/cmd/iam/group_delete.go
+++ b/cmd/iam/group_delete.go
@@ -16,9 +16,10 @@ var groupDeleteCmd = &cobra.Command{
 	The command requires the exact username as an argument.
 	NOTE : alpacon(Alpacon users) group cannot delete or update memberships
 	`,
-	Example: ` 
-	alpacon group delete [GROUP NAME]
-	alpacon group rm [GROUP NAME]
+	Example: `
+	alpacon group delete developers
+	alpacon group rm developers
+	alpacon group delete developers -y
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/iam/group_detail.go
+++ b/cmd/iam/group_detail.go
@@ -15,9 +15,9 @@ var groupDetailCmd = &cobra.Command{
 	The describe command fetches and displays detailed information about a specific group, 
 	including its description, member names and other relevant attributes. 
 	`,
-	Example: ` 
-	# Display details of a group named 'alpacon'
-  	alpacon group describe alpacon
+	Example: `
+	alpacon group describe developers
+	alpacon group desc developers
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/iam/user_delete.go
+++ b/cmd/iam/user_delete.go
@@ -15,9 +15,10 @@ var userDeleteCmd = &cobra.Command{
 	This command is used to permanently delete a specified user account from the Alpacon. 
 	The command requires the exact username as an argument.
 	`,
-	Example: ` 
-	alpacon user delete [USER NAME]	
-	alpacon user rm [USER NAME]
+	Example: `
+	alpacon user delete john
+	alpacon user rm john
+	alpacon user delete john -y
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/iam/user_detail.go
+++ b/cmd/iam/user_detail.go
@@ -15,9 +15,9 @@ var userDetailCmd = &cobra.Command{
 	The describe command fetches and displays detailed information about a specific user, 
 	including its description, shell and other relevant attributes. 
 	`,
-	Example: ` 
-	# Display details of a user named 'admin'
-  	alpacon user describe admin
+	Example: `
+	alpacon user describe john
+	alpacon user desc john
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/iam/user_update.go
+++ b/cmd/iam/user_update.go
@@ -18,7 +18,7 @@ var userUpdateCmd = &cobra.Command{
 	Due to these factors, after successfully executing the update command, the return of user information allows for verification of the modifications.
 	`,
 	Example: `
-	alpacon user update [USER_NAME]
+	alpacon user update john
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/log/log.go
+++ b/cmd/log/log.go
@@ -16,10 +16,10 @@ var LogCmd = &cobra.Command{
 	to limit the output to the last N log entries. Suitable for debugging and monitoring 
 	server activities.`,
 	Example: `
-	alpacon log [SERVER NAME]
-	alpacon logs [SERVER_NAME]
-	alpacon log [SERVER NAME] --tail=10
-	alpacon logs [SERVER NAME] --tail=10
+	alpacon log my-server
+	alpacon logs my-server
+	alpacon log my-server --tail=10
+	alpacon logs my-server --tail=10
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -37,13 +37,13 @@ var loginCmd = &cobra.Command{
 	alpacon login alpacon.example.com
 
 	# Login via API Token
-	alpacon login myworkspace.us1.alpacon.io -t [TOKEN_KEY]
+	alpacon login myworkspace.us1.alpacon.io -t apikey1234
 
 	# Legacy username/password
-	alpacon login [WORKSPACE_URL] -u [USERNAME] -p [PASSWORD]
+	alpacon login myworkspace.us1.alpacon.io -u admin -p mypassword
 
 	# Skip TLS certificate verification
-	alpacon login [WORKSPACE_URL] --insecure
+	alpacon login myworkspace.us1.alpacon.io --insecure
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/note/note_create.go
+++ b/cmd/note/note_create.go
@@ -19,9 +19,8 @@ var noteCreateCmd = &cobra.Command{
 	You can specify the server name, note content, and privacy settings.",
 	`,
 	Example: `
-	alpacon note create 
-	alpacon note create -s [SERVER NAME]
-	alpacon note create -s myserver -c "hello world!" -p true
+	alpacon note create
+	alpacon note create -s my-server -c "hello world!" -p true
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if noteRequest.Server == "" {

--- a/cmd/server/server_delete.go
+++ b/cmd/server/server_delete.go
@@ -17,8 +17,9 @@ var serverDeleteCmd = &cobra.Command{
 	The command requires the exact server name as an argument.
 	`,
 	Example: `
-	alpacon server delete [SERVER NAME]
-	alpacon server rm [SERVER NAME]
+	alpacon server delete my-server
+	alpacon server rm my-server
+	alpacon server delete my-server -y
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/server/server_detail.go
+++ b/cmd/server/server_detail.go
@@ -16,9 +16,9 @@ var serverDetailCmd = &cobra.Command{
 	including its status, and other relevant attributes. 
 	This command is useful for getting an in-depth understanding of a server's current state and configuration.
 	`,
-	Example: ` 
-	# Display details of a server named 'myserver'
-  	alpacon server describe myserver
+	Example: `
+	alpacon server describe my-server
+	alpacon server desc my-server
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/token/acl_add.go
+++ b/cmd/token/acl_add.go
@@ -15,8 +15,8 @@ var aclAddCmd = &cobra.Command{
 	The add command allows you to define access to specific commands for API tokens.
 	`,
 	Example: `
-	alpacon token acl add [TOKEN_ID_OR_NAME] 
-	alpacon token acl add --token=[TOKEN_ID_OR_NAME] --command=[COMMAND]
+	alpacon token acl add
+	alpacon token acl add --token=my-api-token --command="server ls"
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		token, _ := cmd.Flags().GetString("token")

--- a/cmd/token/acl_list.go
+++ b/cmd/token/acl_list.go
@@ -17,8 +17,8 @@ var aclListCmd = &cobra.Command{
 	It shows details such as the token name and the commands associated with each ACL.
 	`,
 	Example: `
-	alpacon token acl ls [TOKEN_ID_OR_NAME]
-	alpacon token acl list [TOKEN_ID_OR_NAME]
+	alpacon token acl ls my-api-token
+	alpacon token acl list my-api-token
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/token/token_delete.go
+++ b/cmd/token/token_delete.go
@@ -15,9 +15,10 @@ var tokenDeleteCmd = &cobra.Command{
 	Removes an existing API token from the system. 
 	This command requires the token name to identify the token to be deleted.
 	`,
-	Example: ` 
-	alpacon token delete [TOKEN_ID_OR_NAME]
-	alpacon token rm [TOKEN_ID_OR_NAME]
+	Example: `
+	alpacon token delete my-api-token
+	alpacon token rm my-api-token
+	alpacon token delete my-api-token -y
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/tunnel/tunnel.go
+++ b/cmd/tunnel/tunnel.go
@@ -55,24 +55,17 @@ var TunnelCmd = &cobra.Command{
 	The tunnel uses WebSocket + smux multiplexing for efficient connection handling.
 	`,
 	Example: `
-	// Create a tunnel to a remote server
-	alpacon tunnel [SERVER NAME] -l [LOCAL PORT] -r [REMOTE PORT]
+	# Create a tunnel to forward local port 9000 to remote port 8082
+	alpacon tunnel my-server -l 9000 -r 8082
 
-	// Forward local port 9000 to remote server's port 8082
-	alpacon tunnel [SERVER NAME] --local 9000 --remote 8082
+	# Forward local port 9000 to remote port 8082 (long flags)
+	alpacon tunnel my-server --local 9000 --remote 8082
 
-	// Forward local port 2222 to remote server's SSH port (22)
-	alpacon tunnel [SERVER NAME] -l 2222 -r 22
+	# Forward local port 2222 to remote server's SSH port (22)
+	alpacon tunnel my-server -l 2222 -r 22
 
-	// Specify username and groupname for the tunnel
-	alpacon tunnel [SERVER NAME] -l [LOCAL PORT] -r [REMOTE PORT] -u [USER NAME] -g [GROUP NAME]
-
-	Flags:
-	-l, --local [PORT]                 Local port to listen on (required).
-	-r, --remote [PORT]                Remote port to connect to (required).
-	-u, --username [USER NAME]         Username for the tunnel.
-	-g, --groupname [GROUP NAME]       Groupname for the tunnel.
-	-v, --verbose                      Show connection logs.
+	# Specify username and groupname for the tunnel
+	alpacon tunnel my-server -l 9000 -r 8082 -u admin -g developers
 	`,
 	Args: cobra.ExactArgs(1),
 	Run:  runTunnel,


### PR DESCRIPTION
## Summary

Replace `[PLACEHOLDER]` format in `Example` sections with realistic values across 23 files, following the project convention documented in CLAUDE.md.

**Before:**
```
alpacon server delete [SERVER NAME]
alpacon csr describe [CSR ID]
alpacon login [WORKSPACE_URL] -u [USERNAME] -p [PASSWORD]
alpacon tunnel [SERVER NAME] -l [LOCAL PORT] -r [REMOTE PORT]
```

**After:**
```
alpacon server delete my-server
alpacon csr describe 550e8400-e29b-41d4-a716-446655440000
alpacon login myworkspace.us1.alpacon.io -u admin -p mypassword
alpacon tunnel my-server -l 9000 -r 8082
```

**Realistic values used:**
| Placeholder | Realistic Value |
|---|---|
| `[SERVER NAME]` | `my-server` |
| `[USER NAME]` | `john` |
| `[GROUP NAME]` | `developers` |
| `[CSR/CERT/AUTHORITY ID]` | `550e8400-e29b-41d4-a716-446655440000` |
| `[TOKEN_ID_OR_NAME]` | `my-api-token` |
| `[TOKEN_KEY]` | `apikey1234` |
| `[USERNAME]`/`[PASSWORD]` | `admin`/`mypassword` |
| `[LOCAL/REMOTE PORT]` | `9000`/`8082` |

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)