### PR TITLE
fix: remove invalid example and unreachable return

### DIFF
--- a/cmd/iam/group_list.go
+++ b/cmd/iam/group_list.go
@@ -17,7 +17,6 @@ var groupListCmd = &cobra.Command{
 	`,
 	Example: `
 	alpacon group ls
-	alpacon groups
 	alpacon group list
 	`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -47,7 +47,6 @@ var logoutCmd = &cobra.Command{
 		envInfo, err := auth0.FetchAuthEnv(validConfig.WorkspaceURL, httpClient)
 		if err != nil {
 			utils.CliErrorWithExit("Failed to fetch authentication environment: %s.", err)
-			return
 		}
 
 		if envInfo.Auth0.Method == "auth0" {


### PR DESCRIPTION
## Summary

- `cmd/iam/group_list.go`: Remove `alpacon groups` from Example — `GroupCmd` has no `groups` alias, so this example was incorrect
- `cmd/logout.go`: Remove unreachable `return` after `CliErrorWithExit`, which already calls `os.Exit(1)`

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)