### PR TITLE
fix: add missing desc alias to describe command examples

### DIFF
--- a/cmd/note/note_detail.go
+++ b/cmd/note/note_detail.go
@@ -17,6 +17,7 @@ var noteDetailCmd = &cobra.Command{
 	`,
 	Example: `
 	alpacon note describe 550e8400-e29b-41d4-a716-446655440000
+	alpacon note desc 550e8400-e29b-41d4-a716-446655440000
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/revoke/revoke_detail.go
+++ b/cmd/revoke/revoke_detail.go
@@ -17,6 +17,7 @@ var revokeDetailCmd = &cobra.Command{
 	`,
 	Example: `
 	alpacon revoke describe 550e8400-e29b-41d4-a716-446655440000
+	alpacon revoke desc 550e8400-e29b-41d4-a716-446655440000
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/webhook/webhook_detail.go
+++ b/cmd/webhook/webhook_detail.go
@@ -17,6 +17,7 @@ var webhookDetailCmd = &cobra.Command{
 	`,
 	Example: `
 	alpacon webhook describe my-webhook
+	alpacon webhook desc my-webhook
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Summary

`webhook describe`, `note describe`, and `revoke describe` commands all have `Aliases: []string{"desc"}` registered, but the `desc` shorthand was not shown in the `Example` section — unlike other describe commands (`server`, `user`, `group`, `cert`, `authority`, `csr`) which all show both forms.

Affected files:
- `cmd/webhook/webhook_detail.go`
- `cmd/note/note_detail.go`
- `cmd/revoke/revoke_detail.go`

## Test plan

- [ ] `go vet ./...` passes
- [ ] `alpacon webhook desc <name>` works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)