### PR TITLE
refactor: remove unnecessary flag binding variables in init()

### DIFF
--- a/cmd/csr/csr_list.go
+++ b/cmd/csr/csr_list.go
@@ -37,7 +37,5 @@ var csrListCmd = &cobra.Command{
 }
 
 func init() {
-	var state string
-
-	csrListCmd.Flags().StringVarP(&state, "status", "s", "", "Specify the status of the CSR (e.g., 'denied', 'signed')")
+	csrListCmd.Flags().StringP("status", "s", "", "Specify the status of the CSR (e.g., 'denied', 'signed')")
 }

--- a/cmd/revoke/revoke_list.go
+++ b/cmd/revoke/revoke_list.go
@@ -38,8 +38,6 @@ var revokeListCmd = &cobra.Command{
 }
 
 func init() {
-	var status string
-	var certificate string
-	revokeListCmd.Flags().StringVar(&status, "status", "", "Filter by status (e.g., pending, approved, denied)")
-	revokeListCmd.Flags().StringVar(&certificate, "certificate", "", "Filter by certificate ID")
+	revokeListCmd.Flags().String("status", "", "Filter by status (e.g., pending, approved, denied)")
+	revokeListCmd.Flags().String("certificate", "", "Filter by certificate ID")
 }


### PR DESCRIPTION
## Summary

`csr_list` and `revoke_list` declared local variables in `init()` solely to pass their address to `StringVarP`/`StringVar`, while the `Run` function retrieved flag values via `GetString` anyway. The intermediate variables served no purpose.

Replace `StringVarP(&state, ...)` / `StringVar(&status, ...)` with `StringP(...)` / `String(...)` to register flags without an unused binding variable.

Affected files:
- `cmd/csr/csr_list.go`: `var state string` removed
- `cmd/revoke/revoke_list.go`: `var status string`, `var certificate string` removed

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `alpacon csr ls --status=signed` filters correctly
- [ ] `alpacon revoke ls --status=pending` filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)