### PR TITLE
refactor: rename Id to ID to follow Go naming convention

### DIFF
--- a/api/cert/cert.go
+++ b/api/cert/cert.go
@@ -73,7 +73,7 @@ func GetCSRList(ac *client.AlpaconClient, status string) ([]CSRAttributes, error
 	var csrList []CSRAttributes
 	for _, csr := range csrs {
 		csrList = append(csrList, CSRAttributes{
-			Id:            csr.Id,
+			ID:            csr.ID,
 			Name:          csr.CommonName,
 			Authority:     csr.Authority.Name,
 			DomainList:    csr.DomainList,
@@ -97,7 +97,7 @@ func GetAuthorityList(ac *client.AlpaconClient) ([]AuthorityAttributes, error) {
 	var authorityList []AuthorityAttributes
 	for _, authority := range authorities {
 		authorityList = append(authorityList, AuthorityAttributes{
-			Id:               authority.Id,
+			ID:               authority.ID,
 			Name:             authority.Name,
 			Organization:     authority.Organization,
 			Domain:           authority.Domain,
@@ -197,7 +197,7 @@ func GetCertificateList(ac *client.AlpaconClient) ([]CertificateAttributes, erro
 	var certList []CertificateAttributes
 	for _, cert := range certs {
 		certList = append(certList, CertificateAttributes{
-			Id:        cert.Id,
+			ID:        cert.ID,
 			Authority: cert.Authority.Name,
 			Csr:       cert.Csr,
 			ValidDays: cert.ValidDays,
@@ -227,7 +227,7 @@ func DownloadCertificateByCSR(ac *client.AlpaconClient, csrId string, filePath s
 	}
 
 	if detail.CrtText == "" {
-		return fmt.Errorf("certificate text is empty for signed CSR (id: %s)", detail.Id)
+		return fmt.Errorf("certificate text is empty for signed CSR (id: %s)", detail.ID)
 	}
 
 	return utils.SaveFile(filePath, []byte(detail.CrtText))

--- a/api/cert/cert_test.go
+++ b/api/cert/cert_test.go
@@ -42,7 +42,7 @@ func TestGetCSRList_Pagination(t *testing.T) {
 		case "1", "":
 			for i := 0; i < 100; i++ {
 				results = append(results, CSRResponse{
-					Id:         fmt.Sprintf("csr-%d", i),
+					ID:         fmt.Sprintf("csr-%d", i),
 					CommonName: fmt.Sprintf("cn-%d", i),
 					Authority: AuthorityResponse{
 						Name: "auth-test",
@@ -53,7 +53,7 @@ func TestGetCSRList_Pagination(t *testing.T) {
 		case "2":
 			for i := 0; i < 50; i++ {
 				results = append(results, CSRResponse{
-					Id:         fmt.Sprintf("csr-p2-%d", i),
+					ID:         fmt.Sprintf("csr-p2-%d", i),
 					CommonName: fmt.Sprintf("cn-p2-%d", i),
 					Authority: AuthorityResponse{
 						Name: "auth-test",
@@ -114,7 +114,7 @@ func TestGetAuthorityList_Pagination(t *testing.T) {
 		case "1", "":
 			for i := 0; i < 100; i++ {
 				results = append(results, AuthorityResponse{
-					Id:   fmt.Sprintf("auth-%d", i),
+					ID:   fmt.Sprintf("auth-%d", i),
 					Name: fmt.Sprintf("authority-%d", i),
 					Owner: iam.UserSummary{
 						Name: "admin",
@@ -124,7 +124,7 @@ func TestGetAuthorityList_Pagination(t *testing.T) {
 		case "2":
 			for i := 0; i < 50; i++ {
 				results = append(results, AuthorityResponse{
-					Id:   fmt.Sprintf("auth-p2-%d", i),
+					ID:   fmt.Sprintf("auth-p2-%d", i),
 					Name: fmt.Sprintf("authority-p2-%d", i),
 					Owner: iam.UserSummary{
 						Name: "admin",
@@ -184,7 +184,7 @@ func TestGetCertificateList_Pagination(t *testing.T) {
 		case "1", "":
 			for i := 0; i < 100; i++ {
 				results = append(results, Certificate{
-					Id: fmt.Sprintf("cert-%d", i),
+					ID: fmt.Sprintf("cert-%d", i),
 					Authority: AuthoritySummary{
 						Name: "auth-test",
 					},
@@ -193,7 +193,7 @@ func TestGetCertificateList_Pagination(t *testing.T) {
 		case "2":
 			for i := 0; i < 50; i++ {
 				results = append(results, Certificate{
-					Id: fmt.Sprintf("cert-p2-%d", i),
+					ID: fmt.Sprintf("cert-p2-%d", i),
 					Authority: AuthoritySummary{
 						Name: "auth-test",
 					},
@@ -236,7 +236,7 @@ func TestGetCertificateList_Pagination(t *testing.T) {
 
 func TestCreateSignRequest(t *testing.T) {
 	expectedResponse := SignRequestResponse{
-		Id:         "new-csr-id",
+		ID:         "new-csr-id",
 		CommonName: "example.com",
 		Status:     "requested",
 		SubmitURL:  "/api/cert/sign-requests/new-csr-id/submit/",
@@ -258,7 +258,7 @@ func TestCreateSignRequest(t *testing.T) {
 
 	resp, err := CreateSignRequest(ac, signReq)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedResponse.Id, resp.Id)
+	assert.Equal(t, expectedResponse.ID, resp.ID)
 	assert.Equal(t, expectedResponse.CommonName, resp.CommonName)
 	assert.Equal(t, expectedResponse.SubmitURL, resp.SubmitURL)
 }
@@ -339,7 +339,7 @@ func TestDownloadCertificateByCSR(t *testing.T) {
 		{
 			name: "signed CSR with certificate",
 			response: SignRequestDetail{
-				Id:         "test-csr-id",
+				ID:         "test-csr-id",
 				CommonName: "example.com",
 				Status:     "signed",
 				CrtText:    "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----",
@@ -350,7 +350,7 @@ func TestDownloadCertificateByCSR(t *testing.T) {
 		{
 			name: "requested CSR without certificate",
 			response: SignRequestDetail{
-				Id:         "test-csr-id",
+				ID:         "test-csr-id",
 				CommonName: "example.com",
 				Status:     "requested",
 				CrtText:    "",
@@ -362,7 +362,7 @@ func TestDownloadCertificateByCSR(t *testing.T) {
 		{
 			name: "denied CSR",
 			response: SignRequestDetail{
-				Id:         "test-csr-id",
+				ID:         "test-csr-id",
 				CommonName: "example.com",
 				Status:     "denied",
 				CrtText:    "",
@@ -374,7 +374,7 @@ func TestDownloadCertificateByCSR(t *testing.T) {
 		{
 			name: "signing in progress",
 			response: SignRequestDetail{
-				Id:         "test-csr-id",
+				ID:         "test-csr-id",
 				CommonName: "example.com",
 				Status:     "signing",
 				CrtText:    "",
@@ -386,7 +386,7 @@ func TestDownloadCertificateByCSR(t *testing.T) {
 		{
 			name: "non-signed CSR with certificate text",
 			response: SignRequestDetail{
-				Id:         "test-csr-id",
+				ID:         "test-csr-id",
 				CommonName: "example.com",
 				Status:     "requested",
 				CrtText:    "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----",
@@ -468,7 +468,7 @@ func TestDownloadCertificate(t *testing.T) {
 		{
 			name: "valid certificate",
 			response: Certificate{
-				Id:      "test-cert-id",
+				ID:      "test-cert-id",
 				CrtText: "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----",
 			},
 			expectError: false,
@@ -476,7 +476,7 @@ func TestDownloadCertificate(t *testing.T) {
 		{
 			name: "empty certificate text",
 			response: Certificate{
-				Id:      "test-cert-id",
+				ID:      "test-cert-id",
 				CrtText: "",
 			},
 			expectError: false,

--- a/api/cert/types.go
+++ b/api/cert/types.go
@@ -16,7 +16,7 @@ type SignRequest struct {
 }
 
 type SignRequestResponse struct {
-	Id           string          `json:"id"`
+	ID           string          `json:"id"`
 	Organization string          `json:"organization"`
 	CommonName   string          `json:"common_name"`
 	DomainList   []string        `json:"domain_list"`
@@ -41,7 +41,7 @@ type AuthorityRequest struct {
 }
 
 type AuthorityCreateResponse struct {
-	Id               string          `json:"id"`
+	ID               string          `json:"id"`
 	Name             string          `json:"name"`
 	Organization     string          `json:"organization"`
 	Domain           string          `json:"domain"`
@@ -55,7 +55,7 @@ type AuthorityCreateResponse struct {
 }
 
 type AuthorityResponse struct {
-	Id               string          `json:"id"`
+	ID               string          `json:"id"`
 	Name             string          `json:"name"`
 	Organization     string          `json:"organization"`
 	Domain           string          `json:"domain"`
@@ -70,7 +70,7 @@ type AuthorityResponse struct {
 }
 
 type AuthorityAttributes struct {
-	Id               string `json:"id" table:"ID"`
+	ID               string `json:"id" table:"ID"`
 	Name             string `json:"name"`
 	Organization     string `json:"organization"`
 	Domain           string `json:"domain"`
@@ -83,7 +83,7 @@ type AuthorityAttributes struct {
 }
 
 type AuthorityDetails struct {
-	Id               string          `json:"id"`
+	ID               string          `json:"id"`
 	Name             string          `json:"name"`
 	Organization     string          `json:"organization"`
 	Domain           string          `json:"domain"`
@@ -103,13 +103,13 @@ type AuthorityDetails struct {
 }
 
 type AuthoritySummary struct {
-	Id    string          `json:"id"`
+	ID    string          `json:"id"`
 	Name  string          `json:"name"`
 	Owner iam.UserSummary `json:"owner"`
 }
 
 type SignRequestDetail struct {
-	Id         string `json:"id"`
+	ID         string `json:"id"`
 	CommonName string `json:"common_name"`
 	Status     string `json:"status"`
 	CrtText    string `json:"crt_text"`
@@ -120,7 +120,7 @@ type CSRSubmit struct {
 }
 
 type CSRResponse struct {
-	Id          string            `json:"id"`
+	ID          string            `json:"id"`
 	Authority   AuthorityResponse `json:"authority"`
 	CommonName  string            `json:"common_name"`
 	DomainList  []string          `json:"domain_list"`
@@ -133,7 +133,7 @@ type CSRResponse struct {
 }
 
 type CSRAttributes struct {
-	Id            string   `json:"id" table:"ID"`
+	ID            string   `json:"id" table:"ID"`
 	Name          string   `json:"name"` // Derived from the first domain in the CSR domain list
 	Authority     string   `json:"authority"`
 	DomainList    []string `json:"domain_list" table:"Domain List"`
@@ -145,7 +145,7 @@ type CSRAttributes struct {
 }
 
 type Certificate struct {
-	Id        string           `json:"id"`
+	ID        string           `json:"id"`
 	Authority AuthoritySummary `json:"authority"`
 	Csr       string           `json:"csr"`
 	CrtText   string           `json:"crt_text"`
@@ -193,7 +193,7 @@ type RevokeRequestAttributes struct {
 }
 
 type CertificateAttributes struct {
-	Id        string `json:"id" table:"ID"`
+	ID        string `json:"id" table:"ID"`
 	Authority string `json:"authority"`
 	Csr       string `json:"csr" table:"CSR"`
 	ValidDays int    `json:"valid_days" table:"Valid Days"`

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -94,7 +94,7 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 		return "", err
 	}
 
-	result, err := PollCommandExecution(ac, cmdResponse[0].Id)
+	result, err := PollCommandExecution(ac, cmdResponse[0].ID)
 	if err != nil {
 		return "", err
 	}

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -44,7 +44,7 @@ type CommandRequest struct {
 }
 
 type CommandResponse struct {
-	Id          string          `json:"id"`
+	ID          string          `json:"id"`
 	Shell       string          `json:"shell"`
 	Line        string          `json:"line"`
 	Data        string          `json:"data"`

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -99,13 +99,13 @@ func executeUpload(ac *client.AlpaconClient, uploadRequest *UploadRequest, conte
 		}
 	}
 
-	relativePath := path.Join(response.Id, "upload")
+	relativePath := path.Join(response.ID, "upload")
 	fullURL := utils.BuildURL(uploadAPIURL, relativePath, nil)
 	if _, err := ac.SendGetRequest(fullURL); err != nil {
 		return err
 	}
 
-	success, message, err := PollTransferStatus(ac, "upload", response.Id)
+	success, message, err := PollTransferStatus(ac, "upload", response.ID)
 	if err != nil {
 		return fmt.Errorf("upload transfer status check failed: %w", err)
 	}
@@ -123,7 +123,7 @@ func uploadSingleFile(ac *client.AlpaconClient, filePath, remotePath, serverID, 
 	}
 
 	uploadRequest := &UploadRequest{
-		Id:             uuid.New().String(),
+		ID:             uuid.New().String(),
 		Name:           filepath.Base(filePath),
 		Path:           remotePath,
 		Server:         serverID,
@@ -163,7 +163,7 @@ func uploadSingleFolder(ac *client.AlpaconClient, folderPath, remotePath, server
 	}
 
 	uploadRequest := &UploadRequest{
-		Id:             uuid.New().String(),
+		ID:             uuid.New().String(),
 		AllowUnzip:     "true",
 		AllowOverwrite: "true",
 		Name:           filepath.Base(folderPath) + ".zip",

--- a/api/ftp/types.go
+++ b/api/ftp/types.go
@@ -31,7 +31,7 @@ type DownloadResponse struct {
 }
 
 type UploadRequest struct {
-	Id             string `json:"id"`
+	ID             string `json:"id"`
 	Name           string `json:"name"`
 	Path           string `json:"path"`
 	Server         string `json:"server"`
@@ -42,7 +42,7 @@ type UploadRequest struct {
 }
 
 type UploadResponse struct {
-	Id        string    `json:"id"`
+	ID        string    `json:"id"`
 	Name      string    `json:"name"`
 	Path      string    `json:"path"`
 	Size      int               `json:"size"`

--- a/api/security/security_test.go
+++ b/api/security/security_test.go
@@ -30,7 +30,7 @@ func TestGetCommandAclList_Pagination(t *testing.T) {
 		case "1", "":
 			for i := 0; i < 100; i++ {
 				results = append(results, CommandAclResponse{
-					Id:      fmt.Sprintf("acl-%d", i),
+					ID:      fmt.Sprintf("acl-%d", i),
 					Token:   "token-id-1",
 					Command: fmt.Sprintf("cmd-%d", i),
 				})
@@ -38,7 +38,7 @@ func TestGetCommandAclList_Pagination(t *testing.T) {
 		case "2":
 			for i := 0; i < 50; i++ {
 				results = append(results, CommandAclResponse{
-					Id:      fmt.Sprintf("acl-p2-%d", i),
+					ID:      fmt.Sprintf("acl-p2-%d", i),
 					Token:   "token-id-1",
 					Command: fmt.Sprintf("cmd-p2-%d", i),
 				})

--- a/api/security/types.go
+++ b/api/security/types.go
@@ -6,7 +6,7 @@ type CommandAclRequest struct {
 }
 
 type CommandAclResponse struct {
-	Id        string `json:"id"`
+	ID        string `json:"id"`
 	Token     string `json:"token"`
 	TokenName string `json:"token_name"`
 	Command   string `json:"command"`

--- a/cmd/csr/csr_create.go
+++ b/cmd/csr/csr_create.go
@@ -58,7 +58,7 @@ var csrCreateCmd = &cobra.Command{
 			utils.CliErrorWithExit("Failed to submit CSR file to server: %s.", err)
 		}
 
-		utils.CliSuccess("CSR created (ID: %s). After approval, run: alpacon csr download-crt %s", response.Id, response.Id)
+		utils.CliSuccess("CSR created (ID: %s). After approval, run: alpacon csr download-crt %s", response.ID, response.ID)
 	},
 }
 


### PR DESCRIPTION
## Summary

Go's naming convention ([Effective Go](https://go.dev/doc/effective_go#mixed-caps)) requires initialisms to be fully uppercase. The `Id` field name violated this — it should be `ID`.

Renamed `Id` → `ID` across all struct definitions and their usages:

| Package | Files |
|---|---|
| `api/cert` | `types.go`, `cert.go`, `cert_test.go` |
| `api/ftp` | `types.go`, `ftp.go` |
| `api/security` | `types.go`, `security_test.go` |
| `api/event` | `types.go`, `event.go` |
| `cmd/csr` | `csr_create.go` |

Note: JSON tags (`json:"id"`) are unchanged — this is a Go field name change only with no API contract impact.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)