### PR TITLE
fix: treat cp download destination as file path when not an existing directory

### DIFF
--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -233,7 +233,11 @@ func saveDownloadedContent(content []byte, dest, remotePath string, recursive bo
 		// If dest is an existing directory or ends with a separator, append the remote filename.
 		// Otherwise treat dest as the target file path directly (cp-style rename semantics).
 		info, err := os.Stat(dest)
-		if (err == nil && info.IsDir()) || strings.HasSuffix(dest, string(filepath.Separator)) {
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to access destination %q: %w", dest, err)
+		}
+		destHasTrailingSep := len(dest) > 0 && os.IsPathSeparator(dest[len(dest)-1])
+		if (err == nil && info.IsDir()) || destHasTrailingSep {
 			filePath = filepath.Join(dest, filepath.Base(remotePath))
 		} else {
 			filePath = dest


### PR DESCRIPTION
## Summary
- `api/ftp/ftp.go`: `saveDownloadedContent` now uses `os.Stat` to check if the destination exists and is a directory before deciding whether to append the remote filename. If the destination is not an existing directory, it is used directly as the target file path (cp-style rename semantics).

## Before
```
alpacon cp server:/path/to/file.txt ./local.txt
# Result: creates ./local.txt/ directory and saves as ./local.txt/file.txt
```

## After
```
alpacon cp server:/path/to/file.txt ./local.txt
# Result: saves directly as ./local.txt ✓
```

## Test plan
- [ ] `alpacon cp server:/path/file.txt ./renamed.txt` saves as `renamed.txt`
- [ ] `alpacon cp server:/path/file.txt ./existing-dir/` saves inside the directory
- [ ] `alpacon cp server:/path/file.txt .` saves as `./file.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)