### PR TITLE
fix(events): adapt command status response to flat format

### DIFF
--- a/api/event/event.go
+++ b/api/event/event.go
@@ -99,11 +99,8 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 		return "", err
 	}
 
-	if result.Status["text"] == "Stuck" || result.Status["text"] == "Error" {
-		if msg, ok := result.Status["message"].(string); ok {
-			return msg, nil
-		}
-		return fmt.Sprintf("command failed with status: %v", result.Status["text"]), nil
+	if result.Status == "stuck" || result.Status == "error" {
+		return fmt.Sprintf("command failed with status: %s", result.Status), nil
 	}
 
 	return result.Result, nil
@@ -130,8 +127,8 @@ func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails,
 				return response, err
 			}
 
-			switch response.Status["text"] {
-			case "Acked":
+			switch response.Status {
+			case "acked":
 				timer.Reset(5 * time.Minute)
 				continue
 			default:

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -22,7 +22,8 @@ type EventDetails struct {
 	Line          string             `json:"line"`
 	Success       *bool              `json:"success"`
 	Result        string             `json:"result"`
-	Status        map[string]any     `json:"status"`
+	Status        string             `json:"status"`
+	Cancellable   bool               `json:"cancellable"`
 	ResponseDelay float64            `json:"response_delay"`
 	ElapsedTime   float64            `json:"elapsed_time"`
 	AddedAt       time.Time          `json:"added_at"`

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -289,13 +289,10 @@ func downloadSingleFile(ac *client.AlpaconClient, remotePath, dest, serverID, us
 		return err
 	}
 
-	if status.Status["text"] == "Stuck" || status.Status["text"] == "Error" {
-		if msg, ok := status.Status["message"].(string); ok {
-			utils.CliErrorWithExit("%s", msg)
-		}
-		utils.CliErrorWithExit("command failed with status: %v", status.Status["text"])
+	if status.Status == "stuck" || status.Status == "error" {
+		utils.CliErrorWithExit("command failed with status: %s", status.Status)
 	}
-	if status.Status["text"] == "Failed" {
+	if status.Status == "failed" {
 		utils.CliErrorWithExit("%s", status.Result)
 	}
 


### PR DESCRIPTION
## Summary
- Updated `EventDetails.Status` from `map[string]any` to `string` (flat status value)
- Added `Cancellable bool` field to `EventDetails`
- Updated all status comparisons from `Status["text"] == "Stuck"` to `Status == "stuck"` (lowercase)
- Removed `Status["message"]` references (no longer in API response)

Adapts to backend API change in alpacax/alpacon-server#554.

## Test plan
- [ ] Verify `alpacon exec` command works correctly with new status format
- [ ] Verify `alpacon cp` (download) handles stuck/error/failed statuses correctly
- [ ] Verify `alpacon events` list displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)