### PR TITLE
feat(mfa): add lightweight MFA completion polling for step-up flow

### DIFF
--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -12,11 +12,16 @@ import (
 )
 
 const (
-	mfaURL = "/api/auth0/mfa"
+	mfaURL           = "/api/auth0/mfa"
+	mfaCompletionURL = "/api/auth0/mfa/completion/"
 )
 
 type mfaResponse struct {
 	MfaURL string `json:"mfa_url"`
+}
+
+type mfaCompletionResponse struct {
+	Completed bool `json:"completed"`
 }
 
 func HandleMFAError(ac *client.AlpaconClient, serverName string) error {
@@ -35,6 +40,20 @@ func HandleMFAError(ac *client.AlpaconClient, serverName string) error {
 	fmt.Fprintf(os.Stderr, "\nMFA authentication required. Please visit:\n  %s\n\n", mfaURL)
 
 	return nil
+}
+
+func CheckMFACompletion(ac *client.AlpaconClient) (bool, error) {
+	responseBody, err := ac.SendGetRequest(mfaCompletionURL)
+	if err != nil {
+		return false, fmt.Errorf("failed to check MFA completion: %w", err)
+	}
+
+	var resp mfaCompletionResponse
+	if err := json.Unmarshal(responseBody, &resp); err != nil {
+		return false, fmt.Errorf("failed to parse MFA completion response: %w", err)
+	}
+
+	return resp.Completed, nil
 }
 
 func GetMFALink(ac *client.AlpaconClient, serverID string, workspaceName string) (string, error) {

--- a/api/mfa/mfa_test.go
+++ b/api/mfa/mfa_test.go
@@ -1,0 +1,61 @@
+package mfa
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckMFACompletion_Completed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, mfaCompletionURL, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"completed": true}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}
+
+	completed, err := CheckMFACompletion(ac)
+	assert.NoError(t, err)
+	assert.True(t, completed)
+}
+
+func TestCheckMFACompletion_NotCompleted(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"completed": false}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}
+
+	completed, err := CheckMFACompletion(ac)
+	assert.NoError(t, err)
+	assert.False(t, completed)
+}
+
+func TestCheckMFACompletion_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"detail": "internal server error"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}
+
+	_, err := CheckMFACompletion(ac)
+	assert.Error(t, err)
+}

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -16,10 +16,10 @@ var ExecCmd = &cobra.Command{
 	Use:   "exec [USER@]SERVER COMMAND...",
 	Short: "Execute a command on a remote server",
 	Long: `Execute a command on a remote server.
-	
+
 	This command executes a specified command on a remote server and returns the output.
 	It supports SSH-like syntax for specifying the user and server.
-	
+
 	Examples:
 	  alpacon exec prod-docker docker ps
 	  alpacon exec root@prod-docker docker ps
@@ -67,6 +67,9 @@ var ExecCmd = &cobra.Command{
 				OnUsernameRequired: func() error {
 					_, err := iam.HandleUsernameRequired()
 					return err
+				},
+				CheckMFACompleted: func() (bool, error) {
+					return mfa.CheckMFACompletion(alpaconClient)
 				},
 				RefreshToken: alpaconClient.RefreshToken,
 				RetryOperation: func() error {

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -103,6 +103,9 @@ Remote paths use the format [USER@]SERVER:/path.`,
 						_, err := iam.HandleUsernameRequired()
 						return err
 					},
+					CheckMFACompleted: func() (bool, error) {
+						return mfa.CheckMFACompletion(alpaconClient)
+					},
 					RefreshToken: alpaconClient.RefreshToken,
 					RetryOperation: func() error {
 						return uploadObject(alpaconClient, sources, dest, username, groupname, recursive)
@@ -125,6 +128,9 @@ Remote paths use the format [USER@]SERVER:/path.`,
 					OnUsernameRequired: func() error {
 						_, err := iam.HandleUsernameRequired()
 						return err
+					},
+					CheckMFACompleted: func() (bool, error) {
+						return mfa.CheckMFACompletion(alpaconClient)
 					},
 					RefreshToken: alpaconClient.RefreshToken,
 					RetryOperation: func() error {

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -157,6 +157,9 @@ Note: All flags must be placed before the server name.
 						_, err := iam.HandleUsernameRequired()
 						return err
 					},
+					CheckMFACompleted: func() (bool, error) {
+						return mfa.CheckMFACompletion(alpaconClient)
+					},
 					RefreshToken: alpaconClient.RefreshToken,
 					RetryOperation: func() error {
 						result, err = event.RunCommand(alpaconClient, serverName, command, username, groupname, env)
@@ -180,6 +183,9 @@ Note: All flags must be placed before the server name.
 					OnUsernameRequired: func() error {
 						_, err := iam.HandleUsernameRequired()
 						return err
+					},
+					CheckMFACompleted: func() (bool, error) {
+						return mfa.CheckMFACompletion(alpaconClient)
 					},
 					RefreshToken: alpaconClient.RefreshToken,
 					RetryOperation: func() error {

--- a/utils/error_handler.go
+++ b/utils/error_handler.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-const maxRetryDuration = 3 * time.Minute
+var maxRetryDuration = 3 * time.Minute
 
 var retryInterval = 5 * time.Second
 
@@ -17,6 +17,10 @@ type ErrorHandlerCallbacks struct {
 
 	// OnUsernameRequired is called when username is required
 	OnUsernameRequired func() error
+
+	// CheckMFACompleted is called to poll for MFA completion via a lightweight endpoint.
+	// If nil, falls back to the legacy RefreshToken+RetryOperation loop.
+	CheckMFACompleted func() (bool, error)
 
 	// RefreshToken is called before each MFA retry to refresh the access token
 	// so the server can see the latest MFA completion state
@@ -47,31 +51,72 @@ func HandleCommonErrors(err error, serverName string, callbacks ErrorHandlerCall
 		spinner.Start()
 
 		startTime := time.Now()
-		// Retry loop
-		for {
-			if time.Since(startTime) > maxRetryDuration {
-				spinner.Stop()
-				return fmt.Errorf("MFA authentication timed out after %v", maxRetryDuration)
-			}
 
-			time.Sleep(retryInterval)
-
-			if callbacks.RefreshToken != nil {
-				if err := callbacks.RefreshToken(); err != nil {
+		if callbacks.CheckMFACompleted != nil {
+			// New flow: poll lightweight completion endpoint, then retry once
+			for {
+				if time.Since(startTime) > maxRetryDuration {
 					spinner.Stop()
-					return fmt.Errorf("failed to refresh token; please run 'alpacon login' to re-authenticate: %w", err)
+					return fmt.Errorf("MFA authentication timed out after %v", maxRetryDuration)
 				}
-			}
 
-			if callbacks.RetryOperation != nil {
-				if err := callbacks.RetryOperation(); err == nil {
-					spinner.Stop()
-					CliSuccess("MFA authentication completed")
-					return nil
+				time.Sleep(retryInterval)
+
+				completed, err := callbacks.CheckMFACompleted()
+				if err != nil {
+					// Non-fatal: endpoint may not be deployed yet, keep polling
+					continue
 				}
-			} else {
+				if !completed {
+					continue
+				}
+
+				// MFA completed — refresh token and retry once
+				if callbacks.RefreshToken != nil {
+					if err := callbacks.RefreshToken(); err != nil {
+						spinner.Stop()
+						return fmt.Errorf("failed to refresh token; please run 'alpacon login' to re-authenticate: %w", err)
+					}
+				}
+
+				if callbacks.RetryOperation != nil {
+					if err := callbacks.RetryOperation(); err != nil {
+						spinner.Stop()
+						return err
+					}
+				}
+
 				spinner.Stop()
-				break
+				CliSuccess("MFA authentication completed")
+				return nil
+			}
+		} else {
+			// Legacy flow: RefreshToken + RetryOperation loop
+			for {
+				if time.Since(startTime) > maxRetryDuration {
+					spinner.Stop()
+					return fmt.Errorf("MFA authentication timed out after %v", maxRetryDuration)
+				}
+
+				time.Sleep(retryInterval)
+
+				if callbacks.RefreshToken != nil {
+					if err := callbacks.RefreshToken(); err != nil {
+						spinner.Stop()
+						return fmt.Errorf("failed to refresh token; please run 'alpacon login' to re-authenticate: %w", err)
+					}
+				}
+
+				if callbacks.RetryOperation != nil {
+					if err := callbacks.RetryOperation(); err == nil {
+						spinner.Stop()
+						CliSuccess("MFA authentication completed")
+						return nil
+					}
+				} else {
+					spinner.Stop()
+					break
+				}
 			}
 		}
 

--- a/utils/error_handler_test.go
+++ b/utils/error_handler_test.go
@@ -16,6 +16,13 @@ func withFastRetry(t *testing.T) {
 	t.Cleanup(func() { retryInterval = orig })
 }
 
+func withFastTimeout(t *testing.T) {
+	t.Helper()
+	orig := maxRetryDuration
+	maxRetryDuration = 200 * time.Millisecond
+	t.Cleanup(func() { maxRetryDuration = orig })
+}
+
 func TestHandleCommonErrors_UnknownError(t *testing.T) {
 	err := errors.New("connection refused")
 	result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{})
@@ -93,4 +100,124 @@ func TestHandleCommonErrors_MFA_RefreshThenRetrySucceeds(t *testing.T) {
 	assert.NoError(t, result)
 	assert.Equal(t, int32(1), refreshCount.Load(), "RefreshToken should be called once")
 	assert.Equal(t, int32(1), retryCount.Load(), "RetryOperation should be called once")
+}
+
+func TestHandleCommonErrors_MFA_PollingSuccess(t *testing.T) {
+	withFastRetry(t)
+	err := errors.New(`{"code": "auth_mfa_required", "source": "command"}`)
+	var pollCount atomic.Int32
+	var refreshCount atomic.Int32
+	var retryCount atomic.Int32
+
+	result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{
+		OnMFARequired: func(srv string) error { return nil },
+		CheckMFACompleted: func() (bool, error) {
+			if pollCount.Add(1) >= 3 {
+				return true, nil
+			}
+			return false, nil
+		},
+		RefreshToken: func() error {
+			refreshCount.Add(1)
+			return nil
+		},
+		RetryOperation: func() error {
+			retryCount.Add(1)
+			return nil
+		},
+	})
+
+	assert.NoError(t, result)
+	assert.GreaterOrEqual(t, pollCount.Load(), int32(3), "should poll until completed")
+	assert.Equal(t, int32(1), refreshCount.Load(), "RefreshToken should be called once after completion")
+	assert.Equal(t, int32(1), retryCount.Load(), "RetryOperation should be called once after completion")
+}
+
+func TestHandleCommonErrors_MFA_PollingErrorRecovery(t *testing.T) {
+	withFastRetry(t)
+	err := errors.New(`{"code": "auth_mfa_required", "source": "command"}`)
+	var pollCount atomic.Int32
+
+	result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{
+		OnMFARequired: func(srv string) error { return nil },
+		CheckMFACompleted: func() (bool, error) {
+			n := pollCount.Add(1)
+			if n <= 2 {
+				return false, errors.New("endpoint not found")
+			}
+			return true, nil
+		},
+		RefreshToken:   func() error { return nil },
+		RetryOperation: func() error { return nil },
+	})
+
+	assert.NoError(t, result)
+	assert.GreaterOrEqual(t, pollCount.Load(), int32(3), "should continue polling after errors")
+}
+
+func TestHandleCommonErrors_MFA_PollingThenRefreshFails(t *testing.T) {
+	withFastRetry(t)
+	err := errors.New(`{"code": "auth_mfa_required", "source": "command"}`)
+	refreshErr := errors.New("refresh token expired")
+
+	result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{
+		OnMFARequired:     func(srv string) error { return nil },
+		CheckMFACompleted: func() (bool, error) { return true, nil },
+		RefreshToken:      func() error { return refreshErr },
+		RetryOperation: func() error {
+			t.Error("RetryOperation should not be called when RefreshToken fails")
+			return nil
+		},
+	})
+
+	assert.ErrorContains(t, result, "failed to refresh token; please run 'alpacon login'")
+	assert.ErrorIs(t, result, refreshErr)
+}
+
+func TestHandleCommonErrors_MFA_PollingThenRetryFails(t *testing.T) {
+	withFastRetry(t)
+	err := errors.New(`{"code": "auth_mfa_required", "source": "command"}`)
+	retryErr := errors.New("session creation failed")
+
+	result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{
+		OnMFARequired:     func(srv string) error { return nil },
+		CheckMFACompleted: func() (bool, error) { return true, nil },
+		RefreshToken:      func() error { return nil },
+		RetryOperation:    func() error { return retryErr },
+	})
+
+	assert.Equal(t, retryErr, result)
+}
+
+func TestHandleCommonErrors_MFA_PollingTimeout(t *testing.T) {
+	withFastRetry(t)
+	withFastTimeout(t)
+	err := errors.New(`{"code": "auth_mfa_required", "source": "command"}`)
+
+	result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{
+		OnMFARequired:     func(srv string) error { return nil },
+		CheckMFACompleted: func() (bool, error) { return false, nil },
+		RefreshToken:      func() error { return nil },
+		RetryOperation:    func() error { return nil },
+	})
+
+	assert.ErrorContains(t, result, "MFA authentication timed out")
+}
+
+func TestHandleCommonErrors_MFA_NilCheckMFACompleted_LegacyFlow(t *testing.T) {
+	withFastRetry(t)
+	err := errors.New(`{"code": "auth_mfa_required", "source": "command"}`)
+	var retryCount atomic.Int32
+
+	result := HandleCommonErrors(err, "server1", ErrorHandlerCallbacks{
+		OnMFARequired: func(srv string) error { return nil },
+		RefreshToken:  func() error { return nil },
+		RetryOperation: func() error {
+			retryCount.Add(1)
+			return nil
+		},
+	})
+
+	assert.NoError(t, result)
+	assert.Equal(t, int32(1), retryCount.Load(), "legacy flow should still work")
 }


### PR DESCRIPTION
## Summary
- Replace inefficient `RefreshToken` + `RetryOperation` loop with 2-phase MFA polling: poll lightweight `GET /api/auth0/mfa/completion/` endpoint first, then refresh token and retry once
- Add `CheckMFACompleted` callback to `ErrorHandlerCallbacks` — falls back to legacy loop when nil (backward compatible)
- Add `CheckMFACompletion()` API function in `api/mfa/`
- Wire up all 5 MFA call sites: `websh` (2), `exec` (1), `cp` (2)

Depends on: alpacax/alpacon-server#1692

## Test plan
- [x] `go build -o alpacon .`
- [x] `go test -race -v ./...` — all pass
- [x] `go vet ./...` — clean
- [x] Manual test: `./alpacon websh root@staging-web-01` with MFA step-up — completes without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)