### PR TITLE
feat(cmd): extend workspace commands with settings, security, and billing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,16 @@ utils/               # Shared utilities (output, prompts, errors, SSH parsing)
 - **Table output**: API response → `*Attributes` struct projection → `utils.PrintTable()`. All list commands follow this pattern
 - **Pagination**: `api.FetchAllPages[T]` (generics) handles all pagination internally. `cmd/` layer never sees pagination
 - **Dual auth tokens**: `AccessToken` (Auth0 Bearer JWT) takes priority; `Token` (legacy API key) is fallback. Set in `client.setHTTPHeader()`
+- **SaaS vs self-hosted detection**: Use `config.IsSaaS()` (package-level function in `config/config.go`) to detect deployment type. Returns `true` when `AccessToken` is present (Auth0 login = Alpacon Cloud). Add early-exit guards before `NewAlpaconAPIClient()` in commands that are SaaS-only or self-hosted-only:
+  ```go
+  isSaaS, err := config.IsSaaS()
+  if err != nil {
+      utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
+  }
+  if !isSaaS {
+      utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
+  }
+  ```
 - **CLI output helpers**: `utils.CliError*/CliInfo*/CliWarning` all write to stderr. stdout is reserved for data output (tables, JSON)
 - **Group commands**: Use `RunE` (not `Run`) to show help + return error when no subcommand is given
 - **Version injection**: `utils.Version` is set via `-ldflags` at build time by GoReleaser. Local builds default to `"dev"`
@@ -154,6 +164,10 @@ _ = json.NewEncoder(w).Encode(resp)
   - **Websh**—the browser-based terminal feature (proper noun). Never "WebSH" or "websh" in prose. Use `websh` only in code and CLI commands
   - **Alpamon**—the agent (proper noun)
   - **Auth0**—third-party service (their capitalization)
+- Deployment type terminology in user-facing messages:
+  - OnPrem deployments → **"self-hosted workspaces"** (never "OnPrem" or "on-premise")
+  - SaaS deployments → **"Alpacon Cloud workspaces"** (never "SaaS" or "cloud")
+  - Example: `"This command is only available on Alpacon Cloud workspaces."`
 - Use em-dashes (`—`) without surrounding spaces: `word—word`, not `word — word`
 
 ## Important notes

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -73,6 +73,25 @@ func GetMFALinkForSudo(ac *client.AlpaconClient, serverName string) (string, err
 	return GetMFALink(ac, serverID, cfg.WorkspaceName)
 }
 
+// GetWorkspaceSecurityMFALink returns an MFA URL for workspace security settings.
+// Uses location "cli" so the mfa-success page notifies the backend,
+// enabling CheckMFACompletion polling to detect when MFA is done.
+func GetWorkspaceSecurityMFALink(ac *client.AlpaconClient, workspaceName string) (string, error) {
+	params := map[string]string{
+		"location":  "cli",
+		"workspace": workspaceName,
+	}
+	responseBody, err := ac.SendGetRequest(utils.BuildURL(mfaURL, "", params))
+	if err != nil {
+		return "", fmt.Errorf("failed to get the MFA URL: %w", err)
+	}
+
+	var mfaResp mfaResponse
+	_ = json.Unmarshal(responseBody, &mfaResp)
+
+	return mfaResp.MfaURL, nil
+}
+
 func GetMFALink(ac *client.AlpaconClient, serverID string, workspaceName string) (string, error) {
 	params := map[string]string{
 		"location":  "cli",

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -87,7 +87,12 @@ func GetWorkspaceSecurityMFALink(ac *client.AlpaconClient, workspaceName string)
 	}
 
 	var mfaResp mfaResponse
-	_ = json.Unmarshal(responseBody, &mfaResp)
+	if err := json.Unmarshal(responseBody, &mfaResp); err != nil {
+		return "", fmt.Errorf("failed to parse MFA URL response: %w", err)
+	}
+	if mfaResp.MfaURL == "" {
+		return "", fmt.Errorf("MFA URL is empty in server response")
+	}
 
 	return mfaResp.MfaURL, nil
 }

--- a/api/workspace/access_control.go
+++ b/api/workspace/access_control.go
@@ -1,0 +1,44 @@
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+const (
+	accessControlURL = "/api/workspaces/access-control/-/"
+)
+
+// GetAccessControl retrieves the workspace access control settings.
+func GetAccessControl(ac *client.AlpaconClient) ([]byte, error) {
+	responseBody, err := ac.SendGetRequest(accessControlURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve access control settings: %w", err)
+	}
+
+	return responseBody, nil
+}
+
+// EditAccessControl retrieves current settings and opens them in an editor for editing.
+// Returns the edited data ready to be sent as a PATCH request.
+func EditAccessControl(ac *client.AlpaconClient) (any, error) {
+	responseBody, err := ac.SendGetRequest(accessControlURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve access control settings: %w", err)
+	}
+
+	data, err := utils.ProcessEditedData(responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// PatchAccessControl sends the edited access control settings to the server.
+// Returns the raw error from SendPatchRequest to preserve error structure for ParseErrorResponse.
+func PatchAccessControl(ac *client.AlpaconClient, data any) ([]byte, error) {
+	return ac.SendPatchRequest(accessControlURL, data)
+}

--- a/api/workspace/access_control_test.go
+++ b/api/workspace/access_control_test.go
@@ -1,0 +1,72 @@
+package workspace
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAccessControl(t *testing.T) {
+	expected := map[string]any{
+		"allow_sudo_with_mfa":      true,
+		"allow_direct_root":        false,
+		"allow_tunnel_by_default":  true,
+		"allow_editor_by_default":  true,
+		"home_directory_permission": "750",
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/workspaces/access-control/-/", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expected)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetAccessControl(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Equal(t, true, got["allow_sudo_with_mfa"])
+	assert.Equal(t, false, got["allow_direct_root"])
+	assert.Equal(t, true, got["allow_tunnel_by_default"])
+	assert.Equal(t, true, got["allow_editor_by_default"])
+	assert.Equal(t, "750", got["home_directory_permission"])
+}
+
+func TestGetAccessControl_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := GetAccessControl(ac)
+	assert.Error(t, err)
+}
+
+func TestGetAccessControl_EmptyResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetAccessControl(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/api/workspace/access_control_test.go
+++ b/api/workspace/access_control_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestGetAccessControl(t *testing.T) {
 	expected := map[string]any{
-		"allow_sudo_with_mfa":      true,
-		"allow_direct_root":        false,
-		"allow_tunnel_by_default":  true,
-		"allow_editor_by_default":  true,
+		"allow_sudo_with_mfa":       true,
+		"allow_direct_root":         false,
+		"allow_tunnel_by_default":   true,
+		"allow_editor_by_default":   true,
 		"home_directory_permission": "750",
 	}
 

--- a/api/workspace/authentication.go
+++ b/api/workspace/authentication.go
@@ -1,0 +1,46 @@
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+const (
+	// authenticationURL points to the workspace security endpoint which manages
+	// authentication settings (MFA requirements, timeout, allowed methods).
+	authenticationURL = "/api/workspaces/security/-/"
+)
+
+// GetAuthentication retrieves the workspace authentication settings.
+func GetAuthentication(ac *client.AlpaconClient) ([]byte, error) {
+	responseBody, err := ac.SendGetRequest(authenticationURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve authentication settings: %w", err)
+	}
+
+	return responseBody, nil
+}
+
+// EditAuthentication retrieves current settings and opens them in an editor for editing.
+// Returns the edited data ready to be sent as a PATCH request.
+func EditAuthentication(ac *client.AlpaconClient) (any, error) {
+	responseBody, err := ac.SendGetRequest(authenticationURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve authentication settings: %w", err)
+	}
+
+	data, err := utils.ProcessEditedData(responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// PatchAuthentication sends the edited authentication settings to the server.
+// Returns the raw error from SendPatchRequest to preserve error structure for ParseErrorResponse.
+func PatchAuthentication(ac *client.AlpaconClient, data any) ([]byte, error) {
+	return ac.SendPatchRequest(authenticationURL, data)
+}

--- a/api/workspace/authentication_test.go
+++ b/api/workspace/authentication_test.go
@@ -1,0 +1,72 @@
+package workspace
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAuthentication(t *testing.T) {
+	expected := map[string]any{
+		"mfa_required":         true,
+		"mfa_timeout":          float64(300),
+		"allowed_mfa_methods":  []any{"email", "otp"},
+		"mfa_required_actions": []any{"server", "websh"},
+		"passkey_as_mfa":       false,
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/workspaces/security/-/", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expected)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetAuthentication(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Equal(t, true, got["mfa_required"])
+	assert.Equal(t, float64(300), got["mfa_timeout"])
+	assert.Equal(t, []any{"email", "otp"}, got["allowed_mfa_methods"])
+	assert.Equal(t, []any{"server", "websh"}, got["mfa_required_actions"])
+	assert.Equal(t, false, got["passkey_as_mfa"])
+}
+
+func TestGetAuthentication_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := GetAuthentication(ac)
+	assert.Error(t, err)
+}
+
+func TestGetAuthentication_EmptyResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetAuthentication(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/api/workspace/mfa_methods.go
+++ b/api/workspace/mfa_methods.go
@@ -1,0 +1,23 @@
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/alpacax/alpacon-cli/client"
+)
+
+const (
+	// mfaMethodsURL points to the endpoint that returns available MFA methods
+	// for the workspace (a read-only subset of the security settings).
+	mfaMethodsURL = "/api/workspaces/security/-/mfa-methods/"
+)
+
+// GetMFAMethods retrieves the available MFA methods for the workspace.
+func GetMFAMethods(ac *client.AlpaconClient) ([]byte, error) {
+	responseBody, err := ac.SendGetRequest(mfaMethodsURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve MFA methods: %w", err)
+	}
+
+	return responseBody, nil
+}

--- a/api/workspace/mfa_methods_test.go
+++ b/api/workspace/mfa_methods_test.go
@@ -13,7 +13,7 @@ import (
 func TestGetMFAMethods(t *testing.T) {
 	expected := map[string]any{
 		"allowed_mfa_methods": []any{"email", "otp"},
-		"passkey_as_mfa":     false,
+		"passkey_as_mfa":      false,
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/workspace/mfa_methods_test.go
+++ b/api/workspace/mfa_methods_test.go
@@ -1,0 +1,66 @@
+package workspace
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMFAMethods(t *testing.T) {
+	expected := map[string]any{
+		"allowed_mfa_methods": []any{"email", "otp"},
+		"passkey_as_mfa":     false,
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/workspaces/security/-/mfa-methods/", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expected)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetMFAMethods(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Equal(t, []any{"email", "otp"}, got["allowed_mfa_methods"])
+	assert.Equal(t, false, got["passkey_as_mfa"])
+}
+
+func TestGetMFAMethods_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := GetMFAMethods(ac)
+	assert.Error(t, err)
+}
+
+func TestGetMFAMethods_EmptyResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetMFAMethods(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/api/workspace/notifications.go
+++ b/api/workspace/notifications.go
@@ -1,0 +1,42 @@
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+const (
+	notificationsURL = "/api/workspaces/notifications/"
+)
+
+// GetNotifications retrieves the workspace notification settings.
+func GetNotifications(ac *client.AlpaconClient) ([]byte, error) {
+	responseBody, err := ac.SendGetRequest(notificationsURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve notification settings: %w", err)
+	}
+
+	return responseBody, nil
+}
+
+// UpdateNotifications opens the current notification settings in an editor and sends the changes.
+func UpdateNotifications(ac *client.AlpaconClient) ([]byte, error) {
+	responseBody, err := ac.SendGetRequest(notificationsURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve notification settings: %w", err)
+	}
+
+	data, err := utils.ProcessEditedData(responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	responseBody, err = ac.SendPatchRequest(notificationsURL, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update notification settings: %w", err)
+	}
+
+	return responseBody, nil
+}

--- a/api/workspace/notifications_test.go
+++ b/api/workspace/notifications_test.go
@@ -1,0 +1,66 @@
+package workspace
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNotifications(t *testing.T) {
+	expected := map[string]any{
+		"disconnection_notification": true,
+		"notification_channels":      []any{"email", "webhook"},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/workspaces/notifications/", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expected)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetNotifications(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Equal(t, true, got["disconnection_notification"])
+	assert.Equal(t, []any{"email", "webhook"}, got["notification_channels"])
+}
+
+func TestGetNotifications_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := GetNotifications(ac)
+	assert.Error(t, err)
+}
+
+func TestGetNotifications_EmptyResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetNotifications(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/api/workspace/preferences.go
+++ b/api/workspace/preferences.go
@@ -1,0 +1,42 @@
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+const (
+	preferencesURL = "/api/workspaces/preferences/-/"
+)
+
+// GetPreferences retrieves the workspace preferences.
+func GetPreferences(ac *client.AlpaconClient) ([]byte, error) {
+	responseBody, err := ac.SendGetRequest(preferencesURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve workspace preferences: %w", err)
+	}
+
+	return responseBody, nil
+}
+
+// UpdatePreferences opens the current preferences in an editor and sends the changes.
+func UpdatePreferences(ac *client.AlpaconClient) ([]byte, error) {
+	responseBody, err := ac.SendGetRequest(preferencesURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve workspace preferences: %w", err)
+	}
+
+	data, err := utils.ProcessEditedData(responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	responseBody, err = ac.SendPatchRequest(preferencesURL, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update workspace preferences: %w", err)
+	}
+
+	return responseBody, nil
+}

--- a/api/workspace/preferences_test.go
+++ b/api/workspace/preferences_test.go
@@ -1,0 +1,76 @@
+package workspace
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPreferences(t *testing.T) {
+	expected := map[string]any{
+		"language":            "ko",
+		"timezone":            "Asia/Seoul",
+		"invite_ttl":          float64(172800),
+		"websh_session_timeout": float64(3600),
+		"auto_agent_upgrade":  true,
+		"package_proxy":       nil,
+		"front_url":           "https://example.alpacon.io",
+		"country":             "KR",
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/workspaces/preferences/-/", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expected)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetPreferences(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Equal(t, "ko", got["language"])
+	assert.Equal(t, "Asia/Seoul", got["timezone"])
+	assert.Equal(t, float64(172800), got["invite_ttl"])
+	assert.Equal(t, float64(3600), got["websh_session_timeout"])
+	assert.Equal(t, true, got["auto_agent_upgrade"])
+	assert.Equal(t, "KR", got["country"])
+}
+
+func TestGetPreferences_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := GetPreferences(ac)
+	assert.Error(t, err)
+}
+
+func TestGetPreferences_EmptyResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	body, err := GetPreferences(ac)
+	assert.NoError(t, err)
+
+	var got map[string]any
+	err = json.Unmarshal(body, &got)
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/api/workspace/preferences_test.go
+++ b/api/workspace/preferences_test.go
@@ -12,14 +12,14 @@ import (
 
 func TestGetPreferences(t *testing.T) {
 	expected := map[string]any{
-		"language":            "ko",
-		"timezone":            "Asia/Seoul",
-		"invite_ttl":          float64(172800),
+		"language":              "ko",
+		"timezone":              "Asia/Seoul",
+		"invite_ttl":            float64(172800),
 		"websh_session_timeout": float64(3600),
-		"auto_agent_upgrade":  true,
-		"package_proxy":       nil,
-		"front_url":           "https://example.alpacon.io",
-		"country":             "KR",
+		"auto_agent_upgrade":    true,
+		"package_proxy":         nil,
+		"front_url":             "https://example.alpacon.io",
+		"country":               "KR",
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/workspace/usage.go
+++ b/api/workspace/usage.go
@@ -65,7 +65,7 @@ func GetWorkspaceID(ac *client.AlpaconClient, paymentBaseURL, workspaceName stri
 			}
 		}
 
-		if response.Next == nil {
+		if response.Next == nil || *response.Next == 0 {
 			break
 		}
 		page = *response.Next

--- a/api/workspace/usage.go
+++ b/api/workspace/usage.go
@@ -1,0 +1,132 @@
+package workspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/alpacax/alpacon-cli/client"
+)
+
+const (
+	paymentAPIProdURL    = "https://pay.alpacax.com"
+	paymentAPIStagingURL = "https://pay.staging.alpacax.com"
+	paymentWorkspacesURL = "/api/workspaces/workspaces/"
+)
+
+// GetPaymentAPIBaseURL determines the payment API base URL from the workspace URL.
+// Dev regions use the staging payment API; all others use production.
+func GetPaymentAPIBaseURL(workspaceURL string) (string, error) {
+	parsed, err := url.Parse(workspaceURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse workspace URL: %w", err)
+	}
+
+	// Host format: {schema_name}.{region}.alpacon.io
+	parts := strings.Split(parsed.Hostname(), ".")
+	if len(parts) >= 4 {
+		region := parts[1]
+		if strings.Contains(region, "dev") {
+			return paymentAPIStagingURL, nil
+		}
+	}
+
+	return paymentAPIProdURL, nil
+}
+
+// GetWorkspaceID retrieves the workspace UUID from the payment API by matching schema_name.
+func GetWorkspaceID(ac *client.AlpaconClient, paymentBaseURL, workspaceName string) (string, error) {
+	listURL := paymentBaseURL + paymentWorkspacesURL
+	body, err := ac.SendGetRequestToURL(listURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to list workspaces from payment API: %w", err)
+	}
+
+	var response struct {
+		Results []struct {
+			ID         string `json:"id"`
+			SchemaName string `json:"schema_name"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to parse workspace list: %w", err)
+	}
+
+	for _, ws := range response.Results {
+		if ws.SchemaName == workspaceName {
+			return ws.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("workspace %q not found in payment API", workspaceName)
+}
+
+// BillingPeriod represents the billing period for a workspace.
+type BillingPeriod struct {
+	Start     string `json:"start"`
+	End       string `json:"end"`
+	TotalDays int    `json:"total_days"`
+}
+
+// SubscriptionPeriod represents the subscription period.
+type SubscriptionPeriod struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// Subscription represents the subscription details.
+type Subscription struct {
+	ProductName  string             `json:"product_name"`
+	PlanName     string             `json:"plan_name"`
+	ProductCode  string             `json:"product_code"`
+	PlanCode     string             `json:"plan_code"`
+	BaseQuantity int                `json:"base_quantity"`
+	UnitPrice    string             `json:"unit_price"`
+	SubTotal     string             `json:"sub_total"`
+	Period       SubscriptionPeriod `json:"period"`
+}
+
+// ServiceUsage represents usage details for a single service.
+type ServiceUsage struct {
+	Name         string   `json:"name"`
+	Unit         string   `json:"unit"`
+	Limit        *float64 `json:"limit"`
+	CurrentUsage float64  `json:"current_usage"`
+	CurrentCost  string   `json:"current_cost"`
+	OverageCost  *string  `json:"overage_cost"`
+}
+
+// UsageMetadata holds account-level metadata for a workspace.
+type UsageMetadata struct {
+	Plan            string `json:"plan"`
+	IsSubscribed    bool   `json:"is_subscribed"`
+	IsTrialing      bool   `json:"is_trialing"`
+	IsPaid          bool   `json:"is_paid"`
+	AvailableCredit string `json:"available_credit"`
+}
+
+// UsageEstimate represents the full usage estimate response.
+type UsageEstimate struct {
+	BillingPeriod BillingPeriod           `json:"billing_period"`
+	Currency      string                  `json:"currency"`
+	Subscription  Subscription            `json:"subscription"`
+	Services      map[string]ServiceUsage `json:"services"`
+	Metadata      *UsageMetadata          `json:"metadata"`
+}
+
+// GetUsageEstimate retrieves the usage estimate for a workspace from the payment API.
+func GetUsageEstimate(ac *client.AlpaconClient, paymentBaseURL, workspaceID string) (*UsageEstimate, error) {
+	estimateURL := fmt.Sprintf("%s%s%s/estimate/", paymentBaseURL, paymentWorkspacesURL, workspaceID)
+	body, err := ac.SendGetRequestToURL(estimateURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve usage estimate: %w", err)
+	}
+
+	var estimate UsageEstimate
+	if err := json.Unmarshal(body, &estimate); err != nil {
+		return nil, fmt.Errorf("failed to parse usage estimate: %w", err)
+	}
+
+	return &estimate, nil
+}

--- a/api/workspace/usage.go
+++ b/api/workspace/usage.go
@@ -36,26 +36,50 @@ func GetPaymentAPIBaseURL(workspaceURL string) (string, error) {
 }
 
 // GetWorkspaceID retrieves the workspace UUID from the payment API by matching schema_name.
+// It follows pagination until the workspace is found or all pages are exhausted.
 func GetWorkspaceID(ac *client.AlpaconClient, paymentBaseURL, workspaceName string) (string, error) {
 	listURL := paymentBaseURL + paymentWorkspacesURL
-	body, err := ac.SendGetRequestToURL(listURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to list workspaces from payment API: %w", err)
-	}
 
-	var response struct {
-		Results []struct {
-			ID         string `json:"id"`
-			SchemaName string `json:"schema_name"`
-		} `json:"results"`
-	}
-	if err := json.Unmarshal(body, &response); err != nil {
-		return "", fmt.Errorf("failed to parse workspace list: %w", err)
-	}
+	for listURL != "" {
+		body, err := ac.SendGetRequestToURL(listURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to list workspaces from payment API: %w", err)
+		}
 
-	for _, ws := range response.Results {
-		if ws.SchemaName == workspaceName {
-			return ws.ID, nil
+		var response struct {
+			Next    string `json:"next"`
+			Results []struct {
+				ID         string `json:"id"`
+				SchemaName string `json:"schema_name"`
+			} `json:"results"`
+		}
+		if err := json.Unmarshal(body, &response); err != nil {
+			return "", fmt.Errorf("failed to parse workspace list: %w", err)
+		}
+
+		for _, ws := range response.Results {
+			if ws.SchemaName == workspaceName {
+				return ws.ID, nil
+			}
+		}
+
+		if response.Next == "" {
+			break
+		}
+
+		// Resolve relative next URLs against the current URL.
+		parsedNext, err := url.Parse(response.Next)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse next page URL: %w", err)
+		}
+		if parsedNext.IsAbs() {
+			listURL = parsedNext.String()
+		} else {
+			parsedCurrent, err := url.Parse(listURL)
+			if err != nil {
+				return "", fmt.Errorf("failed to parse current page URL: %w", err)
+			}
+			listURL = parsedCurrent.ResolveReference(parsedNext).String()
 		}
 	}
 

--- a/api/workspace/usage.go
+++ b/api/workspace/usage.go
@@ -37,17 +37,19 @@ func GetPaymentAPIBaseURL(workspaceURL string) (string, error) {
 
 // GetWorkspaceID retrieves the workspace UUID from the payment API by matching schema_name.
 // It follows pagination until the workspace is found or all pages are exhausted.
+// The payment API uses page-number pagination: next/previous are integers, not URLs.
 func GetWorkspaceID(ac *client.AlpaconClient, paymentBaseURL, workspaceName string) (string, error) {
-	listURL := paymentBaseURL + paymentWorkspacesURL
+	baseURL := paymentBaseURL + paymentWorkspacesURL
+	page := 1
 
-	for listURL != "" {
-		body, err := ac.SendGetRequestToURL(listURL)
+	for {
+		body, err := ac.SendGetRequestToURL(fmt.Sprintf("%s?page=%d", baseURL, page))
 		if err != nil {
 			return "", fmt.Errorf("failed to list workspaces from payment API: %w", err)
 		}
 
 		var response struct {
-			Next    string `json:"next"`
+			Next    *int `json:"next"`
 			Results []struct {
 				ID         string `json:"id"`
 				SchemaName string `json:"schema_name"`
@@ -63,24 +65,10 @@ func GetWorkspaceID(ac *client.AlpaconClient, paymentBaseURL, workspaceName stri
 			}
 		}
 
-		if response.Next == "" {
+		if response.Next == nil {
 			break
 		}
-
-		// Resolve relative next URLs against the current URL.
-		parsedNext, err := url.Parse(response.Next)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse next page URL: %w", err)
-		}
-		if parsedNext.IsAbs() {
-			listURL = parsedNext.String()
-		} else {
-			parsedCurrent, err := url.Parse(listURL)
-			if err != nil {
-				return "", fmt.Errorf("failed to parse current page URL: %w", err)
-			}
-			listURL = parsedCurrent.ResolveReference(parsedNext).String()
-		}
+		page = *response.Next
 	}
 
 	return "", fmt.Errorf("workspace %q not found in payment API", workspaceName)

--- a/api/workspace/usage_test.go
+++ b/api/workspace/usage_test.go
@@ -1,0 +1,119 @@
+package workspace
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPaymentAPIBaseURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		workspaceURL string
+		expected     string
+	}{
+		{"production AP region", "https://myws.ap1.alpacon.io", paymentAPIProdURL},
+		{"production US region", "https://myws.us1.alpacon.io", paymentAPIProdURL},
+		{"staging dev region", "https://myws.dev.alpacon.io", paymentAPIStagingURL},
+		{"staging dev2 region", "https://myws.dev2.alpacon.io", paymentAPIStagingURL},
+		{"short hostname fallback", "https://alpacon.io", paymentAPIProdURL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetPaymentAPIBaseURL(tt.workspaceURL)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetWorkspaceID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/workspaces/workspaces/", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"id": "uuid-1", "schema_name": "ws-alpha"},
+				{"id": "uuid-2", "schema_name": "ws-beta"},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	id, err := GetWorkspaceID(ac, ts.URL, "ws-beta")
+	assert.NoError(t, err)
+	assert.Equal(t, "uuid-2", id)
+}
+
+func TestGetWorkspaceID_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"id": "uuid-1", "schema_name": "ws-alpha"},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, err := GetWorkspaceID(ac, ts.URL, "ws-unknown")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetUsageEstimate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/workspaces/workspaces/uuid-123/estimate/", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"currency": "KRW",
+			"billing_period": map[string]any{
+				"start":      "2026-04-01T00:00:00Z",
+				"end":        "2026-04-30T23:59:59Z",
+				"total_days": float64(30),
+			},
+			"subscription": map[string]any{
+				"product_name": "Alpacon Core",
+				"plan_name":    "Essentials",
+				"sub_total":    "360000",
+			},
+			"services":  map[string]any{},
+			"metadata":  nil,
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	estimate, err := GetUsageEstimate(ac, ts.URL, "uuid-123")
+	assert.NoError(t, err)
+	assert.Equal(t, "KRW", estimate.Currency)
+	assert.Equal(t, 30, estimate.BillingPeriod.TotalDays)
+	assert.Equal(t, "Alpacon Core", estimate.Subscription.ProductName)
+}
+
+func TestGetUsageEstimate_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"permission denied"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, err := GetUsageEstimate(ac, ts.URL, "uuid-123")
+	assert.Error(t, err)
+}

--- a/api/workspace/usage_test.go
+++ b/api/workspace/usage_test.go
@@ -90,8 +90,8 @@ func TestGetUsageEstimate(t *testing.T) {
 				"plan_name":    "Essentials",
 				"sub_total":    "360000",
 			},
-			"services":  map[string]any{},
-			"metadata":  nil,
+			"services": map[string]any{},
+			"metadata": nil,
 		})
 	}))
 	defer ts.Close()

--- a/client/client.go
+++ b/client/client.go
@@ -257,6 +257,17 @@ func (ac *AlpaconClient) SendMultipartRequest(url string, multiPartWriter *multi
 	return respBody, nil
 }
 
+// SendGetRequestToURL sends a GET request to an absolute URL (e.g., an external service)
+// using the client's authentication headers.
+func (ac *AlpaconClient) SendGetRequestToURL(absoluteURL string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, absoluteURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req = ac.setHTTPHeader(req)
+	return ac.sendRequest(req)
+}
+
 // This function returns response for custom error handling in each function, unlike direct error throwing in sendRequest.
 func (ac *AlpaconClient) SendGetRequestForDownload(url string) (*http.Response, error) {
 	req, err := ac.createRequest(http.MethodGet, url, nil)

--- a/cmd/iam/user_create.go
+++ b/cmd/iam/user_create.go
@@ -20,11 +20,11 @@ var userCreateCmd = &cobra.Command{
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		saas, err := config.IsSaaS()
+		isSaaS, err := config.IsSaaS()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if saas {
+		if isSaaS {
 			utils.CliErrorWithExit("This command is only available for self-hosted workspaces. Use 'alpacon user invite' instead.")
 		}
 

--- a/cmd/iam/user_create.go
+++ b/cmd/iam/user_create.go
@@ -3,6 +3,7 @@ package iam
 import (
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -19,13 +20,17 @@ var userCreateCmd = &cobra.Command{
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 
+		saas, err := config.IsSaaS()
+		if err != nil {
+			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
+		}
+		if saas {
+			utils.CliErrorWithExit("This command is only available for self-hosted workspaces. Use 'alpacon user invite' instead.")
+		}
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		if alpaconClient.AccessToken != "" {
-			utils.CliErrorWithExit("user create is only available for self-hosted workspaces. Use 'alpacon user invite' instead")
 		}
 
 		if alpaconClient.Privileges == "general" {

--- a/cmd/iam/user_invite.go
+++ b/cmd/iam/user_invite.go
@@ -24,11 +24,11 @@ This command requires staff or superuser privileges.`,
   alpacon user invite`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		saas, err := config.IsSaaS()
+		isSaaS, err := config.IsSaaS()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if !saas {
+		if !isSaaS {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
 		}
 

--- a/cmd/iam/user_invite.go
+++ b/cmd/iam/user_invite.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -23,13 +24,17 @@ This command requires staff or superuser privileges.`,
   alpacon user invite`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		saas, err := config.IsSaaS()
+		if err != nil {
+			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
+		}
+		if !saas {
+			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
+		}
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		if alpaconClient.AccessToken == "" {
-			utils.CliErrorWithExit("user invite is only available for Alpacon Cloud workspaces")
 		}
 
 		if alpaconClient.Privileges == "general" {

--- a/cmd/iam/user_invite.go
+++ b/cmd/iam/user_invite.go
@@ -38,7 +38,7 @@ This command requires staff or superuser privileges.`,
 		}
 
 		if alpaconClient.Privileges == "general" {
-			utils.CliErrorWithExit("Insufficient permissions to invite users. This action requires staff or superuser privileges. Please contact your administrator to request elevated permissions")
+			utils.CliErrorWithExit("Insufficient permissions to invite users. This action requires staff or superuser privileges. Please contact your administrator to request elevated permissions.")
 		}
 
 		var email string

--- a/cmd/workspace/workspace.go
+++ b/cmd/workspace/workspace.go
@@ -35,4 +35,5 @@ func init() {
 	WorkspaceCmd.AddCommand(workspaceAccessControlCmd)
 	WorkspaceCmd.AddCommand(workspaceAuthenticationCmd)
 	WorkspaceCmd.AddCommand(workspaceMFAMethodsCmd)
+	WorkspaceCmd.AddCommand(workspaceUsageCmd)
 }

--- a/cmd/workspace/workspace.go
+++ b/cmd/workspace/workspace.go
@@ -31,4 +31,5 @@ func init() {
 	WorkspaceCmd.AddCommand(workspaceListCmd)
 	WorkspaceCmd.AddCommand(workspaceSwitchCmd)
 	WorkspaceCmd.AddCommand(workspacePreferencesCmd)
+	WorkspaceCmd.AddCommand(workspaceNotificationsCmd)
 }

--- a/cmd/workspace/workspace.go
+++ b/cmd/workspace/workspace.go
@@ -33,4 +33,5 @@ func init() {
 	WorkspaceCmd.AddCommand(workspacePreferencesCmd)
 	WorkspaceCmd.AddCommand(workspaceNotificationsCmd)
 	WorkspaceCmd.AddCommand(workspaceAccessControlCmd)
+	WorkspaceCmd.AddCommand(workspaceAuthenticationCmd)
 }

--- a/cmd/workspace/workspace.go
+++ b/cmd/workspace/workspace.go
@@ -32,4 +32,5 @@ func init() {
 	WorkspaceCmd.AddCommand(workspaceSwitchCmd)
 	WorkspaceCmd.AddCommand(workspacePreferencesCmd)
 	WorkspaceCmd.AddCommand(workspaceNotificationsCmd)
+	WorkspaceCmd.AddCommand(workspaceAccessControlCmd)
 }

--- a/cmd/workspace/workspace.go
+++ b/cmd/workspace/workspace.go
@@ -34,4 +34,5 @@ func init() {
 	WorkspaceCmd.AddCommand(workspaceNotificationsCmd)
 	WorkspaceCmd.AddCommand(workspaceAccessControlCmd)
 	WorkspaceCmd.AddCommand(workspaceAuthenticationCmd)
+	WorkspaceCmd.AddCommand(workspaceMFAMethodsCmd)
 }

--- a/cmd/workspace/workspace.go
+++ b/cmd/workspace/workspace.go
@@ -30,4 +30,5 @@ var WorkspaceCmd = &cobra.Command{
 func init() {
 	WorkspaceCmd.AddCommand(workspaceListCmd)
 	WorkspaceCmd.AddCommand(workspaceSwitchCmd)
+	WorkspaceCmd.AddCommand(workspacePreferencesCmd)
 }

--- a/cmd/workspace/workspace_access_control.go
+++ b/cmd/workspace/workspace_access_control.go
@@ -1,0 +1,36 @@
+package workspace
+
+import (
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspaceAccessControlCmd = &cobra.Command{
+	Use:     "access-control",
+	Aliases: []string{"acl"},
+	Short:   "Retrieve workspace access control settings",
+	Long:    "Display the current workspace access control settings including sudo, tunneling, and directory permissions.",
+	Example: `
+	alpacon workspace access-control
+	alpacon ws acl`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		accessControlDetail, err := workspace.GetAccessControl(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve access control settings: %s.", err)
+		}
+
+		utils.PrintJson(accessControlDetail)
+		return nil
+	},
+}
+
+func init() {
+	workspaceAccessControlCmd.AddCommand(workspaceAccessControlUpdateCmd)
+}

--- a/cmd/workspace/workspace_access_control_update.go
+++ b/cmd/workspace/workspace_access_control_update.go
@@ -1,0 +1,68 @@
+package workspace
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alpacax/alpacon-cli/api/mfa"
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspaceAccessControlUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update workspace access control settings",
+	Long: `Update workspace access control settings by opening the current settings in your editor.
+Modify the desired fields, save, and close the editor to apply changes.`,
+	Example: `
+	alpacon workspace access-control update
+	alpacon ws acl update`,
+	Run: func(cmd *cobra.Command, args []string) {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		data, err := workspace.EditAccessControl(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to prepare access control update: %s.", err)
+		}
+
+		var accessControlDetail []byte
+		accessControlDetail, err = workspace.PatchAccessControl(alpaconClient, data)
+		if err != nil {
+			err = utils.HandleCommonErrors(err, "", utils.ErrorHandlerCallbacks{
+				OnMFARequired: func(_ string) error {
+					cfg, loadErr := config.LoadConfig()
+					if loadErr != nil {
+						return fmt.Errorf("failed to load configuration: %w", loadErr)
+					}
+					mfaURL, mfaErr := mfa.GetWorkspaceSecurityMFALink(alpaconClient, cfg.WorkspaceName)
+					if mfaErr != nil {
+						return mfaErr
+					}
+					fmt.Fprintf(os.Stderr, "\nMFA authentication required. Please visit:\n%s\n\n", mfaURL)
+					utils.OpenBrowser(mfaURL)
+					return nil
+				},
+				CheckMFACompleted: func() (bool, error) {
+					return mfa.CheckMFACompletion(alpaconClient)
+				},
+				RefreshToken: alpaconClient.RefreshToken,
+				RetryOperation: func() error {
+					accessControlDetail, err = workspace.PatchAccessControl(alpaconClient, data)
+					return err
+				},
+			})
+			if err != nil {
+				utils.CliErrorWithExit("Failed to update access control settings: %s.", err)
+			}
+		}
+
+		utils.CliSuccess("Access control settings updated.")
+		utils.PrintJson(accessControlDetail)
+	},
+}

--- a/cmd/workspace/workspace_access_control_update.go
+++ b/cmd/workspace/workspace_access_control_update.go
@@ -22,7 +22,7 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 	alpacon ws acl update`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if !utils.IsInteractiveShell() {
-			utils.CliErrorWithExit("this command requires an interactive terminal")
+			utils.CliErrorWithExit("This command requires an interactive terminal.")
 		}
 
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/workspace/workspace_access_control_update.go
+++ b/cmd/workspace/workspace_access_control_update.go
@@ -21,6 +21,10 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 	alpacon workspace access-control update
 	alpacon ws acl update`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if !utils.IsInteractiveShell() {
+			utils.CliErrorWithExit("this command requires an interactive terminal")
+		}
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)

--- a/cmd/workspace/workspace_authentication.go
+++ b/cmd/workspace/workspace_authentication.go
@@ -1,0 +1,36 @@
+package workspace
+
+import (
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspaceAuthenticationCmd = &cobra.Command{
+	Use:     "authentication",
+	Aliases: []string{"auth"},
+	Short:   "Retrieve workspace authentication settings",
+	Long:    "Display the current workspace authentication settings including MFA requirements, timeout, and allowed methods.",
+	Example: `
+	alpacon workspace authentication
+	alpacon ws auth`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		authenticationDetail, err := workspace.GetAuthentication(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve authentication settings: %s.", err)
+		}
+
+		utils.PrintJson(authenticationDetail)
+		return nil
+	},
+}
+
+func init() {
+	workspaceAuthenticationCmd.AddCommand(workspaceAuthenticationUpdateCmd)
+}

--- a/cmd/workspace/workspace_authentication.go
+++ b/cmd/workspace/workspace_authentication.go
@@ -17,11 +17,11 @@ var workspaceAuthenticationCmd = &cobra.Command{
 	alpacon workspace authentication
 	alpacon ws auth`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		saas, err := config.IsSaaS()
+		isSaaS, err := config.IsSaaS()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if !saas {
+		if !isSaaS {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
 		}
 

--- a/cmd/workspace/workspace_authentication.go
+++ b/cmd/workspace/workspace_authentication.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"github.com/alpacax/alpacon-cli/api/workspace"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +17,14 @@ var workspaceAuthenticationCmd = &cobra.Command{
 	alpacon workspace authentication
 	alpacon ws auth`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		saas, err := config.IsSaaS()
+		if err != nil {
+			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
+		}
+		if !saas {
+			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
+		}
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)

--- a/cmd/workspace/workspace_authentication_update.go
+++ b/cmd/workspace/workspace_authentication_update.go
@@ -21,6 +21,18 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 	alpacon workspace authentication update
 	alpacon ws auth update`,
 	Run: func(cmd *cobra.Command, args []string) {
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
+		}
+		saas, err := config.IsSaaS()
+		if err != nil {
+			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
+		}
+		if !saas {
+			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
+		}
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
@@ -36,10 +48,6 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 		if err != nil {
 			err = utils.HandleCommonErrors(err, "", utils.ErrorHandlerCallbacks{
 				OnMFARequired: func(_ string) error {
-					cfg, loadErr := config.LoadConfig()
-					if loadErr != nil {
-						return fmt.Errorf("failed to load configuration: %w", loadErr)
-					}
 					mfaURL, mfaErr := mfa.GetWorkspaceSecurityMFALink(alpaconClient, cfg.WorkspaceName)
 					if mfaErr != nil {
 						return mfaErr

--- a/cmd/workspace/workspace_authentication_update.go
+++ b/cmd/workspace/workspace_authentication_update.go
@@ -22,18 +22,14 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 	alpacon ws auth update`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if !utils.IsInteractiveShell() {
-			utils.CliErrorWithExit("this command requires an interactive terminal")
+			utils.CliErrorWithExit("This command requires an interactive terminal.")
 		}
 
 		cfg, err := config.LoadConfig()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		isSaaS, err := config.IsSaaS()
-		if err != nil {
-			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
-		}
-		if !isSaaS {
+		if cfg.AccessToken == "" {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
 		}
 

--- a/cmd/workspace/workspace_authentication_update.go
+++ b/cmd/workspace/workspace_authentication_update.go
@@ -21,6 +21,10 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 	alpacon workspace authentication update
 	alpacon ws auth update`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if !utils.IsInteractiveShell() {
+			utils.CliErrorWithExit("this command requires an interactive terminal")
+		}
+
 		cfg, err := config.LoadConfig()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")

--- a/cmd/workspace/workspace_authentication_update.go
+++ b/cmd/workspace/workspace_authentication_update.go
@@ -1,0 +1,68 @@
+package workspace
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alpacax/alpacon-cli/api/mfa"
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspaceAuthenticationUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update workspace authentication settings",
+	Long: `Update workspace authentication settings by opening the current settings in your editor.
+Modify the desired fields, save, and close the editor to apply changes.`,
+	Example: `
+	alpacon workspace authentication update
+	alpacon ws auth update`,
+	Run: func(cmd *cobra.Command, args []string) {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		data, err := workspace.EditAuthentication(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to prepare authentication update: %s.", err)
+		}
+
+		var authenticationDetail []byte
+		authenticationDetail, err = workspace.PatchAuthentication(alpaconClient, data)
+		if err != nil {
+			err = utils.HandleCommonErrors(err, "", utils.ErrorHandlerCallbacks{
+				OnMFARequired: func(_ string) error {
+					cfg, loadErr := config.LoadConfig()
+					if loadErr != nil {
+						return fmt.Errorf("failed to load configuration: %w", loadErr)
+					}
+					mfaURL, mfaErr := mfa.GetWorkspaceSecurityMFALink(alpaconClient, cfg.WorkspaceName)
+					if mfaErr != nil {
+						return mfaErr
+					}
+					fmt.Fprintf(os.Stderr, "\nMFA authentication required. Please visit:\n%s\n\n", mfaURL)
+					utils.OpenBrowser(mfaURL)
+					return nil
+				},
+				CheckMFACompleted: func() (bool, error) {
+					return mfa.CheckMFACompletion(alpaconClient)
+				},
+				RefreshToken: alpaconClient.RefreshToken,
+				RetryOperation: func() error {
+					authenticationDetail, err = workspace.PatchAuthentication(alpaconClient, data)
+					return err
+				},
+			})
+			if err != nil {
+				utils.CliErrorWithExit("Failed to update authentication settings: %s.", err)
+			}
+		}
+
+		utils.CliSuccess("Authentication settings updated.")
+		utils.PrintJson(authenticationDetail)
+	},
+}

--- a/cmd/workspace/workspace_authentication_update.go
+++ b/cmd/workspace/workspace_authentication_update.go
@@ -25,11 +25,11 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 			utils.CliErrorWithExit("This command requires an interactive terminal.")
 		}
 
-		isSaaS, err := config.IsSaaS()
+		cfg, err := config.LoadConfig()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if !isSaaS {
+		if !cfg.IsSaaS() {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
 		}
 
@@ -48,10 +48,6 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 		if err != nil {
 			err = utils.HandleCommonErrors(err, "", utils.ErrorHandlerCallbacks{
 				OnMFARequired: func(_ string) error {
-					cfg, loadErr := config.LoadConfig()
-					if loadErr != nil {
-						return fmt.Errorf("failed to load configuration: %w", loadErr)
-					}
 					mfaURL, mfaErr := mfa.GetWorkspaceSecurityMFALink(alpaconClient, cfg.WorkspaceName)
 					if mfaErr != nil {
 						return mfaErr

--- a/cmd/workspace/workspace_authentication_update.go
+++ b/cmd/workspace/workspace_authentication_update.go
@@ -25,11 +25,11 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 			utils.CliErrorWithExit("This command requires an interactive terminal.")
 		}
 
-		cfg, err := config.LoadConfig()
+		isSaaS, err := config.IsSaaS()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if cfg.AccessToken == "" {
+		if !isSaaS {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
 		}
 
@@ -48,6 +48,10 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 		if err != nil {
 			err = utils.HandleCommonErrors(err, "", utils.ErrorHandlerCallbacks{
 				OnMFARequired: func(_ string) error {
+					cfg, loadErr := config.LoadConfig()
+					if loadErr != nil {
+						return fmt.Errorf("failed to load configuration: %w", loadErr)
+					}
 					mfaURL, mfaErr := mfa.GetWorkspaceSecurityMFALink(alpaconClient, cfg.WorkspaceName)
 					if mfaErr != nil {
 						return mfaErr

--- a/cmd/workspace/workspace_authentication_update.go
+++ b/cmd/workspace/workspace_authentication_update.go
@@ -25,11 +25,11 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		saas, err := config.IsSaaS()
+		isSaaS, err := config.IsSaaS()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if !saas {
+		if !isSaaS {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
 		}
 

--- a/cmd/workspace/workspace_mfa_methods.go
+++ b/cmd/workspace/workspace_mfa_methods.go
@@ -1,0 +1,32 @@
+package workspace
+
+import (
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspaceMFAMethodsCmd = &cobra.Command{
+	Use:     "mfa-methods",
+	Aliases: []string{"mfa"},
+	Short:   "Retrieve allowed MFA methods for the workspace",
+	Long:    "Display the MFA methods available for the workspace including allowed methods and passkey-as-MFA setting.",
+	Example: `
+	alpacon workspace mfa-methods
+	alpacon ws mfa`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		mfaMethodsDetail, err := workspace.GetMFAMethods(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve MFA methods: %s.", err)
+		}
+
+		utils.PrintJson(mfaMethodsDetail)
+		return nil
+	},
+}

--- a/cmd/workspace/workspace_mfa_methods.go
+++ b/cmd/workspace/workspace_mfa_methods.go
@@ -17,11 +17,11 @@ var workspaceMFAMethodsCmd = &cobra.Command{
 	alpacon workspace mfa-methods
 	alpacon ws mfa`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		saas, err := config.IsSaaS()
+		isSaaS, err := config.IsSaaS()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if !saas {
+		if !isSaaS {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
 		}
 

--- a/cmd/workspace/workspace_mfa_methods.go
+++ b/cmd/workspace/workspace_mfa_methods.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"github.com/alpacax/alpacon-cli/api/workspace"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +17,14 @@ var workspaceMFAMethodsCmd = &cobra.Command{
 	alpacon workspace mfa-methods
 	alpacon ws mfa`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		saas, err := config.IsSaaS()
+		if err != nil {
+			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
+		}
+		if !saas {
+			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
+		}
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)

--- a/cmd/workspace/workspace_notifications.go
+++ b/cmd/workspace/workspace_notifications.go
@@ -1,0 +1,36 @@
+package workspace
+
+import (
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspaceNotificationsCmd = &cobra.Command{
+	Use:     "notifications",
+	Aliases: []string{"noti"},
+	Short:   "Retrieve workspace notification settings",
+	Long:    "Display the current workspace notification settings including disconnection alerts and notification channels.",
+	Example: `
+	alpacon workspace notifications
+	alpacon ws noti`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		notificationsDetail, err := workspace.GetNotifications(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve notification settings: %s.", err)
+		}
+
+		utils.PrintJson(notificationsDetail)
+		return nil
+	},
+}
+
+func init() {
+	workspaceNotificationsCmd.AddCommand(workspaceNotificationsUpdateCmd)
+}

--- a/cmd/workspace/workspace_notifications_update.go
+++ b/cmd/workspace/workspace_notifications_update.go
@@ -1,0 +1,32 @@
+package workspace
+
+import (
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspaceNotificationsUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update workspace notification settings",
+	Long: `Update workspace notification settings by opening the current settings in your editor.
+Modify the desired fields, save, and close the editor to apply changes.`,
+	Example: `
+	alpacon workspace notifications update
+	alpacon ws noti update`,
+	Run: func(cmd *cobra.Command, args []string) {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		notificationsDetail, err := workspace.UpdateNotifications(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to update notification settings: %s.", err)
+		}
+
+		utils.CliSuccess("Notification settings updated.")
+		utils.PrintJson(notificationsDetail)
+	},
+}

--- a/cmd/workspace/workspace_notifications_update.go
+++ b/cmd/workspace/workspace_notifications_update.go
@@ -16,6 +16,10 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 	alpacon workspace notifications update
 	alpacon ws noti update`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if !utils.IsInteractiveShell() {
+			utils.CliErrorWithExit("this command requires an interactive terminal")
+		}
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)

--- a/cmd/workspace/workspace_notifications_update.go
+++ b/cmd/workspace/workspace_notifications_update.go
@@ -17,7 +17,7 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 	alpacon ws noti update`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if !utils.IsInteractiveShell() {
-			utils.CliErrorWithExit("this command requires an interactive terminal")
+			utils.CliErrorWithExit("This command requires an interactive terminal.")
 		}
 
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/workspace/workspace_preferences.go
+++ b/cmd/workspace/workspace_preferences.go
@@ -1,0 +1,36 @@
+package workspace
+
+import (
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspacePreferencesCmd = &cobra.Command{
+	Use:     "preferences",
+	Aliases: []string{"prefs"},
+	Short: "Retrieve workspace preferences",
+	Long:  "Display the current workspace preferences including language, timezone, and other settings.",
+	Example: `
+	alpacon workspace preferences
+	alpacon ws preferences`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		preferencesDetail, err := workspace.GetPreferences(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve workspace preferences: %s.", err)
+		}
+
+		utils.PrintJson(preferencesDetail)
+		return nil
+	},
+}
+
+func init() {
+	workspacePreferencesCmd.AddCommand(workspacePreferencesUpdateCmd)
+}

--- a/cmd/workspace/workspace_preferences.go
+++ b/cmd/workspace/workspace_preferences.go
@@ -10,8 +10,8 @@ import (
 var workspacePreferencesCmd = &cobra.Command{
 	Use:     "preferences",
 	Aliases: []string{"prefs"},
-	Short: "Retrieve workspace preferences",
-	Long:  "Display the current workspace preferences including language, timezone, and other settings.",
+	Short:   "Retrieve workspace preferences",
+	Long:    "Display the current workspace preferences including language, timezone, and other settings.",
 	Example: `
 	alpacon workspace preferences
 	alpacon ws preferences`,

--- a/cmd/workspace/workspace_preferences_update.go
+++ b/cmd/workspace/workspace_preferences_update.go
@@ -16,6 +16,10 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 	alpacon workspace preferences update
 	alpacon ws preferences update`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if !utils.IsInteractiveShell() {
+			utils.CliErrorWithExit("this command requires an interactive terminal")
+		}
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)

--- a/cmd/workspace/workspace_preferences_update.go
+++ b/cmd/workspace/workspace_preferences_update.go
@@ -17,7 +17,7 @@ Modify the desired fields, save, and close the editor to apply changes.`,
 	alpacon ws preferences update`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if !utils.IsInteractiveShell() {
-			utils.CliErrorWithExit("this command requires an interactive terminal")
+			utils.CliErrorWithExit("This command requires an interactive terminal.")
 		}
 
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/workspace/workspace_preferences_update.go
+++ b/cmd/workspace/workspace_preferences_update.go
@@ -1,0 +1,32 @@
+package workspace
+
+import (
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspacePreferencesUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update workspace preferences",
+	Long: `Update workspace preferences by opening the current settings in your editor.
+Modify the desired fields, save, and close the editor to apply changes.`,
+	Example: `
+	alpacon workspace preferences update
+	alpacon ws preferences update`,
+	Run: func(cmd *cobra.Command, args []string) {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		preferencesDetail, err := workspace.UpdatePreferences(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to update workspace preferences: %s.", err)
+		}
+
+		utils.CliSuccess("Workspace preferences updated.")
+		utils.PrintJson(preferencesDetail)
+	},
+}

--- a/cmd/workspace/workspace_usage.go
+++ b/cmd/workspace/workspace_usage.go
@@ -22,6 +22,13 @@ var workspaceUsageCmd = &cobra.Command{
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
+		saas, err := config.IsSaaS()
+		if err != nil {
+			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
+		}
+		if !saas {
+			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
+		}
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/workspace/workspace_usage.go
+++ b/cmd/workspace/workspace_usage.go
@@ -22,11 +22,7 @@ var workspaceUsageCmd = &cobra.Command{
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		isSaaS, err := config.IsSaaS()
-		if err != nil {
-			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
-		}
-		if !isSaaS {
+		if cfg.AccessToken == "" {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
 		}
 

--- a/cmd/workspace/workspace_usage.go
+++ b/cmd/workspace/workspace_usage.go
@@ -18,17 +18,12 @@ var workspaceUsageCmd = &cobra.Command{
 	alpacon workspace usage
 	alpacon ws usage`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		isSaaS, err := config.IsSaaS()
+		cfg, err := config.LoadConfig()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if !isSaaS {
+		if !cfg.IsSaaS() {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
-		}
-
-		cfg, err := config.LoadConfig()
-		if err != nil {
-			utils.CliErrorWithExit("Failed to load configuration: %s.", err)
 		}
 
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/workspace/workspace_usage.go
+++ b/cmd/workspace/workspace_usage.go
@@ -1,0 +1,53 @@
+package workspace
+
+import (
+	"encoding/json"
+
+	"github.com/alpacax/alpacon-cli/api/workspace"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workspaceUsageCmd = &cobra.Command{
+	Use:   "usage",
+	Short: "Retrieve workspace usage and billing estimate",
+	Long:  "Display the current billing period usage and cost estimate for the workspace.",
+	Example: `
+	alpacon workspace usage
+	alpacon ws usage`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
+		}
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		paymentBaseURL, err := workspace.GetPaymentAPIBaseURL(cfg.WorkspaceURL)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to determine payment API URL: %s.", err)
+		}
+
+		workspaceID, err := workspace.GetWorkspaceID(alpaconClient, paymentBaseURL, cfg.WorkspaceName)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to find workspace: %s.", err)
+		}
+
+		estimate, err := workspace.GetUsageEstimate(alpaconClient, paymentBaseURL, workspaceID)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve usage estimate: %s.", err)
+		}
+
+		data, err := json.Marshal(estimate)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to format usage data: %s.", err)
+		}
+		utils.PrintJson(data)
+		return nil
+	},
+}

--- a/cmd/workspace/workspace_usage.go
+++ b/cmd/workspace/workspace_usage.go
@@ -18,12 +18,17 @@ var workspaceUsageCmd = &cobra.Command{
 	alpacon workspace usage
 	alpacon ws usage`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.LoadConfig()
+		isSaaS, err := config.IsSaaS()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if cfg.AccessToken == "" {
+		if !isSaaS {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
+		}
+
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			utils.CliErrorWithExit("Failed to load configuration: %s.", err)
 		}
 
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/workspace/workspace_usage.go
+++ b/cmd/workspace/workspace_usage.go
@@ -22,11 +22,11 @@ var workspaceUsageCmd = &cobra.Command{
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		saas, err := config.IsSaaS()
+		isSaaS, err := config.IsSaaS()
 		if err != nil {
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' first.")
 		}
-		if !saas {
+		if !isSaaS {
 			utils.CliErrorWithExit("This command is only available on Alpacon Cloud workspaces.")
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -140,6 +140,11 @@ func IsSaaS() (bool, error) {
 	return cfg.AccessToken != "", nil
 }
 
+// IsSaaS returns true if the config represents an Alpacon Cloud (SaaS) deployment.
+func (c Config) IsSaaS() bool {
+	return c.AccessToken != ""
+}
+
 // GetSmuxConfig returns a ready-to-use smux configuration.
 func GetSmuxConfig() *smux.Config {
 	config := smux.DefaultConfig()

--- a/config/config.go
+++ b/config/config.go
@@ -130,6 +130,16 @@ func LoadConfig() (Config, error) {
 	return config, nil
 }
 
+// IsSaaS returns true if the workspace is an Alpacon Cloud (SaaS) deployment authenticated
+// via Auth0. OnPrem deployments use a legacy API token and return false.
+func IsSaaS() (bool, error) {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return false, err
+	}
+	return cfg.AccessToken != "", nil
+}
+
 // GetSmuxConfig returns a ready-to-use smux configuration.
 func GetSmuxConfig() *smux.Config {
 	config := smux.DefaultConfig()


### PR DESCRIPTION
## Summary

Add workspace settings, security, and billing commands to the CLI. Introduces `config.IsSaaS()` as a package-level function to replace scattered `AccessToken` checks, applying consistent SaaS/OnPrem guards across all relevant commands.

## New Commands

| Command | Description | Availability |
|---------|-------------|--------------|
| `workspace preferences [update]` | Workspace preferences | OnPrem + SaaS |
| `workspace notifications [update]` | Notification settings | OnPrem + SaaS |
| `workspace access-control [update]` | Access control settings | OnPrem + SaaS |
| `workspace authentication [update]` | Auth/MFA settings | SaaS only |
| `workspace mfa-methods` | Allowed MFA methods | SaaS only |
| `workspace usage` | Billing estimate | SaaS only |

## Changes

- **`config.IsSaaS()`**: package-level function in `config/config.go` that replaces scattered `AccessToken != ""` checks for deployment type detection
- **Consistent error messages**: OnPrem → `"self-hosted workspaces"`, SaaS → `"Alpacon Cloud workspaces"`
- **Non-interactive guard**: all `*_update` commands now fail fast with a clear error when not running in an interactive terminal
- **MFA retry flow**: `authentication update` and `access-control update` open browser for MFA, poll for completion, and automatically retry the operation
- **Unit tests**: added for all new API functions (`httptest`-based)

## Checklist

### Universal
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] No hardcoded secrets or credentials
- [ ] Updated relevant documentation

### Go
- [ ] Error handling is complete
- [ ] Tests include edge cases
- [ ] `go mod tidy` executed