### PR TITLE
fix(events): wait for all intermediate statuses in PollCommandExecution

### DIFF
--- a/api/event/event.go
+++ b/api/event/event.go
@@ -128,7 +128,7 @@ func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails,
 			}
 
 			switch response.Status {
-			case "running", "acked":
+			case "queued", "scheduled", "delivered", "verifying", "running", "acked":
 				timer.Reset(5 * time.Minute)
 				continue
 			default:

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -33,7 +33,7 @@ func TestGetEventList_NoExtraPagination(t *testing.T) {
 		}
 
 		var results []EventDetails
-		for i := 0; i < 25; i++ {
+		for i := range 25 {
 			results = append(results, EventDetails{
 				ID:          fmt.Sprintf("evt-%d", i),
 				Server:      types.ServerSummary{Name: "test-server"},
@@ -98,6 +98,27 @@ func TestPollCommandExecution(t *testing.T) {
 			wantStatus:     "error",
 			wantResult:     "done",
 			wantRequests:   1,
+		},
+		{
+			name:           "queued then delivered then running then success",
+			statusSequence: []string{"queued", "delivered", "running", "success"},
+			wantStatus:     "success",
+			wantResult:     "done",
+			wantRequests:   4,
+		},
+		{
+			name:           "scheduled then queued then success",
+			statusSequence: []string{"scheduled", "queued", "success"},
+			wantStatus:     "success",
+			wantResult:     "done",
+			wantRequests:   3,
+		},
+		{
+			name:           "verifying then running then success",
+			statusSequence: []string{"verifying", "running", "success"},
+			wantStatus:     "success",
+			wantResult:     "done",
+			wantRequests:   3,
 		},
 	}
 


### PR DESCRIPTION
## Summary

`exec` and non-interactive `websh` (e.g. `alpacon websh server ls`) returned empty output because `PollCommandExecution` only waited for `running` and `acked` statuses. Commands go through several intermediate states before producing a result — and the CLI was returning immediately with an empty result on the first non-matching status.

## Changes

- Add `queued`, `scheduled`, `delivered`, and `verifying` to the keep-polling status set in `PollCommandExecution`
- Add table-driven test cases covering full state transitions: `queued → delivered → running → success`, `scheduled → queued → success`, `verifying → running → success`
- Fix `for i := 0; i < 25; i++` → `for i := range 25` (rangeint lint)

## Root cause

Commit `2be242f` adapted the polling logic from nested `{"text": "Acked"}` to flat `"acked"` string format but only carried over `acked` as the keep-polling case, missing all other intermediate states. With the recent addition of command verification (AI signing), commands now pass through `verifying` before execution, making the issue consistently reproducible.

## Checklist

### Universal
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] No hardcoded secrets or credentials

### Go
- [x] Error handling is complete
- [x] Tests include edge cases