### PR TITLE
feat(cmd/server): add server token create/ls/delete commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,10 @@ Use: "exec [USER@]SERVER COMMAND... [flags]"
 - `Long`: Document SSH-like `user@host` syntax where supported
 - `Example`: Use realistic values (e.g., `my-server`, not `[SERVER_NAME]`)
 
+### Go declaration order
+
+Top-level declarations within a file must follow: `const → var → type → func`. Private helper types belong in the `type` block, never between functions.
+
 ### Error handling
 
 - golangci-lint `errcheck` is enabled—all error returns must be explicitly handled

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -174,6 +174,7 @@ type groupSummary struct {
 // buildGroupUUIDToNameMap fetches all IAM groups and returns a UUID→name map.
 // On failure it returns an empty map so callers never block on a group-lookup error.
 func buildGroupUUIDToNameMap(ac *client.AlpaconClient) map[string]string {
+	// "/api/iam/groups/" is intentionally duplicated from api/iam to avoid an import cycle.
 	groups, err := api.FetchAllPages[groupSummary](ac, "/api/iam/groups/", nil)
 	if err != nil {
 		return map[string]string{}
@@ -204,7 +205,17 @@ func GetRegistrationTokenAttributes(ac *client.AlpaconClient) ([]RegistrationTok
 		return nil, err
 	}
 
-	groupMap := buildGroupUUIDToNameMap(ac)
+	needsGroups := false
+	for _, t := range tokens {
+		if len(t.AllowedGroups) > 0 {
+			needsGroups = true
+			break
+		}
+	}
+	groupMap := map[string]string{}
+	if needsGroups {
+		groupMap = buildGroupUUIDToNameMap(ac)
+	}
 
 	var out []RegistrationTokenAttributes
 	for _, t := range tokens {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/client"
@@ -161,6 +162,72 @@ func GetRegistrationTokenByName(ac *client.AlpaconClient, name string) (Registra
 
 func ListRegistrationTokens(ac *client.AlpaconClient) ([]RegistrationTokenDetails, error) {
 	return api.FetchAllPages[RegistrationTokenDetails](ac, registrationTokenURL, nil)
+}
+
+// groupSummary is a minimal projection used to build a UUID→name map for group display.
+// Keeping it local avoids importing api/iam and pulling in its heavier GroupResponse type.
+type groupSummary struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// buildGroupUUIDToNameMap fetches all IAM groups and returns a UUID→name map.
+// On failure it returns an empty map so callers never block on a group-lookup error.
+func buildGroupUUIDToNameMap(ac *client.AlpaconClient) map[string]string {
+	groups, err := api.FetchAllPages[groupSummary](ac, "/api/iam/groups/", nil)
+	if err != nil {
+		return map[string]string{}
+	}
+	m := make(map[string]string, len(groups))
+	for _, g := range groups {
+		m[g.ID] = g.Name
+	}
+	return m
+}
+
+// DeleteRegistrationToken resolves a token name to its ID and sends a DELETE request.
+func DeleteRegistrationToken(ac *client.AlpaconClient, tokenName string) error {
+	token, err := GetRegistrationTokenByName(ac, tokenName)
+	if err != nil {
+		return err
+	}
+	_, err = ac.SendDeleteRequest(utils.BuildURL(registrationTokenURL, token.ID, nil))
+	return err
+}
+
+// GetRegistrationTokenAttributes returns all registration tokens projected for table/JSON display.
+// Group UUIDs are resolved to group names using a single batched lookup; on lookup failure,
+// UUIDs are shown as-is and the overall list is not blocked.
+func GetRegistrationTokenAttributes(ac *client.AlpaconClient) ([]RegistrationTokenAttributes, error) {
+	tokens, err := ListRegistrationTokens(ac)
+	if err != nil {
+		return nil, err
+	}
+
+	groupMap := buildGroupUUIDToNameMap(ac)
+
+	var out []RegistrationTokenAttributes
+	for _, t := range tokens {
+		names := make([]string, 0, len(t.AllowedGroups))
+		for _, id := range t.AllowedGroups {
+			if n, ok := groupMap[id]; ok {
+				names = append(names, n)
+			} else {
+				names = append(names, id)
+			}
+		}
+		expires := "never"
+		if t.ExpiresAt != nil {
+			expires = *t.ExpiresAt
+		}
+		out = append(out, RegistrationTokenAttributes{
+			Name:          t.Name,
+			AllowedGroups: strings.Join(names, ", "),
+			ExpiresAt:     expires,
+			Enabled:       t.Enabled,
+		})
+	}
+	return out, nil
 }
 
 func GetRegistrationGuideJSON(ac *client.AlpaconClient, platform, serverName, tokenID string) (RegistrationMethodGuideJsonResponse, error) {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -15,7 +15,8 @@ const (
 	serverURL            = "/api/servers/servers/"
 	registrationTokenURL = "/api/servers/registration-tokens/"
 	registrationGuideURL = "/api/servers/registration-methods/token-install/guide/"
-	// iamGroupURL is intentionally duplicated from api/iam to avoid an import cycle.
+	// iamGroupURL is duplicated from api/iam so this package can build a lean
+	// UUID→name projection without pulling in the full iam.GroupResponse type.
 	iamGroupURL = "/api/iam/groups/"
 )
 
@@ -174,10 +175,12 @@ func ListRegistrationTokens(ac *client.AlpaconClient) ([]RegistrationTokenDetail
 }
 
 // buildGroupUUIDToNameMap fetches all IAM groups and returns a UUID→name map.
-// On failure it returns an empty map so callers never block on a group-lookup error.
+// On failure it emits a one-time warning and returns an empty map so callers
+// never block on a group-lookup error; the list still renders with raw UUIDs.
 func buildGroupUUIDToNameMap(ac *client.AlpaconClient) map[string]string {
 	groups, err := api.FetchAllPages[groupSummary](ac, iamGroupURL, nil)
 	if err != nil {
+		utils.CliWarning("Could not resolve group names; showing UUIDs instead: %s", err)
 		return map[string]string{}
 	}
 	m := make(map[string]string, len(groups))
@@ -218,7 +221,7 @@ func GetRegistrationTokenAttributes(ac *client.AlpaconClient) ([]RegistrationTok
 		groupMap = buildGroupUUIDToNameMap(ac)
 	}
 
-	var out []RegistrationTokenAttributes
+	out := make([]RegistrationTokenAttributes, 0, len(tokens))
 	for _, t := range tokens {
 		names := make([]string, 0, len(t.AllowedGroups))
 		for _, id := range t.AllowedGroups {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -15,10 +15,19 @@ const (
 	serverURL            = "/api/servers/servers/"
 	registrationTokenURL = "/api/servers/registration-tokens/"
 	registrationGuideURL = "/api/servers/registration-methods/token-install/guide/"
+	// iamGroupURL is intentionally duplicated from api/iam to avoid an import cycle.
+	iamGroupURL = "/api/iam/groups/"
 )
 
 // ErrRegistrationTokenNotFound is returned when no registration token matches the given name.
 var ErrRegistrationTokenNotFound = errors.New("no registration token found with the given name")
+
+// groupSummary is a minimal projection used to build a UUID→name map for group display.
+// Keeping it local avoids importing api/iam and pulling in its heavier GroupResponse type.
+type groupSummary struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
 
 func GetServerList(ac *client.AlpaconClient) ([]ServerAttributes, error) {
 	servers, err := api.FetchAllPages[ServerDetails](ac, serverURL, nil)
@@ -164,18 +173,10 @@ func ListRegistrationTokens(ac *client.AlpaconClient) ([]RegistrationTokenDetail
 	return api.FetchAllPages[RegistrationTokenDetails](ac, registrationTokenURL, nil)
 }
 
-// groupSummary is a minimal projection used to build a UUID→name map for group display.
-// Keeping it local avoids importing api/iam and pulling in its heavier GroupResponse type.
-type groupSummary struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
 // buildGroupUUIDToNameMap fetches all IAM groups and returns a UUID→name map.
 // On failure it returns an empty map so callers never block on a group-lookup error.
 func buildGroupUUIDToNameMap(ac *client.AlpaconClient) map[string]string {
-	// "/api/iam/groups/" is intentionally duplicated from api/iam to avoid an import cycle.
-	groups, err := api.FetchAllPages[groupSummary](ac, "/api/iam/groups/", nil)
+	groups, err := api.FetchAllPages[groupSummary](ac, iamGroupURL, nil)
 	if err != nil {
 		return map[string]string{}
 	}

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -207,6 +208,238 @@ func TestListRegistrationTokens(t *testing.T) {
 	}
 	if got[0].Name != "prod-token" || got[1].Name != "dev-token" {
 		t.Errorf("unexpected token names: %v", got)
+	}
+}
+
+func TestCreateRegistrationToken_WithExpiresAt(t *testing.T) {
+	expiresAt := "2026-12-31T00:00:00Z"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		var req RegistrationTokenRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if req.ExpiresAt == nil || *req.ExpiresAt != expiresAt {
+			t.Errorf("expected expires_at %q, got %v", expiresAt, req.ExpiresAt)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RegistrationTokenCreatedResponse{
+			ID:        "tok-uuid",
+			Name:      "x",
+			Key:       "alpacax_key",
+			ExpiresAt: &expiresAt,
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := CreateRegistrationToken(ac, RegistrationTokenRequest{Name: "x", ExpiresAt: &expiresAt})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateRegistrationToken_WithoutExpiresAt(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		if strings.Contains(string(body), "expires_at") {
+			t.Errorf("expected no expires_at in body, got: %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RegistrationTokenCreatedResponse{ID: "tok-uuid", Name: "x", Key: "alpacax_key"})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := CreateRegistrationToken(ac, RegistrationTokenRequest{Name: "x"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteRegistrationToken_ByName_Success(t *testing.T) {
+	const tokenID = "tok-uuid-abc"
+	var deleteCalled bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.RawQuery, "search=") {
+			resp := api.ListResponse[RegistrationTokenDetails]{
+				Count:   1,
+				Results: []RegistrationTokenDetails{{ID: tokenID, Name: "target-token", Enabled: true}},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		if r.Method == http.MethodDelete {
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	if err := DeleteRegistrationToken(ac, "target-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deleteCalled {
+		t.Error("DELETE request was not sent")
+	}
+}
+
+func TestDeleteRegistrationToken_ByName_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := api.ListResponse[RegistrationTokenDetails]{Count: 0, Results: []RegistrationTokenDetails{}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	err := DeleteRegistrationToken(ac, "ghost")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrRegistrationTokenNotFound) {
+		t.Errorf("expected ErrRegistrationTokenNotFound, got %v", err)
+	}
+}
+
+func TestGetRegistrationTokenAttributes_MapsGroupNames(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/api/iam/groups/") {
+			type groupItem struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}
+			resp := api.ListResponse[groupItem]{
+				Count: 2,
+				Results: []groupItem{
+					{ID: "uuid-g1", Name: "dev"},
+					{ID: "uuid-g2", Name: "ops"},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// registration tokens
+		resp := api.ListResponse[RegistrationTokenDetails]{
+			Count: 1,
+			Results: []RegistrationTokenDetails{
+				{ID: "tok-1", Name: "my-token", AllowedGroups: []string{"uuid-g1", "uuid-g2"}, Enabled: true},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	attrs, err := GetRegistrationTokenAttributes(ac)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(attrs) != 1 {
+		t.Fatalf("expected 1 attribute, got %d", len(attrs))
+	}
+	if attrs[0].AllowedGroups != "dev, ops" {
+		t.Errorf("expected AllowedGroups %q, got %q", "dev, ops", attrs[0].AllowedGroups)
+	}
+}
+
+func TestGetRegistrationTokenAttributes_FallsBackToUUID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/api/iam/groups/") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		resp := api.ListResponse[RegistrationTokenDetails]{
+			Count: 1,
+			Results: []RegistrationTokenDetails{
+				{ID: "tok-1", Name: "my-token", AllowedGroups: []string{"uuid-g1"}, Enabled: true},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	attrs, err := GetRegistrationTokenAttributes(ac)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(attrs) != 1 {
+		t.Fatalf("expected 1 attribute, got %d", len(attrs))
+	}
+	if attrs[0].AllowedGroups != "uuid-g1" {
+		t.Errorf("expected AllowedGroups %q, got %q", "uuid-g1", attrs[0].AllowedGroups)
+	}
+}
+
+func TestGetRegistrationTokenAttributes_ExpiresNever(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/api/iam/groups/") {
+			resp := api.ListResponse[struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}]{Count: 0}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		resp := api.ListResponse[RegistrationTokenDetails]{
+			Count: 1,
+			Results: []RegistrationTokenDetails{
+				{ID: "tok-1", Name: "no-expire-token", AllowedGroups: nil, ExpiresAt: nil, Enabled: true},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	attrs, err := GetRegistrationTokenAttributes(ac)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(attrs) != 1 {
+		t.Fatalf("expected 1 attribute, got %d", len(attrs))
+	}
+	if attrs[0].ExpiresAt != "never" {
+		t.Errorf("expected ExpiresAt %q, got %q", "never", attrs[0].ExpiresAt)
+	}
+}
+
+func TestGetRegistrationTokenAttributes_EmptyList(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/api/iam/groups/") {
+			resp := api.ListResponse[struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}]{Count: 0}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		resp := api.ListResponse[RegistrationTokenDetails]{Count: 0, Results: []RegistrationTokenDetails{}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	attrs, err := GetRegistrationTokenAttributes(ac)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(attrs) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(attrs))
 	}
 }
 

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -244,8 +245,7 @@ func TestCreateRegistrationToken_WithExpiresAt(t *testing.T) {
 
 func TestCreateRegistrationToken_WithoutExpiresAt(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body := make([]byte, r.ContentLength)
-		_, _ = r.Body.Read(body)
+		body, _ := io.ReadAll(r.Body)
 		if strings.Contains(string(body), "expires_at") {
 			t.Errorf("expected no expires_at in body, got: %s", body)
 		}

--- a/api/server/types.go
+++ b/api/server/types.go
@@ -15,9 +15,11 @@ type ServerAttributes struct {
 }
 
 // RegistrationTokenRequest is used to create a new server registration token.
+// ExpiresAt is an RFC3339 timestamp; omit to create a non-expiring token.
 type RegistrationTokenRequest struct {
 	Name          string   `json:"name"`
 	AllowedGroups []string `json:"allowed_groups,omitempty"`
+	ExpiresAt     *string  `json:"expires_at,omitempty"`
 }
 
 // RegistrationTokenCreatedResponse holds the result after creating a server registration token.
@@ -27,6 +29,7 @@ type RegistrationTokenCreatedResponse struct {
 	Name          string   `json:"name"`
 	AllowedGroups []string `json:"allowed_groups"`
 	Key           string   `json:"key"`
+	ExpiresAt     *string  `json:"expires_at"`
 	AddedAt       string   `json:"added_at"`
 }
 
@@ -37,7 +40,18 @@ type RegistrationTokenDetails struct {
 	Name          string   `json:"name"`
 	AllowedGroups []string `json:"allowed_groups"`
 	Enabled       bool     `json:"enabled"`
+	ExpiresAt     *string  `json:"expires_at"`
 	AddedAt       string   `json:"added_at"`
+}
+
+// RegistrationTokenAttributes is the table/JSON projection used by 'server token ls'.
+// AllowedGroups is rendered as a comma-separated list of group names (UUIDs when the name cannot be resolved),
+// and ExpiresAt is rendered as the raw timestamp or "never" when the token does not expire.
+type RegistrationTokenAttributes struct {
+	Name          string `json:"name"`
+	AllowedGroups string `json:"allowed_groups" table:"Allowed Groups"`
+	ExpiresAt     string `json:"expires_at" table:"Expires At"`
+	Enabled       bool   `json:"enabled"`
 }
 
 // RegistrationMethodGuideRequest is the request body for the guide API.

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -14,7 +14,7 @@ var ServerCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon server list', 'alpacon server create', 'alpacon server describe', 'alpacon server update', or 'alpacon server delete'. Run 'alpacon server --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon server list', 'alpacon server create', 'alpacon server describe', 'alpacon server update', 'alpacon server delete', or 'alpacon server token'. Run 'alpacon server --help' for more information")
 	},
 }
 
@@ -24,4 +24,5 @@ func init() {
 	ServerCmd.AddCommand(serverCreateCmd)
 	ServerCmd.AddCommand(serverDeleteCmd)
 	ServerCmd.AddCommand(serverUpdateCmd)
+	ServerCmd.AddCommand(tokenCmd)
 }

--- a/cmd/server/token.go
+++ b/cmd/server/token.go
@@ -9,7 +9,7 @@ import (
 var tokenCmd = &cobra.Command{
 	Use:   "token",
 	Short: "Manage server registration tokens",
-	Long:  "Create, list, and delete registration tokens used by servers to self-register via alpamon.",
+	Long:  "Create, list, and delete registration tokens used by servers to self-register via Alpamon.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cmd.Help(); err != nil {
 			return err

--- a/cmd/server/token.go
+++ b/cmd/server/token.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var tokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Manage server registration tokens",
+	Long:  "Create, list, and delete registration tokens used by servers to self-register via alpamon.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+		return errors.New("a subcommand is required. Use 'alpacon server token create', 'alpacon server token ls', or 'alpacon server token delete'. Run 'alpacon server token --help' for more information")
+	},
+}
+
+func init() {
+	tokenCmd.AddCommand(tokenCreateCmd)
+	tokenCmd.AddCommand(tokenListCmd)
+	tokenCmd.AddCommand(tokenDeleteCmd)
+}

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	iamAPI "github.com/alpacax/alpacon-cli/api/iam"
 	serverAPI "github.com/alpacax/alpacon-cli/api/server"
@@ -87,6 +88,7 @@ func init() {
 func resolveGroupIDs(ac *client.AlpaconClient, entries []string) ([]string, error) {
 	ids := make([]string, 0, len(entries))
 	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
 		if entry == "" {
 			continue
 		}

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -35,12 +35,12 @@ The token key is displayed once at creation time and cannot be retrieved again.`
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
-			utils.CliErrorWithExit("connection to Alpacon API failed: %s. consider re-logging.", err)
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
 		groupIDs, err := resolveGroupIDs(alpaconClient, groups)
 		if err != nil {
-			utils.CliErrorWithExit("failed to resolve groups: %s.", err)
+			utils.CliErrorWithExit("Failed to resolve groups: %s.", err)
 		}
 
 		req := serverAPI.RegistrationTokenRequest{
@@ -53,13 +53,13 @@ The token key is displayed once at creation time and cannot be retrieved again.`
 
 		resp, err := serverAPI.CreateRegistrationToken(alpaconClient, req)
 		if err != nil {
-			utils.CliErrorWithExit("failed to create registration token: %s.", err)
+			utils.CliErrorWithExit("Failed to create registration token: %s.", err)
 		}
 
 		if utils.OutputFormat == utils.OutputFormatJSON {
 			data, err := json.Marshal(resp)
 			if err != nil {
-				utils.CliErrorWithExit("failed to marshal response: %s.", err)
+				utils.CliErrorWithExit("Failed to marshal response: %s.", err)
 			}
 			utils.PrintJson(data)
 		}

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -47,6 +47,9 @@ The token key is displayed once at creation time and cannot be retrieved again.`
 			Name:          name,
 			AllowedGroups: groupIDs,
 		}
+		if expiresInDays < 0 {
+			utils.CliErrorWithExit("--expires-in-days must be 0 (no expiry) or a positive number, got %d.", expiresInDays)
+		}
 		if expiresInDays > 0 {
 			req.ExpiresAt = utils.TimeFormat(expiresInDays)
 		}

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -25,6 +25,10 @@ The token key is displayed once at creation time and cannot be retrieved again.`
 		groups, _ := cmd.Flags().GetStringSlice("groups")
 		expiresInDays, _ := cmd.Flags().GetInt("expires-in-days")
 
+		if expiresInDays < 0 {
+			utils.CliErrorWithExit("--expires-in-days must be 0 (no expiry) or a positive number, got %d.", expiresInDays)
+		}
+
 		interactive := name == ""
 
 		if name == "" {
@@ -48,9 +52,6 @@ The token key is displayed once at creation time and cannot be retrieved again.`
 			Name:          name,
 			AllowedGroups: groupIDs,
 		}
-		if expiresInDays < 0 {
-			utils.CliErrorWithExit("--expires-in-days must be 0 (no expiry) or a positive number, got %d.", expiresInDays)
-		}
 		if expiresInDays > 0 {
 			req.ExpiresAt = utils.TimeFormat(expiresInDays)
 		}
@@ -66,6 +67,7 @@ The token key is displayed once at creation time and cannot be retrieved again.`
 				utils.CliErrorWithExit("Failed to marshal response: %s.", err)
 			}
 			utils.PrintJson(data)
+			return
 		}
 
 		utils.CliSuccess("Registration token created: %s", resp.Name)

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -24,7 +24,7 @@ The token key is displayed once at creation time and cannot be retrieved again.`
 		groups, _ := cmd.Flags().GetStringSlice("groups")
 		expiresInDays, _ := cmd.Flags().GetInt("expires-in-days")
 
-		interactive := !cmd.Flags().Changed("name")
+		interactive := name == ""
 
 		if name == "" {
 			name = utils.PromptForRequiredInput("Token name: ")

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -95,7 +95,7 @@ func resolveGroupIDs(ac *client.AlpaconClient, entries []string) ([]string, erro
 		} else {
 			id, err := iamAPI.GetGroupIDByName(ac, entry)
 			if err != nil {
-				return nil, fmt.Errorf("group %q not found: %w", entry, err)
+				return nil, fmt.Errorf("failed to resolve group %q: %w", entry, err)
 			}
 			ids = append(ids, id)
 		}

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -1,0 +1,13 @@
+package server
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var tokenCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new server registration token",
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: implement in Phase 4
+	},
+}

--- a/cmd/server/token_create.go
+++ b/cmd/server/token_create.go
@@ -1,13 +1,101 @@
 package server
 
 import (
+	"encoding/json"
+	"fmt"
+
+	iamAPI "github.com/alpacax/alpacon-cli/api/iam"
+	serverAPI "github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
 
 var tokenCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new server registration token",
+	Long: `Generates a new server registration token.
+The token key is displayed once at creation time and cannot be retrieved again.`,
+	Example: `
+    alpacon server token create --name k8s-nodes --groups infra --expires-in-days 365
+    alpacon server token create  # interactive mode`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: implement in Phase 4
+		name, _ := cmd.Flags().GetString("name")
+		groups, _ := cmd.Flags().GetStringSlice("groups")
+		expiresInDays, _ := cmd.Flags().GetInt("expires-in-days")
+
+		interactive := !cmd.Flags().Changed("name")
+
+		if name == "" {
+			name = utils.PromptForRequiredInput("Token name: ")
+		}
+		if interactive && len(groups) == 0 {
+			groups = utils.PromptForListInput("Allowed group names or UUIDs (comma-separated, optional): ")
+		}
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("connection to Alpacon API failed: %s. consider re-logging.", err)
+		}
+
+		groupIDs, err := resolveGroupIDs(alpaconClient, groups)
+		if err != nil {
+			utils.CliErrorWithExit("failed to resolve groups: %s.", err)
+		}
+
+		req := serverAPI.RegistrationTokenRequest{
+			Name:          name,
+			AllowedGroups: groupIDs,
+		}
+		if expiresInDays > 0 {
+			req.ExpiresAt = utils.TimeFormat(expiresInDays)
+		}
+
+		resp, err := serverAPI.CreateRegistrationToken(alpaconClient, req)
+		if err != nil {
+			utils.CliErrorWithExit("failed to create registration token: %s.", err)
+		}
+
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			data, err := json.Marshal(resp)
+			if err != nil {
+				utils.CliErrorWithExit("failed to marshal response: %s.", err)
+			}
+			utils.PrintJson(data)
+		}
+
+		utils.CliSuccess("Registration token created: %s", resp.Name)
+		utils.CliWarning("Save this key now—it will not be shown again: %s", utils.Green(resp.Key))
+		if resp.ExpiresAt != nil {
+			utils.CliInfo("Token expires at: %s", *resp.ExpiresAt)
+		}
 	},
+}
+
+func init() {
+	tokenCreateCmd.Flags().StringP("name", "n", "", "A name to identify the token.")
+	tokenCreateCmd.Flags().StringSliceP("groups", "g", []string{}, "Group names or UUIDs to assign on registration (comma-separated).")
+	tokenCreateCmd.Flags().Int("expires-in-days", 0, "Number of days until the token expires (0 = no expiry).")
+}
+
+// resolveGroupIDs converts a list of group names or UUIDs to UUIDs.
+// Entries that are already UUIDs pass through unchanged.
+// Entries that look like names are resolved via the IAM API.
+func resolveGroupIDs(ac *client.AlpaconClient, entries []string) ([]string, error) {
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry == "" {
+			continue
+		}
+		if utils.IsUUID(entry) {
+			ids = append(ids, entry)
+		} else {
+			id, err := iamAPI.GetGroupIDByName(ac, entry)
+			if err != nil {
+				return nil, fmt.Errorf("group %q not found: %w", entry, err)
+			}
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
 }

--- a/cmd/server/token_create_test.go
+++ b/cmd/server/token_create_test.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/api"
+	"github.com/alpacax/alpacon-cli/client"
+)
+
+// groupListResponse is a minimal helper type for mock IAM group responses.
+type groupListItem struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestResolveGroupIDs_UUID_PassThrough(t *testing.T) {
+	// UUIDs should pass through without any HTTP call.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected HTTP request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	input := []string{
+		"550e8400-e29b-41d4-a716-446655440000",
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+	}
+	got, err := resolveGroupIDs(ac, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 IDs, got %d", len(got))
+	}
+	for i, id := range input {
+		if got[i] != id {
+			t.Errorf("index %d: expected %q, got %q", i, id, got[i])
+		}
+	}
+}
+
+func TestResolveGroupIDs_NameResolved(t *testing.T) {
+	const wantID = "aaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := api.ListResponse[groupListItem]{
+			Count:   1,
+			Results: []groupListItem{{ID: wantID, Name: "dev"}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	got, err := resolveGroupIDs(ac, []string{"dev"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 ID, got %d", len(got))
+	}
+	if got[0] != wantID {
+		t.Errorf("expected %q, got %q", wantID, got[0])
+	}
+}
+
+func TestResolveGroupIDs_NameNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := api.ListResponse[groupListItem]{Count: 0, Results: []groupListItem{}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	_, err := resolveGroupIDs(ac, []string{"nonexistent-group"})
+	if err == nil {
+		t.Fatal("expected error for unknown group name, got nil")
+	}
+}
+
+func TestResolveGroupIDs_Empty(t *testing.T) {
+	// Empty input should return empty slice without any HTTP call.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected HTTP request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	got, err := resolveGroupIDs(ac, []string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(got))
+	}
+}

--- a/cmd/server/token_delete.go
+++ b/cmd/server/token_delete.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var tokenDeleteCmd = &cobra.Command{
+	Use:     "delete TOKEN",
+	Aliases: []string{"rm"},
+	Short:   "Delete a server registration token",
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: implement in Phase 6
+	},
+}

--- a/cmd/server/token_delete.go
+++ b/cmd/server/token_delete.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	serverAPI "github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -8,8 +11,34 @@ var tokenDeleteCmd = &cobra.Command{
 	Use:     "delete TOKEN",
 	Aliases: []string{"rm"},
 	Short:   "Delete a server registration token",
-	Args:    cobra.ExactArgs(1),
+	Long: `Delete a server registration token by name.
+The token is resolved by name—UUID input is not supported.`,
+	Example: `
+    alpacon server token delete my-token
+    alpacon server token rm my-token
+    alpacon server token delete my-token -y`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: implement in Phase 6
+		name := args[0]
+
+		yes, _ := cmd.Flags().GetBool("yes")
+		if !yes {
+			utils.ConfirmAction("Delete registration token '%s'?", name)
+		}
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if err := serverAPI.DeleteRegistrationToken(alpaconClient, name); err != nil {
+			utils.CliErrorWithExit("Failed to delete the registration token: %s.", err)
+		}
+
+		utils.CliSuccess("Registration token deleted: %s", name)
 	},
+}
+
+func init() {
+	tokenDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 }

--- a/cmd/server/token_list.go
+++ b/cmd/server/token_list.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	serverAPI "github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -8,7 +11,23 @@ var tokenListCmd = &cobra.Command{
 	Use:     "ls",
 	Aliases: []string{"list"},
 	Short:   "List server registration tokens",
+	Long: `Display all server registration tokens.
+Tokens are used by alpamon to self-register servers without manual intervention.`,
+	Example: `
+    alpacon server token ls
+    alpacon server token list
+    alpacon server token ls --output json`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: implement in Phase 5
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		tokens, err := serverAPI.GetRegistrationTokenAttributes(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve the registration tokens: %s.", err)
+		}
+
+		utils.PrintTable(tokens)
 	},
 }

--- a/cmd/server/token_list.go
+++ b/cmd/server/token_list.go
@@ -1,0 +1,14 @@
+package server
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var tokenListCmd = &cobra.Command{
+	Use:     "ls",
+	Aliases: []string{"list"},
+	Short:   "List server registration tokens",
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: implement in Phase 5
+	},
+}

--- a/cmd/server/token_list.go
+++ b/cmd/server/token_list.go
@@ -12,7 +12,7 @@ var tokenListCmd = &cobra.Command{
 	Aliases: []string{"list"},
 	Short:   "List server registration tokens",
 	Long: `Display all server registration tokens.
-Tokens are used by alpamon to self-register servers without manual intervention.`,
+Tokens are used by Alpamon to self-register servers without manual intervention.`,
 	Example: `
     alpacon server token ls
     alpacon server token list


### PR DESCRIPTION
## Summary

Installing alpamon previously required manually copying a registration token from
the web UI, making fully automated provisioning with Terraform/Ansible/CloudInit
impossible. This PR adds the `alpacon server token` subcommand group—create, ls,
and delete—so tokens can be managed entirely from the CLI.

Closes #146

## Changes

- Add `server token create` — generates a registration token; key is printed once and cannot be retrieved again; supports `--name`, `--groups`, `--expires-in-days`, `--output json`
- Add `server token ls` — lists all tokens with group UUIDs resolved to names; supports `--output json`
- Add `server token delete TOKEN` — deletes a token by name; `-y` skips confirmation
- Extend `RegistrationToken*` structs with `ExpiresAt`; add `RegistrationTokenAttributes` for table projection
- Add `DeleteRegistrationToken`, `GetRegistrationTokenAttributes`, `buildGroupUUIDToNameMap` to `api/server`
- Add 8 API-layer tests and 4 unit tests for `resolveGroupIDs`
- Fix: reject negative `--expires-in-days` values instead of silently creating non-expiring tokens
- Refactor: move `groupSummary` type before functions (Go declaration order); extract magic string to `iamGroupURL` constant

## Stack: golang

## Checklist

### Universal
- [ ] Self-reviewed the code
- [ ] No hardcoded secrets or credentials
- [ ] Updated relevant documentation

### Go
- [ ] Error handling is complete
- [ ] Tests include edge cases
- [ ] `go mod tidy` executed