### PR TITLE
fix(utils): suppress spinner and ANSI colors in non-TTY output

### DIFF
--- a/utils/color.go
+++ b/utils/color.go
@@ -1,6 +1,11 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/term"
+)
 
 const (
 	ansiReset  = "\033[0m"
@@ -11,27 +16,47 @@ const (
 	ansiBlue   = "\033[34m"
 )
 
+// colorEnabled reports whether stderr is a terminal. Color helpers are
+// only used for log/prompt output (which goes to stderr), so gating on
+// stderr avoids ANSI artifacts when logs are piped or redirected.
+var colorEnabled = term.IsTerminal(int(os.Stderr.Fd()))
+
 // Green returns a bold green string for terminal output.
 func Green(value string) string {
+	if !colorEnabled {
+		return value
+	}
 	return fmt.Sprintf("%s%s%s%s", ansiBold, ansiGreen, value, ansiReset)
 }
 
 // Yellow returns a bold yellow string for terminal output.
 func Yellow(value string) string {
+	if !colorEnabled {
+		return value
+	}
 	return fmt.Sprintf("%s%s%s%s", ansiBold, ansiYellow, value, ansiReset)
 }
 
 // Blue returns a bold blue string for terminal output.
 func Blue(value string) string {
+	if !colorEnabled {
+		return value
+	}
 	return fmt.Sprintf("%s%s%s%s", ansiBold, ansiBlue, value, ansiReset)
 }
 
 // Red returns a bold red string for terminal output.
 func Red(value string) string {
+	if !colorEnabled {
+		return value
+	}
 	return fmt.Sprintf("%s%s%s%s", ansiBold, ansiRed, value, ansiReset)
 }
 
 // Bold returns a bold string for terminal output.
 func Bold(value string) string {
+	if !colorEnabled {
+		return value
+	}
 	return fmt.Sprintf("%s%s%s", ansiBold, value, ansiReset)
 }

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -6,9 +6,13 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/term"
 )
 
-// Spinner displays an animated spinner with a message
+// Spinner displays an animated spinner with a message.
+// Output is suppressed when stderr is not a terminal (e.g., piped or redirected),
+// so automated/CI environments get clean logs without ANSI artifacts.
 type Spinner struct {
 	message  string
 	frames   []string
@@ -18,6 +22,7 @@ type Spinner struct {
 	doneCh   chan struct{}
 	mu       sync.Mutex
 	running  bool
+	enabled  bool
 }
 
 // NewSpinner creates a new spinner with the given message
@@ -30,11 +35,18 @@ func NewSpinner(message string) *Spinner {
 		interval: 100 * time.Millisecond,
 		stopCh:   make(chan struct{}),
 		doneCh:   make(chan struct{}),
+		enabled:  term.IsTerminal(int(os.Stderr.Fd())),
 	}
 }
 
 // Start begins the spinner animation
 func (s *Spinner) Start() {
+	if !s.enabled {
+		// Print a static message so users still see progress in non-TTY output
+		fmt.Fprintln(os.Stderr, s.message)
+		return
+	}
+
 	s.mu.Lock()
 	if s.running {
 		s.mu.Unlock()
@@ -86,6 +98,10 @@ func (s *Spinner) Start() {
 
 // Stop stops the spinner animation
 func (s *Spinner) Stop() {
+	if !s.enabled {
+		return
+	}
+
 	s.mu.Lock()
 	if !s.running {
 		s.mu.Unlock()

--- a/utils/spinner.go
+++ b/utils/spinner.go
@@ -11,8 +11,9 @@ import (
 )
 
 // Spinner displays an animated spinner with a message.
-// Output is suppressed when stderr is not a terminal (e.g., piped or redirected),
-// so automated/CI environments get clean logs without ANSI artifacts.
+// When stderr is not a terminal (e.g., piped or redirected), the spinner
+// animation is replaced with a single static progress line so logs stay
+// clean without ANSI artifacts.
 type Spinner struct {
 	message  string
 	frames   []string
@@ -41,12 +42,6 @@ func NewSpinner(message string) *Spinner {
 
 // Start begins the spinner animation
 func (s *Spinner) Start() {
-	if !s.enabled {
-		// Print a static message so users still see progress in non-TTY output
-		fmt.Fprintln(os.Stderr, s.message)
-		return
-	}
-
 	s.mu.Lock()
 	if s.running {
 		s.mu.Unlock()
@@ -54,6 +49,12 @@ func (s *Spinner) Start() {
 	}
 	s.running = true
 	s.mu.Unlock()
+
+	if !s.enabled {
+		// Print a static message so users still see progress in non-TTY output
+		fmt.Fprintln(os.Stderr, s.message)
+		return
+	}
 
 	go func() {
 		defer close(s.doneCh)
@@ -98,10 +99,6 @@ func (s *Spinner) Start() {
 
 // Stop stops the spinner animation
 func (s *Spinner) Stop() {
-	if !s.enabled {
-		return
-	}
-
 	s.mu.Lock()
 	if !s.running {
 		s.mu.Unlock()
@@ -109,6 +106,10 @@ func (s *Spinner) Stop() {
 	}
 	s.running = false
 	s.mu.Unlock()
+
+	if !s.enabled {
+		return
+	}
 
 	close(s.stopCh)
 	<-s.doneCh


### PR DESCRIPTION
## Summary

The CLI spinner and color escape codes were unconditionally emitted to stderr, even when stderr was piped or redirected. This contaminated logs in CI and piped workflows (feedback from Windows shell user: "⠋ Uploading... ANSI가 stdout에 섞여서 파이프/파싱 시 거슬림").

## Changes

- **`utils/spinner.go`**: Check `term.IsTerminal(stderr)` on creation. In non-TTY environments, print a single static message line and skip the animation loop entirely
- **`utils/color.go`**: Gate ANSI escape emission on `term.IsTerminal(stderr)`. Return plain text in non-TTY environments

## Before / After

```bash
# Before
$ alpacon cp file host:/path 2>&1 | tee log.txt
$ cat log.txt
⠋ Uploading file...⠙ Uploading file...⠹ Uploading file...[K
# ANSI artifacts everywhere

# After
$ alpacon cp file host:/path 2>&1 | tee log.txt
$ cat log.txt
Uploading file...
# Clean static message
```

## Stack: golang

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Error handling is complete
- [x] Tests pass (all existing tests continue to work since stderr TTY detection is transparent)
- [x] `go vet` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)