### PR TITLE
feat(token): add token duplicate subcommand

### DIFF
--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -17,11 +17,10 @@ import (
 )
 
 const (
-	loginURL              = "/api/auth/login/"
-	logoutURL             = "/api/auth/logout/"
-	tokenURL              = "/api/auth/tokens/"
-	statusURL             = "/api/status/"
-	duplicateTokenBaseURL = "/api/tokens/"
+	loginURL  = "/api/auth/login/"
+	logoutURL = "/api/auth/logout/"
+	tokenURL  = "/api/auth/tokens/"
+	statusURL = "/api/status/"
 )
 
 func LoginAndSaveCredentials(loginReq *LoginRequest, token string, insecure bool) error {
@@ -167,7 +166,7 @@ func DeleteAPIToken(ac *client.AlpaconClient, tokenID string) error {
 }
 
 func DuplicateAPIToken(ac *client.AlpaconClient, tokenID, name string) (string, error) {
-	url := utils.BuildURL(duplicateTokenBaseURL, tokenID+"/duplicate", nil)
+	url := utils.BuildURL(tokenURL, tokenID+"/duplicate", nil)
 	req := APITokenDuplicateRequest{Name: name}
 	resp, err := ac.SendPostRequest(url, req)
 	if err != nil {

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	loginURL  = "/api/auth/login/"
-	logoutURL = "/api/auth/logout/"
-	tokenURL  = "/api/auth/tokens/"
-	statusURL = "/api/status/"
+	loginURL              = "/api/auth/login/"
+	logoutURL             = "/api/auth/logout/"
+	tokenURL              = "/api/auth/tokens/"
+	statusURL             = "/api/status/"
+	duplicateTokenBaseURL = "/api/tokens/"
 )
 
 func LoginAndSaveCredentials(loginReq *LoginRequest, token string, insecure bool) error {
@@ -163,6 +164,22 @@ func DeleteAPIToken(ac *client.AlpaconClient, tokenID string) error {
 	}
 
 	return nil
+}
+
+func DuplicateAPIToken(ac *client.AlpaconClient, tokenID, name string) (string, error) {
+	url := utils.BuildURL(duplicateTokenBaseURL, tokenID+"/duplicate", nil)
+	req := APITokenDuplicateRequest{Name: name}
+	resp, err := ac.SendPostRequest(url, req)
+	if err != nil {
+		return "", err
+	}
+
+	var response APITokenResponse
+	if err = json.Unmarshal(resp, &response); err != nil {
+		return "", err
+	}
+
+	return response.Key, nil
 }
 
 func Logout(ac *client.AlpaconClient) error {

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -162,5 +163,57 @@ func TestDeleteAPIToken(t *testing.T) {
 	}
 	if !deleteCalled {
 		t.Error("DELETE request was not sent")
+	}
+}
+
+func TestDuplicateAPIToken(t *testing.T) {
+	const wantKey = "duplicated-token-key-xyz"
+
+	tests := []struct {
+		name     string
+		copyName string
+		wantBody bool
+	}{
+		{"with name", "my-token-copy", true},
+		{"without name", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				if !strings.Contains(r.URL.Path, "/duplicate") {
+					t.Errorf("expected path to contain /duplicate, got %s", r.URL.Path)
+				}
+
+				var body map[string]string
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				if tt.wantBody {
+					if body["name"] != tt.copyName {
+						t.Errorf("expected body name %q, got %q", tt.copyName, body["name"])
+					}
+				} else {
+					if _, ok := body["name"]; ok {
+						t.Errorf("expected no name field in body, but found %q", body["name"])
+					}
+				}
+
+				resp := APITokenResponse{ID: "new-token-id", Name: "copy", Key: wantKey}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			key, err := DuplicateAPIToken(ac, "source-token-id", tt.copyName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if key != wantKey {
+				t.Errorf("expected key %q, got %q", wantKey, key)
+			}
+		})
 	}
 }

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -189,7 +189,11 @@ func TestDuplicateAPIToken(t *testing.T) {
 				}
 
 				var body map[string]string
-				_ = json.NewDecoder(r.Body).Decode(&body)
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+					http.Error(w, "invalid request body", http.StatusBadRequest)
+					return
+				}
 				if tt.wantBody {
 					if body["name"] != tt.copyName {
 						t.Errorf("expected body name %q, got %q", tt.copyName, body["name"])

--- a/api/auth/types.go
+++ b/api/auth/types.go
@@ -18,6 +18,10 @@ type APITokenRequest struct {
 	ExpiresAt *string `json:"expires_at"`
 }
 
+type APITokenDuplicateRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
 type APITokenResponse struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -13,7 +13,7 @@ var TokenCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon token create', 'alpacon token list', 'alpacon token delete', or 'alpacon token acl' to manage API tokens. Run 'alpacon token --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon token create', 'alpacon token list', 'alpacon token delete', 'alpacon token duplicate', or 'alpacon token acl' to manage API tokens. Run 'alpacon token --help' for more information")
 	},
 }
 
@@ -21,6 +21,7 @@ func init() {
 	TokenCmd.AddCommand(tokenCreateCmd)
 	TokenCmd.AddCommand(tokenListCmd)
 	TokenCmd.AddCommand(tokenDeleteCmd)
+	TokenCmd.AddCommand(tokenDuplicateCmd)
 
 	// ACL
 	TokenCmd.AddCommand(AclCmd)

--- a/cmd/token/token_duplicate.go
+++ b/cmd/token/token_duplicate.go
@@ -9,7 +9,7 @@ import (
 
 var tokenDuplicateCmd = &cobra.Command{
 	Use:   "duplicate TOKEN",
-	Short: "Duplicate an API token with its scopes and ACL rules",
+	Short: "Duplicate an api token with its scopes and ACL rules",
 	Long: `
 	Creates a copy of an existing API token, including all scopes and ACL rules
 	(Command, Server, File). The source token is identified by name or UUID.

--- a/cmd/token/token_duplicate.go
+++ b/cmd/token/token_duplicate.go
@@ -1,0 +1,51 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/auth"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var tokenDuplicateCmd = &cobra.Command{
+	Use:   "duplicate TOKEN",
+	Short: "Duplicate an API token with its scopes and ACL rules",
+	Long: `
+	Creates a copy of an existing API token, including all scopes and ACL rules
+	(Command, Server, File). The source token is identified by name or UUID.
+	`,
+	Example: `
+	alpacon token duplicate my-api-token
+	alpacon token duplicate my-api-token --name "my-api-token-copy"
+	alpacon token duplicate 550e8400-e29b-41d4-a716-446655440000
+	`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		tokenID := args[0]
+		name, _ := cmd.Flags().GetString("name")
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if !utils.IsUUID(tokenID) {
+			tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenID)
+			if err != nil {
+				utils.CliErrorWithExit("Failed to duplicate the API token: %s.", err)
+			}
+		}
+
+		key, err := auth.DuplicateAPIToken(alpaconClient, tokenID, name)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to duplicate the API token: %s.", err)
+		}
+
+		utils.CliSuccess("API token duplicated: %s", key)
+		utils.CliWarning("This token cannot be retrieved again after you exit.")
+	},
+}
+
+func init() {
+	tokenDuplicateCmd.Flags().StringP("name", "n", "", "Name for the new token (optional)")
+}

--- a/cmd/token/token_duplicate.go
+++ b/cmd/token/token_duplicate.go
@@ -9,7 +9,7 @@ import (
 
 var tokenDuplicateCmd = &cobra.Command{
 	Use:   "duplicate TOKEN",
-	Short: "Duplicate an api token with its scopes and ACL rules",
+	Short: "Duplicate an api token and its rules",
 	Long: `
 	Creates a copy of an existing API token, including all scopes and ACL rules
 	(Command, Server, File). The source token is identified by name or UUID.


### PR DESCRIPTION
### Summary

Adds `alpacon token duplicate TOKEN` subcommand that creates a copy of an existing API token, preserving all scopes and ACL rules (Command, Server, File).

### Changes

- `cmd/token/token_duplicate.go` — New subcommand. Accepts token name or UUID as a positional argument; optional `--name` / `-n` flag to set the new token's name
- `api/auth/auth.go` — `DuplicateAPIToken()` calling `POST /api/auth/tokens/{id}/duplicate/`
- `api/auth/types.go` — `APITokenDuplicateRequest` type with `name,omitempty`
- `api/auth/auth_test.go` — `TestDuplicateAPIToken` covering with-name and without-name cases
- `cmd/token/token.go` — Register subcommand and update help message

### Usage

```bash
alpacon token duplicate my-api-token
alpacon token duplicate my-api-token --name "my-api-token-copy"
alpacon token duplicate 550e8400-e29b-41d4-a716-446655440000
```

### Test plan

- [ ] `go test -race -v ./api/auth/...` passes
- [ ] Duplicate by name: `alpacon token duplicate <TOKEN_NAME>`
- [ ] Duplicate by UUID: `alpacon token duplicate <UUID>`
- [ ] With custom name: `alpacon token duplicate <TOKEN> --name "copy"`
- [ ] Error message on unknown token name