### PR TITLE
feat(token): add scoped API tokens and token scopes subcommand

### DIFF
--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -199,7 +199,7 @@ func GetTokenScopes(ac *client.AlpaconClient) ([]TokenScopeAttributes, error) {
 	for _, w := range response.Wildcards {
 		result = append(result, TokenScopeAttributes{
 			Name:    w,
-			Actions: "(matches all scopes)",
+			Actions: "",
 			ACL:     "",
 		})
 	}

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -184,6 +184,28 @@ func DuplicateAPIToken(ac *client.AlpaconClient, tokenID, name string) (string, 
 	return response.Key, nil
 }
 
+func GetTokenScopes(ac *client.AlpaconClient) ([]TokenScopeAttributes, error) {
+	resp, err := ac.SendGetRequest(tokenScopesURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var response TokenScopesResponse
+	if err = json.Unmarshal(resp, &response); err != nil {
+		return nil, err
+	}
+
+	var result []TokenScopeAttributes
+	for _, r := range response.Resources {
+		result = append(result, TokenScopeAttributes{
+			Name:    r.Name,
+			Actions: strings.Join(r.Actions, ", "),
+			ACL:     strings.Join(r.ACL, ", "),
+		})
+	}
+	return result, nil
+}
+
 func Logout(ac *client.AlpaconClient) error {
 	_, err := ac.SendPostRequest(logoutURL, nil)
 	if err != nil {

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -196,6 +196,13 @@ func GetTokenScopes(ac *client.AlpaconClient) ([]TokenScopeAttributes, error) {
 	}
 
 	var result []TokenScopeAttributes
+	for _, w := range response.Wildcards {
+		result = append(result, TokenScopeAttributes{
+			Name:    w,
+			Actions: "(matches all scopes)",
+			ACL:     "",
+		})
+	}
 	for _, r := range response.Resources {
 		result = append(result, TokenScopeAttributes{
 			Name:    r.Name,

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/client"
@@ -17,10 +18,11 @@ import (
 )
 
 const (
-	loginURL  = "/api/auth/login/"
-	logoutURL = "/api/auth/logout/"
-	tokenURL  = "/api/auth/tokens/"
-	statusURL = "/api/status/"
+	loginURL       = "/api/auth/login/"
+	logoutURL      = "/api/auth/logout/"
+	tokenURL       = "/api/auth/tokens/"
+	tokenScopesURL = "/api/auth/tokens/scopes/"
+	statusURL      = "/api/status/"
 )
 
 func LoginAndSaveCredentials(loginReq *LoginRequest, token string, insecure bool) error {
@@ -129,6 +131,7 @@ func GetAPITokenList(ac *client.AlpaconClient) ([]APITokenAttributes, error) {
 			Enabled:   token.Enabled,
 			UpdatedAt: utils.TimeUtils(token.UpdatedAt),
 			ExpiresAt: utils.TimeUtils(token.ExpiresAt),
+			Scopes:    strings.Join(token.Scopes, ", "),
 		})
 	}
 	return tokenList, nil

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -301,8 +301,8 @@ func TestGetTokenScopes(t *testing.T) {
 	if scopes[0].Name != "*" {
 		t.Errorf("expected wildcard name %q, got %q", "*", scopes[0].Name)
 	}
-	if scopes[0].Actions != "(matches all scopes)" {
-		t.Errorf("expected wildcard actions %q, got %q", "(matches all scopes)", scopes[0].Actions)
+	if scopes[0].Actions != "" {
+		t.Errorf("expected empty wildcard actions, got %q", scopes[0].Actions)
 	}
 	if scopes[1].Name != "server" {
 		t.Errorf("expected name %q, got %q", "server", scopes[1].Name)

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -295,19 +295,25 @@ func TestGetTokenScopes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(scopes) != 2 {
-		t.Fatalf("expected 2 scopes, got %d", len(scopes))
+	if len(scopes) != 3 {
+		t.Fatalf("expected 3 scopes, got %d", len(scopes))
 	}
-	if scopes[0].Name != "server" {
-		t.Errorf("expected name %q, got %q", "server", scopes[0].Name)
+	if scopes[0].Name != "*" {
+		t.Errorf("expected wildcard name %q, got %q", "*", scopes[0].Name)
 	}
-	if scopes[0].Actions != "read, create" {
-		t.Errorf("expected actions %q, got %q", "read, create", scopes[0].Actions)
+	if scopes[0].Actions != "(matches all scopes)" {
+		t.Errorf("expected wildcard actions %q, got %q", "(matches all scopes)", scopes[0].Actions)
 	}
-	if scopes[0].ACL != "server" {
-		t.Errorf("expected ACL %q, got %q", "server", scopes[0].ACL)
+	if scopes[1].Name != "server" {
+		t.Errorf("expected name %q, got %q", "server", scopes[1].Name)
 	}
-	if scopes[1].ACL != "" {
-		t.Errorf("expected empty ACL, got %q", scopes[1].ACL)
+	if scopes[1].Actions != "read, create" {
+		t.Errorf("expected actions %q, got %q", "read, create", scopes[1].Actions)
+	}
+	if scopes[1].ACL != "server" {
+		t.Errorf("expected ACL %q, got %q", "server", scopes[1].ACL)
+	}
+	if scopes[2].ACL != "" {
+		t.Errorf("expected empty ACL, got %q", scopes[2].ACL)
 	}
 }

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -129,23 +129,66 @@ func TestGetAPITokenIDByName(t *testing.T) {
 func TestCreateAPIToken(t *testing.T) {
 	const wantKey = "secret-api-key-xyz"
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
-		}
-		resp := APITokenResponse{ID: "new-token-id", Name: "ci-token", Key: wantKey, UpdatedAt: time.Now()}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer ts.Close()
-
-	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	key, err := CreateAPIToken(ac, APITokenRequest{Name: "ci-token"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name       string
+		request    APITokenRequest
+		wantScopes []string
+	}{
+		{
+			name:       "no scopes — field omitted",
+			request:    APITokenRequest{Name: "ci-token"},
+			wantScopes: nil,
+		},
+		{
+			name:       "with scopes",
+			request:    APITokenRequest{Name: "ci-token", Scopes: []string{"server:read", "command:create"}},
+			wantScopes: []string{"server:read", "command:create"},
+		},
 	}
-	if key != wantKey {
-		t.Errorf("expected key %q, got %q", wantKey, key)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				var body map[string]json.RawMessage
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("failed to decode body: %v", err)
+				}
+				if tt.wantScopes == nil {
+					if _, ok := body["scopes"]; ok {
+						t.Errorf("expected scopes field to be omitted, but it was present")
+					}
+				} else {
+					raw, ok := body["scopes"]
+					if !ok {
+						t.Errorf("expected scopes field in body, but missing")
+					} else {
+						var got []string
+						if err := json.Unmarshal(raw, &got); err != nil {
+							t.Errorf("failed to unmarshal scopes: %v", err)
+						}
+						if len(got) != len(tt.wantScopes) {
+							t.Errorf("expected scopes %v, got %v", tt.wantScopes, got)
+						}
+					}
+				}
+				resp := APITokenResponse{ID: "new-token-id", Name: "ci-token", Key: wantKey, UpdatedAt: time.Now()}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			key, err := CreateAPIToken(ac, tt.request)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if key != wantKey {
+				t.Errorf("expected key %q, got %q", wantKey, key)
+			}
+		})
 	}
 }
 

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -32,8 +32,9 @@ func TestGetAPITokenList_Pagination(t *testing.T) {
 		case "1", "":
 			for i := 0; i < 100; i++ {
 				results = append(results, APITokenResponse{
-					ID:   fmt.Sprintf("tid-%d", i),
-					Name: fmt.Sprintf("token-%d", i),
+					ID:     fmt.Sprintf("tid-%d", i),
+					Name:   fmt.Sprintf("token-%d", i),
+					Scopes: []string{"server:read", "command:create"},
 				})
 			}
 		case "2":
@@ -75,6 +76,9 @@ func TestGetAPITokenList_Pagination(t *testing.T) {
 	}
 	if len(tokens) != 150 {
 		t.Errorf("expected 150 tokens, got %d", len(tokens))
+	}
+	if tokens[0].Scopes != "server:read, command:create" {
+		t.Errorf("expected scopes %q, got %q", "server:read, command:create", tokens[0].Scopes)
 	}
 }
 

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -154,7 +155,7 @@ func TestCreateAPIToken(t *testing.T) {
 				}
 				var body map[string]json.RawMessage
 				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-					t.Errorf("failed to decode body: %v", err)
+					t.Fatalf("failed to decode body: %v", err)
 				}
 				if tt.wantScopes == nil {
 					if _, ok := body["scopes"]; ok {
@@ -167,9 +168,9 @@ func TestCreateAPIToken(t *testing.T) {
 					} else {
 						var got []string
 						if err := json.Unmarshal(raw, &got); err != nil {
-							t.Errorf("failed to unmarshal scopes: %v", err)
+							t.Fatalf("failed to unmarshal scopes: %v", err)
 						}
-						if len(got) != len(tt.wantScopes) {
+						if !reflect.DeepEqual(got, tt.wantScopes) {
 							t.Errorf("expected scopes %v, got %v", tt.wantScopes, got)
 						}
 					}

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -225,3 +225,45 @@ func TestDuplicateAPIToken(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTokenScopes(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/scopes/") {
+			t.Errorf("expected path ending /scopes/, got %s", r.URL.Path)
+		}
+		resp := TokenScopesResponse{
+			Resources: []TokenScopeResource{
+				{Name: "server", Actions: []string{"read", "create"}, ACL: []string{"server"}},
+				{Name: "command", Actions: []string{"create", "delete"}, ACL: []string{}},
+			},
+			Wildcards: []string{"*"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	scopes, err := GetTokenScopes(ac)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(scopes) != 2 {
+		t.Fatalf("expected 2 scopes, got %d", len(scopes))
+	}
+	if scopes[0].Name != "server" {
+		t.Errorf("expected name %q, got %q", "server", scopes[0].Name)
+	}
+	if scopes[0].Actions != "read, create" {
+		t.Errorf("expected actions %q, got %q", "read, create", scopes[0].Actions)
+	}
+	if scopes[0].ACL != "server" {
+		t.Errorf("expected ACL %q, got %q", "server", scopes[0].ACL)
+	}
+	if scopes[1].ACL != "" {
+		t.Errorf("expected empty ACL, got %q", scopes[1].ACL)
+	}
+}

--- a/api/auth/types.go
+++ b/api/auth/types.go
@@ -14,8 +14,9 @@ type LoginResponse struct {
 }
 
 type APITokenRequest struct {
-	Name      string  `json:"name"`
-	ExpiresAt *string `json:"expires_at"`
+	Name      string   `json:"name"`
+	ExpiresAt *string  `json:"expires_at"`
+	Scopes    []string `json:"scopes,omitempty"`
 }
 
 type APITokenDuplicateRequest struct {
@@ -29,6 +30,7 @@ type APITokenResponse struct {
 	Key       string    `json:"key"`
 	UpdatedAt time.Time `json:"updated_at"`
 	ExpiresAt time.Time `json:"expires_at"`
+	Scopes    []string  `json:"scopes"`
 }
 
 type APITokenAttributes struct {
@@ -37,4 +39,22 @@ type APITokenAttributes struct {
 	Enabled   bool   `json:"enabled"`
 	UpdatedAt string `json:"updated_at" table:"Updated At"`
 	ExpiresAt string `json:"expires_at" table:"Expires At"`
+	Scopes    string `json:"scopes" table:"Scopes"`
+}
+
+type TokenScopesResponse struct {
+	Resources []TokenScopeResource `json:"resources"`
+	Wildcards []string             `json:"wildcards"`
+}
+
+type TokenScopeResource struct {
+	Name    string   `json:"name"`
+	Actions []string `json:"actions"`
+	ACL     []string `json:"acl"`
+}
+
+type TokenScopeAttributes struct {
+	Resource string `json:"name" table:"Resource"`
+	Actions  string `json:"actions" table:"Actions"`
+	ACL      string `json:"acl" table:"ACL"`
 }

--- a/api/auth/types.go
+++ b/api/auth/types.go
@@ -54,7 +54,7 @@ type TokenScopeResource struct {
 }
 
 type TokenScopeAttributes struct {
-	Resource string `json:"name" table:"Resource"`
-	Actions  string `json:"actions" table:"Actions"`
-	ACL      string `json:"acl" table:"ACL"`
+	Name    string `json:"name" table:"Resource"`
+	Actions string `json:"actions" table:"Actions"`
+	ACL     string `json:"acl" table:"ACL"`
 }

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -13,7 +13,7 @@ var TokenCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon token create', 'alpacon token list', 'alpacon token delete', 'alpacon token duplicate', 'alpacon token acl', or 'alpacon token scopes' to manage API tokens. Run 'alpacon token --help' for more information")
+		return errors.New("a subcommand is required. Run 'alpacon token --help' for more information")
 	},
 }
 

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -13,7 +13,7 @@ var TokenCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon token create', 'alpacon token list', 'alpacon token delete', 'alpacon token duplicate', or 'alpacon token acl' to manage API tokens. Run 'alpacon token --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon token create', 'alpacon token list', 'alpacon token delete', 'alpacon token duplicate', 'alpacon token acl', or 'alpacon token scopes' to manage API tokens. Run 'alpacon token --help' for more information")
 	},
 }
 
@@ -22,6 +22,7 @@ func init() {
 	TokenCmd.AddCommand(tokenListCmd)
 	TokenCmd.AddCommand(tokenDeleteCmd)
 	TokenCmd.AddCommand(tokenDuplicateCmd)
+	TokenCmd.AddCommand(tokenScopesCmd)
 
 	// ACL
 	TokenCmd.AddCommand(AclCmd)

--- a/cmd/token/token_create.go
+++ b/cmd/token/token_create.go
@@ -1,8 +1,6 @@
 package token
 
 import (
-	"strings"
-
 	"github.com/alpacax/alpacon-cli/api/auth"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
@@ -42,13 +40,7 @@ var tokenCreateCmd = &cobra.Command{
 				tokenRequest.ExpiresAt = utils.TimeFormat(expiresAt)
 			}
 
-			if scopesStr != "" {
-				for _, s := range strings.Split(scopesStr, ",") {
-					if trimmed := strings.TrimSpace(s); trimmed != "" {
-						tokenRequest.Scopes = append(tokenRequest.Scopes, trimmed)
-					}
-				}
-			}
+			tokenRequest.Scopes = utils.SplitAndTrim(scopesStr, ",")
 		}
 
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/token/token_create.go
+++ b/cmd/token/token_create.go
@@ -1,6 +1,8 @@
 package token
 
 import (
+	"strings"
+
 	"github.com/alpacax/alpacon-cli/api/auth"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
@@ -11,14 +13,19 @@ var tokenCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new api token",
 	Long: `
-	Generates a new API token for accessing the server. 
-	This command allows you to create a token by specifying options such as token name, expiration, and limits
+	Generates a new API token for accessing the server.
+	This command allows you to create a token by specifying options such as token name, expiration, and scopes.
 	`,
-	Example: `alpacon token create`,
+	Example: `
+	alpacon token create
+	alpacon token create --name ci-token --scopes "server:read,command:create"
+	alpacon token create --name deploy-token --scopes "*"
+	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		name, _ := cmd.Flags().GetString("name")
 		limit, _ := cmd.Flags().GetBool("limit")
 		expiresAt, _ := cmd.Flags().GetInt("expiration-in-days")
+		scopesStr, _ := cmd.Flags().GetString("scopes")
 
 		var tokenRequest auth.APITokenRequest
 		var err error
@@ -33,6 +40,14 @@ var tokenCreateCmd = &cobra.Command{
 
 			if limit && expiresAt > 0 {
 				tokenRequest.ExpiresAt = utils.TimeFormat(expiresAt)
+			}
+
+			if scopesStr != "" {
+				for _, s := range strings.Split(scopesStr, ",") {
+					if trimmed := strings.TrimSpace(s); trimmed != "" {
+						tokenRequest.Scopes = append(tokenRequest.Scopes, trimmed)
+					}
+				}
 			}
 		}
 
@@ -59,6 +74,7 @@ func init() {
 	tokenCreateCmd.Flags().StringVarP(&name, "name", "n", "", "A name to remember the token easily.")
 	tokenCreateCmd.Flags().BoolVarP(&limit, "limit", "l", true, "Set to true to apply usage limits.")
 	tokenCreateCmd.Flags().IntVar(&expiresAt, "expiration-in-days", 0, "This token can be used by the specified time. (in days)")
+	tokenCreateCmd.Flags().String("scopes", "", `Comma-separated list of scopes (e.g. "server:read,command:create"). Omit to default to full access.`)
 }
 
 func promptForToken() (auth.APITokenRequest, error) {
@@ -68,6 +84,10 @@ func promptForToken() (auth.APITokenRequest, error) {
 		tokenRequest.ExpiresAt = utils.TimeFormat(utils.PromptForIntInput("Valid days for the token (default: 30): ", 30))
 	} else {
 		tokenRequest.ExpiresAt = nil
+	}
+	scopes := utils.PromptForListInput("Scopes (comma-separated, default *): ")
+	if len(scopes) > 0 {
+		tokenRequest.Scopes = scopes
 	}
 	return tokenRequest, nil
 }

--- a/cmd/token/token_create.go
+++ b/cmd/token/token_create.go
@@ -9,7 +9,7 @@ import (
 
 var tokenCreateCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create a new api token",
+	Short: "Create a new API token",
 	Long: `
 	Generates a new API token for accessing the server.
 	This command allows you to create a token by specifying options such as token name, expiration, and scopes.

--- a/cmd/token/token_create.go
+++ b/cmd/token/token_create.go
@@ -74,8 +74,6 @@ func promptForToken() (auth.APITokenRequest, error) {
 	tokenRequest.Name = utils.PromptForRequiredInput("Token name: ")
 	if utils.PromptForBool("Set expiration for token?") {
 		tokenRequest.ExpiresAt = utils.TimeFormat(utils.PromptForIntInput("Valid days for the token (default: 30): ", 30))
-	} else {
-		tokenRequest.ExpiresAt = nil
 	}
 	scopes := utils.PromptForListInput("Scopes (comma-separated, default *): ")
 	if len(scopes) > 0 {

--- a/cmd/token/token_scopes.go
+++ b/cmd/token/token_scopes.go
@@ -9,7 +9,7 @@ import (
 
 var tokenScopesCmd = &cobra.Command{
 	Use:   "scopes",
-	Short: "List available scopes for API tokens",
+	Short: "List available scopes for api tokens",
 	Long: `
 	Lists all scope resources and their actions that the current user
 	has RBAC permission to grant when creating an API token.

--- a/cmd/token/token_scopes.go
+++ b/cmd/token/token_scopes.go
@@ -1,0 +1,31 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/auth"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var tokenScopesCmd = &cobra.Command{
+	Use:   "scopes",
+	Short: "List available scopes for API tokens",
+	Long: `
+	Lists all scope resources and their actions that the current user
+	has RBAC permission to grant when creating an API token.
+	`,
+	Example: `alpacon token scopes`,
+	Run: func(cmd *cobra.Command, args []string) {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		scopes, err := auth.GetTokenScopes(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve available scopes: %s.", err)
+		}
+
+		utils.PrintTable(scopes)
+	},
+}

--- a/cmd/token/token_scopes.go
+++ b/cmd/token/token_scopes.go
@@ -26,6 +26,14 @@ var tokenScopesCmd = &cobra.Command{
 			utils.CliErrorWithExit("Failed to retrieve available scopes: %s.", err)
 		}
 
+		if utils.OutputFormat != utils.OutputFormatJSON {
+			for i := range scopes {
+				if scopes[i].Actions == "" {
+					scopes[i].Actions = "(matches all scopes)"
+				}
+			}
+		}
+
 		utils.PrintTable(scopes)
 	},
 }

--- a/cmd/token/token_scopes.go
+++ b/cmd/token/token_scopes.go
@@ -12,7 +12,7 @@ var tokenScopesCmd = &cobra.Command{
 	Short: "List available scopes for api tokens",
 	Long: `
 	Lists all scope resources and their actions that the current user
-	has RBAC permission to grant when creating an API token.
+	has permission to grant when creating an API token.
 	`,
 	Example: `alpacon token scopes`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/token/token_scopes.go
+++ b/cmd/token/token_scopes.go
@@ -9,7 +9,7 @@ import (
 
 var tokenScopesCmd = &cobra.Command{
 	Use:   "scopes",
-	Short: "List available scopes for api tokens",
+	Short: "List available scopes for API tokens",
 	Long: `
 	Lists all scope resources and their actions that the current user
 	has permission to grant when creating an API token.

--- a/utils/prompt.go
+++ b/utils/prompt.go
@@ -113,16 +113,7 @@ func PromptForIntInput(promptText string, defaultValue int) int {
 }
 
 func PromptForListInput(promptText string) []string {
-	inputStr := PromptForInput(promptText)
-	inputList := strings.Split(inputStr, ",")
-	for i, item := range inputList {
-		inputList[i] = strings.TrimSpace(item)
-	}
-	if len(inputList) == 1 && inputList[0] == "" {
-		return []string{}
-	}
-
-	return inputList
+	return SplitAndTrim(PromptForInput(promptText), ",")
 }
 
 func PromptForRequiredListInput(promptText string) []string {

--- a/utils/prompt.go
+++ b/utils/prompt.go
@@ -119,7 +119,7 @@ func PromptForListInput(promptText string) []string {
 func PromptForRequiredListInput(promptText string) []string {
 	for {
 		inputList := PromptForListInput(promptText)
-		if len(inputList) > 0 && inputList[0] != "" {
+		if len(inputList) > 0 {
 			return inputList
 		}
 		CliWarning("This field is required. Please enter a value.")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -481,5 +481,8 @@ func SplitAndTrim(s, sep string) []string {
 			result = append(result, trimmed)
 		}
 	}
+	if len(result) == 0 {
+		return nil
+	}
 	return result
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -467,3 +467,19 @@ func CommandConfirm() bool {
 func IsInteractiveShell() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
+
+// SplitAndTrim splits s by sep, trims whitespace from each element, and drops empty entries.
+// Returns nil when the input is empty or yields no non-empty elements.
+func SplitAndTrim(s, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, sep)
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
Closes #144

## Summary

Adds scoped API-token support to the CLI so callers can mint least-privilege tokens for CI/CD and agents:

- `alpacon token create --scopes "server:read,command:create"` (wildcards `*`, `server:*`, `*:read` supported)
- `alpacon token ls` now includes a `Scopes` column
- New `alpacon token scopes` subcommand enumerates the scope resources, actions, and ACLs the current user is allowed to grant

## Changes

- `api/auth`
  - `APITokenRequest.Scopes` with `omitempty` (legacy callers unchanged on the wire)
  - `APITokenResponse.Scopes`, projected into `APITokenAttributes.Scopes` for table output
  - New `TokenScopesResponse` / `TokenScopeResource` / `TokenScopeAttributes`
  - New `GetTokenScopes()` hitting `/api/auth/tokens/scopes/`
- `cmd/token`
  - `token create --scopes` flag + interactive prompt (empty input falls back to server-side `*` default)
  - New `token scopes` subcommand
- `utils`
  - Extracted `SplitAndTrim` and reused it from `PromptForListInput`

## Presentation notes

Wildcard rows come back from the API layer with empty `Actions`. The table renderer in `token scopes` fills in `(matches all scopes)` only for table output, so `--output json` stays free of human-readable strings.

## Stack

golang

## Impact

- Depends on the server exposing `/api/auth/tokens/scopes/` and accepting `scopes` on `POST /api/auth/tokens/`. Older self-hosted servers will get an error from `token scopes`; `token create` without `--scopes` keeps working (field is `omitempty`).

## Checklist

- [x] Code follows project style guidelines (golangci-lint v2 clean)
- [x] Self-reviewed the code
- [x] No print/log debug statements left
- [x] No hardcoded secrets or credentials
- [x] Error handling is complete on every new code path
- [x] Tests cover edge cases: scopes omitempty on create, Scopes column population, wildcards + empty ACL in token scopes

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`
- [ ] Against staging: `alpacon token create --name ci-token --scopes "server:read,command:create"` and confirm the issued token can hit only those endpoints
- [ ] Against staging: `alpacon token create --name full --scopes "*"` issues a full-access token
- [ ] `alpacon token create` (interactive, empty scopes) falls back to server default
- [ ] `alpacon token ls` shows the new `Scopes` column
- [ ] `alpacon token scopes` lists wildcards + resources; `--output json` emits empty `actions` for wildcard rows