### PR TITLE
feat(token/acl): extend token ACL with server, file, and command subcommand groups

### DIFF
--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -159,6 +159,13 @@ func GetAPITokenIDByName(ac *client.AlpaconClient, tokenName string) (string, er
 	return response.Results[0].ID, nil
 }
 
+func ResolveTokenID(ac *client.AlpaconClient, nameOrID string) (string, error) {
+	if utils.IsUUID(nameOrID) {
+		return nameOrID, nil
+	}
+	return GetAPITokenIDByName(ac, nameOrID)
+}
+
 func DeleteAPIToken(ac *client.AlpaconClient, tokenID string) error {
 	_, err := ac.SendDeleteRequest(utils.BuildURL(tokenURL, tokenID, nil))
 	if err != nil {

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -127,6 +127,63 @@ func TestGetAPITokenIDByName(t *testing.T) {
 	}
 }
 
+func TestResolveTokenID(t *testing.T) {
+	const (
+		validUUID = "550e8400-e29b-41d4-a716-446655440000"
+		tokenName = "ci-token"
+		tokenID   = "token-uuid-abc"
+	)
+
+	tests := []struct {
+		name      string
+		input     string
+		count     int
+		wantID    string
+		wantHTTP  bool
+		wantErr   bool
+	}{
+		{"uuid fast-path — no HTTP request", validUUID, 0, validUUID, false, false},
+		{"name found", tokenName, 1, tokenID, true, false},
+		{"name not found", "ghost-token", 0, "", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var httpCalled bool
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				httpCalled = true
+				var results []APITokenResponse
+				if tt.count > 0 {
+					results = append(results, APITokenResponse{ID: tt.wantID, Name: tt.input})
+				}
+				resp := api.ListResponse[APITokenResponse]{Count: tt.count, Results: results}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			id, err := ResolveTokenID(ac, tt.input)
+
+			if tt.wantHTTP != httpCalled {
+				t.Errorf("HTTP called = %v, want %v", httpCalled, tt.wantHTTP)
+			}
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if id != tt.wantID {
+					t.Errorf("expected id %q, got %q", tt.wantID, id)
+				}
+			}
+		})
+	}
+}
+
 func TestCreateAPIToken(t *testing.T) {
 	const wantKey = "secret-api-key-xyz"
 

--- a/api/security/security.go
+++ b/api/security/security.go
@@ -75,3 +75,18 @@ func DeleteServerAcl(ac *client.AlpaconClient, serverAclID string) error {
 	_, err := ac.SendDeleteRequest(utils.BuildURL(serverAclURL, serverAclID, nil))
 	return err
 }
+
+func GetFileAclList(ac *client.AlpaconClient, tokenID string) ([]FileAclResponse, error) {
+	params := map[string]string{"token": tokenID}
+	return api.FetchAllPages[FileAclResponse](ac, fileAclURL, params)
+}
+
+func AddFileAcl(ac *client.AlpaconClient, request FileAclRequest) error {
+	_, err := ac.SendPostRequest(fileAclURL, request)
+	return err
+}
+
+func DeleteFileAcl(ac *client.AlpaconClient, fileAclID string) error {
+	_, err := ac.SendDeleteRequest(utils.BuildURL(fileAclURL, fileAclID, nil))
+	return err
+}

--- a/api/security/security.go
+++ b/api/security/security.go
@@ -23,20 +23,12 @@ func GetCommandAclList(ac *client.AlpaconClient, tokenId string) ([]CommandAclRe
 
 func AddCommandAcl(ac *client.AlpaconClient, request CommandAclRequest) error {
 	_, err := ac.SendPostRequest(commandAclURL, request)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func DeleteCommandAcl(ac *client.AlpaconClient, commandAclId string) error {
 	_, err := ac.SendDeleteRequest(utils.BuildURL(commandAclURL, commandAclId, nil))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func GetServerAclList(ac *client.AlpaconClient, tokenID string) ([]ServerAclAttributes, error) {
@@ -66,7 +58,7 @@ func BulkAddServerAcl(ac *client.AlpaconClient, request ServerAclBulkRequest) er
 	return err
 }
 
-func BulkDeleteServerAcl(ac *client.AlpaconClient, request ServerAclBulkDeleteRequest) error {
+func BulkDeleteServerAcl(ac *client.AlpaconClient, request ServerAclBulkRequest) error {
 	_, err := ac.SendPostRequest(serverAclBulkDelURL, request)
 	return err
 }

--- a/api/security/security.go
+++ b/api/security/security.go
@@ -14,9 +14,9 @@ const (
 	fileAclURL          = "/api/security/file-acl/"
 )
 
-func GetCommandAclList(ac *client.AlpaconClient, tokenId string) ([]CommandAclResponse, error) {
+func GetCommandAclList(ac *client.AlpaconClient, tokenID string) ([]CommandAclResponse, error) {
 	params := map[string]string{
-		"token": tokenId,
+		"token": tokenID,
 	}
 	return api.FetchAllPages[CommandAclResponse](ac, commandAclURL, params)
 }

--- a/api/security/security.go
+++ b/api/security/security.go
@@ -7,7 +7,11 @@ import (
 )
 
 const (
-	commandAclURL = "/api/security/command-acl/"
+	commandAclURL       = "/api/security/command-acl/"
+	serverAclURL        = "/api/security/server-acl/"
+	serverAclBulkURL    = "/api/security/server-acl/bulk/"
+	serverAclBulkDelURL = "/api/security/server-acl/bulk/delete/"
+	fileAclURL          = "/api/security/file-acl/"
 )
 
 func GetCommandAclList(ac *client.AlpaconClient, tokenId string) ([]CommandAclResponse, error) {
@@ -33,4 +37,41 @@ func DeleteCommandAcl(ac *client.AlpaconClient, commandAclId string) error {
 	}
 
 	return nil
+}
+
+func GetServerAclList(ac *client.AlpaconClient, tokenID string) ([]ServerAclAttributes, error) {
+	params := map[string]string{"token": tokenID}
+	raw, err := api.FetchAllPages[serverAclResponse](ac, serverAclURL, params)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ServerAclAttributes, len(raw))
+	for i, r := range raw {
+		out[i] = ServerAclAttributes{
+			ID:         r.ID,
+			TokenName:  r.TokenName,
+			ServerName: r.Server.Name,
+		}
+	}
+	return out, nil
+}
+
+func AddServerAcl(ac *client.AlpaconClient, request ServerAclRequest) error {
+	_, err := ac.SendPostRequest(serverAclURL, request)
+	return err
+}
+
+func BulkAddServerAcl(ac *client.AlpaconClient, request ServerAclBulkRequest) error {
+	_, err := ac.SendPostRequest(serverAclBulkURL, request)
+	return err
+}
+
+func BulkDeleteServerAcl(ac *client.AlpaconClient, request ServerAclBulkDeleteRequest) error {
+	_, err := ac.SendPostRequest(serverAclBulkDelURL, request)
+	return err
+}
+
+func DeleteServerAcl(ac *client.AlpaconClient, serverAclID string) error {
+	_, err := ac.SendDeleteRequest(utils.BuildURL(serverAclURL, serverAclID, nil))
+	return err
 }

--- a/api/security/security_test.go
+++ b/api/security/security_test.go
@@ -28,7 +28,7 @@ func TestGetCommandAclList_Pagination(t *testing.T) {
 		var results []CommandAclResponse
 		switch page {
 		case "1", "":
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				results = append(results, CommandAclResponse{
 					ID:        fmt.Sprintf("acl-%d", i),
 					TokenName: "my-token",
@@ -36,7 +36,7 @@ func TestGetCommandAclList_Pagination(t *testing.T) {
 				})
 			}
 		case "2":
-			for i := 0; i < 50; i++ {
+			for i := range 50 {
 				results = append(results, CommandAclResponse{
 					ID:        fmt.Sprintf("acl-p2-%d", i),
 					TokenName: "my-token",
@@ -92,7 +92,7 @@ func TestGetServerAclList_Pagination(t *testing.T) {
 		var results []serverAclResponse
 		switch page {
 		case "1", "":
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				results = append(results, serverAclResponse{
 					ID:        fmt.Sprintf("sacl-%d", i),
 					Token:     "token-id-1",
@@ -101,7 +101,7 @@ func TestGetServerAclList_Pagination(t *testing.T) {
 				})
 			}
 		case "2":
-			for i := 0; i < 30; i++ {
+			for i := range 30 {
 				results = append(results, serverAclResponse{
 					ID:        fmt.Sprintf("sacl-p2-%d", i),
 					Token:     "token-id-1",
@@ -143,5 +143,70 @@ func TestGetServerAclList_Pagination(t *testing.T) {
 	}
 	if acls[0].ServerName != "server-0" {
 		t.Errorf("expected server name 'server-0', got %q", acls[0].ServerName)
+	}
+}
+
+func TestGetFileAclList_Pagination(t *testing.T) {
+	var requestCount atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := requestCount.Add(1)
+		if count > 3 {
+			t.Errorf("infinite loop detected: request #%d", count)
+			return
+		}
+
+		page := r.URL.Query().Get("page")
+		var results []FileAclResponse
+		switch page {
+		case "1", "":
+			for i := range 100 {
+				results = append(results, FileAclResponse{
+					ID:        fmt.Sprintf("facl-%d", i),
+					TokenName: "my-token",
+					Path:      fmt.Sprintf("/home/deploy/%d/*", i),
+					Action:    "upload",
+				})
+			}
+		case "2":
+			for i := range 20 {
+				results = append(results, FileAclResponse{
+					ID:        fmt.Sprintf("facl-p2-%d", i),
+					TokenName: "my-token",
+					Path:      "/tmp/*",
+					Action:    "*",
+				})
+			}
+		}
+
+		var next int
+		if page == "1" || page == "" {
+			next = 2
+		}
+		resp := api.ListResponse[FileAclResponse]{
+			Count:   120,
+			Next:    next,
+			Results: results,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}
+
+	acls, err := GetFileAclList(ac, "token-id-1")
+	if err != nil {
+		t.Fatalf("GetFileAclList error: %v", err)
+	}
+
+	if int(requestCount.Load()) != 2 {
+		t.Errorf("expected 2 requests, got %d", requestCount.Load())
+	}
+	if len(acls) != 120 {
+		t.Errorf("expected 120 ACLs, got %d", len(acls))
 	}
 }

--- a/api/security/security_test.go
+++ b/api/security/security_test.go
@@ -30,17 +30,17 @@ func TestGetCommandAclList_Pagination(t *testing.T) {
 		case "1", "":
 			for i := 0; i < 100; i++ {
 				results = append(results, CommandAclResponse{
-					ID:      fmt.Sprintf("acl-%d", i),
-					Token:   "token-id-1",
-					Command: fmt.Sprintf("cmd-%d", i),
+					ID:        fmt.Sprintf("acl-%d", i),
+					TokenName: "my-token",
+					Command:   fmt.Sprintf("cmd-%d", i),
 				})
 			}
 		case "2":
 			for i := 0; i < 50; i++ {
 				results = append(results, CommandAclResponse{
-					ID:      fmt.Sprintf("acl-p2-%d", i),
-					Token:   "token-id-1",
-					Command: fmt.Sprintf("cmd-p2-%d", i),
+					ID:        fmt.Sprintf("acl-p2-%d", i),
+					TokenName: "my-token",
+					Command:   fmt.Sprintf("cmd-p2-%d", i),
 				})
 			}
 		}
@@ -75,5 +75,73 @@ func TestGetCommandAclList_Pagination(t *testing.T) {
 	}
 	if len(acls) != 150 {
 		t.Errorf("expected 150 ACLs, got %d", len(acls))
+	}
+}
+
+func TestGetServerAclList_Pagination(t *testing.T) {
+	var requestCount atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := requestCount.Add(1)
+		if count > 3 {
+			t.Errorf("infinite loop detected: request #%d", count)
+			return
+		}
+
+		page := r.URL.Query().Get("page")
+		var results []serverAclResponse
+		switch page {
+		case "1", "":
+			for i := 0; i < 100; i++ {
+				results = append(results, serverAclResponse{
+					ID:        fmt.Sprintf("sacl-%d", i),
+					Token:     "token-id-1",
+					TokenName: "my-token",
+					Server:    serverAclServer{ID: fmt.Sprintf("srv-%d", i), Name: fmt.Sprintf("server-%d", i)},
+				})
+			}
+		case "2":
+			for i := 0; i < 30; i++ {
+				results = append(results, serverAclResponse{
+					ID:        fmt.Sprintf("sacl-p2-%d", i),
+					Token:     "token-id-1",
+					TokenName: "my-token",
+					Server:    serverAclServer{ID: fmt.Sprintf("srv-p2-%d", i), Name: fmt.Sprintf("server-p2-%d", i)},
+				})
+			}
+		}
+
+		var next int
+		if page == "1" || page == "" {
+			next = 2
+		}
+		resp := api.ListResponse[serverAclResponse]{
+			Count:   130,
+			Next:    next,
+			Results: results,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}
+
+	acls, err := GetServerAclList(ac, "token-id-1")
+	if err != nil {
+		t.Fatalf("GetServerAclList error: %v", err)
+	}
+
+	if int(requestCount.Load()) != 2 {
+		t.Errorf("expected 2 requests, got %d", requestCount.Load())
+	}
+	if len(acls) != 130 {
+		t.Errorf("expected 130 ACLs, got %d", len(acls))
+	}
+	if acls[0].ServerName != "server-0" {
+		t.Errorf("expected server name 'server-0', got %q", acls[0].ServerName)
 	}
 }

--- a/api/security/types.go
+++ b/api/security/types.go
@@ -1,5 +1,11 @@
 package security
 
+const (
+	FileAclActionUpload   = "upload"
+	FileAclActionDownload = "download"
+	FileAclActionAll      = "*"
+)
+
 type CommandAclRequest struct {
 	Token     string `json:"token"`
 	Command   string `json:"command"`
@@ -43,12 +49,6 @@ type ServerAclAttributes struct {
 	TokenName  string `json:"token_name"  table:"Token"`
 	ServerName string `json:"server_name" table:"Server"`
 }
-
-const (
-	FileAclActionUpload   = "upload"
-	FileAclActionDownload = "download"
-	FileAclActionAll      = "*"
-)
 
 type FileAclRequest struct {
 	Token     string `json:"token"`

--- a/api/security/types.go
+++ b/api/security/types.go
@@ -1,13 +1,73 @@
 package security
 
+// ── CommandACL ────────────────────────────────────────────────────────────────
+
 type CommandAclRequest struct {
-	Token   string `json:"token"`
-	Command string `json:"command"`
+	Token     string `json:"token"`
+	Command   string `json:"command"`
+	Username  string `json:"username,omitempty"`
+	Groupname string `json:"groupname,omitempty"`
 }
 
 type CommandAclResponse struct {
-	ID        string `json:"id"`
+	ID        string `json:"id"         table:"ID"`
+	TokenName string `json:"token_name" table:"Token"`
+	Command   string `json:"command"    table:"Command"`
+	Username  string `json:"username"   table:"Username"`
+	Groupname string `json:"groupname"  table:"Groupname"`
+}
+
+// ── ServerACL ─────────────────────────────────────────────────────────────────
+
+type ServerAclRequest struct {
+	Token  string `json:"token"`
+	Server string `json:"server"` // server UUID
+}
+
+type ServerAclBulkRequest struct {
+	Token   string   `json:"token"`
+	Servers []string `json:"servers"` // server UUIDs
+}
+
+type ServerAclBulkDeleteRequest struct {
+	Token   string   `json:"token"`
+	Servers []string `json:"servers"` // server UUIDs
+}
+
+type serverAclServer struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type serverAclResponse struct {
+	ID        string          `json:"id"`
+	Token     string          `json:"token"`
+	TokenName string          `json:"token_name"`
+	Server    serverAclServer `json:"server"`
+}
+
+// ServerAclAttributes is the flat projection used for table output.
+type ServerAclAttributes struct {
+	ID         string `json:"id"          table:"ID"`
+	TokenName  string `json:"token_name"  table:"Token"`
+	ServerName string `json:"server_name" table:"Server"`
+}
+
+// ── FileACL ───────────────────────────────────────────────────────────────────
+
+type FileAclRequest struct {
 	Token     string `json:"token"`
-	TokenName string `json:"token_name"`
-	Command   string `json:"command"`
+	Path      string `json:"path"`
+	Action    string `json:"action"`
+	Username  string `json:"username,omitempty"`
+	Groupname string `json:"groupname,omitempty"`
+}
+
+type FileAclResponse struct {
+	ID        string `json:"id"         table:"ID"`
+	TokenName string `json:"token_name" table:"Token"`
+	Path      string `json:"path"       table:"Path"`
+	Action    string `json:"action"     table:"Action"`
+	Username  string `json:"username"   table:"Username"`
+	Groupname string `json:"groupname"  table:"Groupname"`
 }

--- a/api/security/types.go
+++ b/api/security/types.go
@@ -48,6 +48,14 @@ type ServerAclAttributes struct {
 	ServerName string `json:"server_name" table:"Server"`
 }
 
+// ── FileACL actions ───────────────────────────────────────────────────────────
+
+const (
+	FileAclActionUpload   = "upload"
+	FileAclActionDownload = "download"
+	FileAclActionAll      = "*"
+)
+
 // ── FileACL ───────────────────────────────────────────────────────────────────
 
 type FileAclRequest struct {

--- a/api/security/types.go
+++ b/api/security/types.go
@@ -29,11 +29,6 @@ type ServerAclBulkRequest struct {
 	Servers []string `json:"servers"` // server UUIDs
 }
 
-type ServerAclBulkDeleteRequest struct {
-	Token   string   `json:"token"`
-	Servers []string `json:"servers"` // server UUIDs
-}
-
 type serverAclServer struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/api/security/types.go
+++ b/api/security/types.go
@@ -1,7 +1,5 @@
 package security
 
-// ── CommandACL ────────────────────────────────────────────────────────────────
-
 type CommandAclRequest struct {
 	Token     string `json:"token"`
 	Command   string `json:"command"`
@@ -16,8 +14,6 @@ type CommandAclResponse struct {
 	Username  string `json:"username"   table:"Username"`
 	Groupname string `json:"groupname"  table:"Groupname"`
 }
-
-// ── ServerACL ─────────────────────────────────────────────────────────────────
 
 type ServerAclRequest struct {
 	Token  string `json:"token"`
@@ -48,15 +44,11 @@ type ServerAclAttributes struct {
 	ServerName string `json:"server_name" table:"Server"`
 }
 
-// ── FileACL actions ───────────────────────────────────────────────────────────
-
 const (
 	FileAclActionUpload   = "upload"
 	FileAclActionDownload = "download"
 	FileAclActionAll      = "*"
 )
-
-// ── FileACL ───────────────────────────────────────────────────────────────────
 
 type FileAclRequest struct {
 	Token     string `json:"token"`

--- a/cmd/token/acl.go
+++ b/cmd/token/acl.go
@@ -2,28 +2,34 @@ package token
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 
 var AclCmd = &cobra.Command{
 	Use:   "acl",
-	Short: "Manage command access for API tokens",
-	Long: `Configure access control for API tokens, specifying which server-side shell commands
-each token can execute via websh or exec (e.g., "whoami", "systemctl status *").
+	Short: "Manage access control for API tokens",
+	Long: `Configure fine-grained access control for API tokens.
 
-Create, list, and modify ACL rules to fine-tune command execution permissions.`,
+Three independent ACL types enforce deny-by-default:
+  command  — which shell commands the token can execute via websh/exec
+  server   — which servers the token can access
+  file     — which file paths the token can read/write via cp
+
+If no ACL rule exists for a given type, that access is denied entirely.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := cmd.Help()
-		if err != nil {
-			return err
-		}
-		return errors.New("a subcommand is required. Use 'alpacon token acl list', 'alpacon token acl add', or 'alpacon token acl delete' to manage access control rules. Run 'alpacon token acl --help' for more information")
+		_ = cmd.Help()
+		return errors.New("a subcommand is required. Run 'alpacon token acl --help' for more information")
 	},
 }
 
 func init() {
 	AclCmd.AddCommand(aclCommandCmd)
-	AclCmd.AddCommand(aclListCmd)
+	AclCmd.AddCommand(aclServerCmd)
+	AclCmd.AddCommand(aclFileCmd)
+
+	// Legacy top-level aliases (deprecated, hidden)
 	AclCmd.AddCommand(aclAddCmd)
+	AclCmd.AddCommand(aclListCmd)
 	AclCmd.AddCommand(aclDeleteCmd)
 }

--- a/cmd/token/acl.go
+++ b/cmd/token/acl.go
@@ -22,6 +22,7 @@ Create, list, and modify ACL rules to fine-tune command execution permissions.`,
 }
 
 func init() {
+	AclCmd.AddCommand(aclCommandCmd)
 	AclCmd.AddCommand(aclListCmd)
 	AclCmd.AddCommand(aclAddCmd)
 	AclCmd.AddCommand(aclDeleteCmd)

--- a/cmd/token/acl_add.go
+++ b/cmd/token/acl_add.go
@@ -2,8 +2,6 @@ package token
 
 import "github.com/spf13/cobra"
 
-// aclAddCmd is kept for backward compatibility.
-// Delegates to the same handler as 'acl command add'.
 var aclAddCmd = &cobra.Command{
 	Use:        "add",
 	Short:      "Add a command ACL rule to a token (deprecated: use 'acl command add')",

--- a/cmd/token/acl_add.go
+++ b/cmd/token/acl_add.go
@@ -1,13 +1,20 @@
 package token
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/alpacax/alpacon-cli/api/auth"
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
 
 var aclAddCmd = &cobra.Command{
 	Use:        "add",
 	Short:      "Add a command ACL rule to a token (deprecated: use 'acl command add')",
 	Deprecated: "use 'alpacon token acl command add' instead",
 	Hidden:     true,
-	Run:        runCommandAclAdd,
+	Args:       cobra.RangeArgs(0, 1),
+	Run:        runLegacyAclAdd,
 }
 
 func init() {
@@ -15,4 +22,45 @@ func init() {
 	aclAddCmd.Flags().StringP("command", "c", "", "Server-side shell command (supports * wildcard)")
 	aclAddCmd.Flags().String("username", "", "Username restriction")
 	aclAddCmd.Flags().String("groupname", "", "Groupname restriction")
+}
+
+func runLegacyAclAdd(cmd *cobra.Command, args []string) {
+	tokenFlag, _ := cmd.Flags().GetString("token")
+	var tokenArg string
+	switch {
+	case tokenFlag != "":
+		tokenArg = tokenFlag
+	case len(args) > 0:
+		tokenArg = args[0]
+	default:
+		utils.CliErrorWithExit("token name or ID is required (use --token or positional argument)")
+	}
+
+	command, _ := cmd.Flags().GetString("command")
+	if command == "" {
+		utils.CliErrorWithExit("--command is required")
+	}
+	username, _ := cmd.Flags().GetString("username")
+	groupname, _ := cmd.Flags().GetString("groupname")
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
+	}
+
+	tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to resolve token: %v.", err)
+	}
+
+	if err = security.AddCommandAcl(alpaconClient, security.CommandAclRequest{
+		Token:     tokenID,
+		Command:   command,
+		Username:  username,
+		Groupname: groupname,
+	}); err != nil {
+		utils.CliErrorWithExit("Failed to add the command ACL: %v.", err)
+	}
+
+	utils.CliSuccess("Command ACL added to token %s: %s", tokenArg, command)
 }

--- a/cmd/token/acl_add.go
+++ b/cmd/token/acl_add.go
@@ -1,79 +1,20 @@
 package token
 
-import (
-	"github.com/alpacax/alpacon-cli/api/auth"
-	"github.com/alpacax/alpacon-cli/api/security"
-	"github.com/alpacax/alpacon-cli/client"
-	"github.com/alpacax/alpacon-cli/utils"
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
+// aclAddCmd is kept for backward compatibility.
+// Delegates to the same handler as 'acl command add'.
 var aclAddCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Add a command ACL rule to a token",
-	Long: `Define which server-side shell commands an API token is allowed to execute
-via websh or exec (e.g., "whoami", "systemctl status *", "docker compose *").
-
-Use * as a wildcard to match any arguments. Without a wildcard, only the exact
-command string is matched.`,
-	Example: `  # Server-side command ACL: allow executing "whoami" on remote servers via websh/exec
-  alpacon token acl add --token=my-api-token --command="whoami"
-
-  # Wildcard: allow "echo" with any arguments (matches "echo hello", "echo foo bar", etc.)
-  alpacon token acl add --token=my-api-token --command="echo *"
-
-  # Wildcard: allow "systemctl status" with any service name
-  alpacon token acl add --token=my-api-token --command="systemctl status *"
-
-  # Interactive mode (prompts for token and command)
-  alpacon token acl add`,
-	Run: func(cmd *cobra.Command, args []string) {
-		token, _ := cmd.Flags().GetString("token")
-		command, _ := cmd.Flags().GetString("command")
-
-		var commandAclRequest security.CommandAclRequest
-		if token == "" || command == "" {
-			commandAclRequest = promptForAcl()
-		} else {
-			commandAclRequest = security.CommandAclRequest{
-				Token:   token,
-				Command: command,
-			}
-		}
-
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		if !utils.IsUUID(commandAclRequest.Token) {
-			commandAclRequest.Token, err = auth.GetAPITokenIDByName(alpaconClient, commandAclRequest.Token)
-			if err != nil {
-				utils.CliErrorWithExit("Failed to add the command ACL to token: %v.", err)
-			}
-		}
-
-		err = security.AddCommandAcl(alpaconClient, commandAclRequest)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to add the command ACL to token: %v.", err)
-		}
-
-		utils.CliSuccess("Command ACL added to token %s: %s", token, command)
-	},
+	Use:        "add",
+	Short:      "Add a command ACL rule to a token (deprecated: use 'acl command add')",
+	Deprecated: "use 'alpacon token acl command add' instead",
+	Hidden:     true,
+	Run:        runCommandAclAdd,
 }
 
 func init() {
-	var token, command string
-
-	aclAddCmd.Flags().StringVarP(&token, "token", "t", "", "Token ID")
-	aclAddCmd.Flags().StringVarP(&command, "command", "c", "", "Server-side shell command (supports * wildcard)")
-}
-
-func promptForAcl() security.CommandAclRequest {
-	var commandAclRequest security.CommandAclRequest
-
-	commandAclRequest.Token = utils.PromptForRequiredInput("Token ID or name: ")
-	commandAclRequest.Command = utils.PromptForRequiredInput("Command: ")
-
-	return commandAclRequest
+	aclAddCmd.Flags().StringP("token", "t", "", "Token name or ID")
+	aclAddCmd.Flags().StringP("command", "c", "", "Server-side shell command (supports * wildcard)")
+	aclAddCmd.Flags().String("username", "", "Username restriction")
+	aclAddCmd.Flags().String("groupname", "", "Groupname restriction")
 }

--- a/cmd/token/acl_command.go
+++ b/cmd/token/acl_command.go
@@ -1,0 +1,27 @@
+package token
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var aclCommandCmd = &cobra.Command{
+	Use:   "command",
+	Short: "Manage command ACL rules for a token",
+	Long: `Configure which server-side shell commands an API token is allowed to execute
+via websh or exec (e.g., "whoami", "systemctl status *", "docker compose *").`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := cmd.Help()
+		if err != nil {
+			return err
+		}
+		return errors.New("a subcommand is required. Use 'alpacon token acl command add', 'alpacon token acl command ls', or 'alpacon token acl command delete'. Run 'alpacon token acl command --help' for more information")
+	},
+}
+
+func init() {
+	aclCommandCmd.AddCommand(aclCommandAddCmd)
+	aclCommandCmd.AddCommand(aclCommandListCmd)
+	aclCommandCmd.AddCommand(aclCommandDeleteCmd)
+}

--- a/cmd/token/acl_command.go
+++ b/cmd/token/acl_command.go
@@ -12,11 +12,8 @@ var aclCommandCmd = &cobra.Command{
 	Long: `Configure which server-side shell commands an API token is allowed to execute
 via websh or exec (e.g., "whoami", "systemctl status *", "docker compose *").`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := cmd.Help()
-		if err != nil {
-			return err
-		}
-		return errors.New("a subcommand is required. Use 'alpacon token acl command add', 'alpacon token acl command ls', or 'alpacon token acl command delete'. Run 'alpacon token acl command --help' for more information")
+		_ = cmd.Help()
+		return errors.New("a subcommand is required")
 	},
 }
 

--- a/cmd/token/acl_command_add.go
+++ b/cmd/token/acl_command_add.go
@@ -41,7 +41,7 @@ func runCommandAclAdd(cmd *cobra.Command, args []string) {
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
 	}
 
 	tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)

--- a/cmd/token/acl_command_add.go
+++ b/cmd/token/acl_command_add.go
@@ -55,11 +55,9 @@ func runCommandAclAdd(cmd *cobra.Command, _ []string) {
 		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 	}
 
-	if !utils.IsUUID(req.Token) {
-		req.Token, err = auth.GetAPITokenIDByName(alpaconClient, req.Token)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to add the command ACL: %v.", err)
-		}
+	req.Token, err = auth.ResolveTokenID(alpaconClient, req.Token)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to add the command ACL: %v.", err)
 	}
 
 	if err = security.AddCommandAcl(alpaconClient, req); err != nil {

--- a/cmd/token/acl_command_add.go
+++ b/cmd/token/acl_command_add.go
@@ -1,0 +1,77 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/auth"
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var aclCommandAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a command ACL rule to a token",
+	Long: `Define which server-side shell commands an API token is allowed to execute
+via websh or exec (e.g., "whoami", "systemctl status *", "docker compose *").
+
+Use * as a wildcard to match any arguments. Without a wildcard, only the exact
+command string is matched.
+
+Username semantics: "" = token owner only, "*" = any user, exact name = match only.
+Groupname semantics: "" = no group restriction, "*" = any group, exact name = match only.`,
+	Example: `  alpacon token acl command add --token=my-api-token --command="whoami"
+  alpacon token acl command add --token=my-api-token --command="docker *" --username=root
+  alpacon token acl command add --token=my-api-token --command="systemctl status *" --username="*" --groupname="*"`,
+	Run: runCommandAclAdd,
+}
+
+func init() {
+	aclCommandAddCmd.Flags().StringP("token", "t", "", "Token name or ID")
+	aclCommandAddCmd.Flags().StringP("command", "c", "", "Server-side shell command (supports * wildcard)")
+	aclCommandAddCmd.Flags().String("username", "", `Username restriction: "" = token owner only, "*" = any user`)
+	aclCommandAddCmd.Flags().String("groupname", "", `Groupname restriction: "" = no restriction, "*" = any group`)
+}
+
+func runCommandAclAdd(cmd *cobra.Command, _ []string) {
+	token, _ := cmd.Flags().GetString("token")
+	command, _ := cmd.Flags().GetString("command")
+	username, _ := cmd.Flags().GetString("username")
+	groupname, _ := cmd.Flags().GetString("groupname")
+
+	var req security.CommandAclRequest
+	if token == "" || command == "" {
+		req = promptForCommandAcl()
+	} else {
+		req = security.CommandAclRequest{
+			Token:     token,
+			Command:   command,
+			Username:  username,
+			Groupname: groupname,
+		}
+	}
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	if !utils.IsUUID(req.Token) {
+		req.Token, err = auth.GetAPITokenIDByName(alpaconClient, req.Token)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to add the command ACL: %v.", err)
+		}
+	}
+
+	if err = security.AddCommandAcl(alpaconClient, req); err != nil {
+		utils.CliErrorWithExit("Failed to add the command ACL: %v.", err)
+	}
+
+	utils.CliSuccess("Command ACL added to token %s: %s", req.Token, req.Command)
+}
+
+func promptForCommandAcl() security.CommandAclRequest {
+	return security.CommandAclRequest{
+		Token:   utils.PromptForRequiredInput("Token ID or name: "),
+		Command: utils.PromptForRequiredInput("Command: "),
+	}
+}

--- a/cmd/token/acl_command_add.go
+++ b/cmd/token/acl_command_add.go
@@ -9,7 +9,7 @@ import (
 )
 
 var aclCommandAddCmd = &cobra.Command{
-	Use:   "add",
+	Use:   "add TOKEN",
 	Short: "Add a command ACL rule to a token",
 	Long: `Define which server-side shell commands an API token is allowed to execute
 via websh or exec (e.g., "whoami", "systemctl status *", "docker compose *").
@@ -19,35 +19,27 @@ command string is matched.
 
 Username semantics: "" = token owner only, "*" = any user, exact name = match only.
 Groupname semantics: "" = no group restriction, "*" = any group, exact name = match only.`,
-	Example: `  alpacon token acl command add --token=my-api-token --command="whoami"
-  alpacon token acl command add --token=my-api-token --command="docker *" --username=root
-  alpacon token acl command add --token=my-api-token --command="systemctl status *" --username="*" --groupname="*"`,
-	Run: runCommandAclAdd,
+	Example: `  alpacon token acl command add my-api-token --command="whoami"
+  alpacon token acl command add my-api-token --command="docker *" --username=root
+  alpacon token acl command add my-api-token --command="systemctl status *" --username="*" --groupname="*"`,
+	Args: cobra.ExactArgs(1),
+	Run:  runCommandAclAdd,
 }
 
 func init() {
-	aclCommandAddCmd.Flags().StringP("token", "t", "", "Token name or ID")
 	aclCommandAddCmd.Flags().StringP("command", "c", "", "Server-side shell command (supports * wildcard)")
 	aclCommandAddCmd.Flags().String("username", "", `Username restriction: "" = token owner only, "*" = any user`)
 	aclCommandAddCmd.Flags().String("groupname", "", `Groupname restriction: "" = no restriction, "*" = any group`)
 }
 
-func runCommandAclAdd(cmd *cobra.Command, _ []string) {
-	token, _ := cmd.Flags().GetString("token")
+func runCommandAclAdd(cmd *cobra.Command, args []string) {
+	tokenArg := args[0]
 	command, _ := cmd.Flags().GetString("command")
 	username, _ := cmd.Flags().GetString("username")
 	groupname, _ := cmd.Flags().GetString("groupname")
 
-	var req security.CommandAclRequest
-	if token == "" || command == "" {
-		req = promptForCommandAcl()
-	} else {
-		req = security.CommandAclRequest{
-			Token:     token,
-			Command:   command,
-			Username:  username,
-			Groupname: groupname,
-		}
+	if command == "" {
+		utils.CliErrorWithExit("--command is required.")
 	}
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
@@ -55,22 +47,20 @@ func runCommandAclAdd(cmd *cobra.Command, _ []string) {
 		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 	}
 
-	originalToken := req.Token
-	req.Token, err = auth.ResolveTokenID(alpaconClient, req.Token)
+	tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)
 	if err != nil {
-		utils.CliErrorWithExit("Failed to add the command ACL: %v.", err)
+		utils.CliErrorWithExit("Failed to resolve token: %v.", err)
 	}
 
+	req := security.CommandAclRequest{
+		Token:     tokenID,
+		Command:   command,
+		Username:  username,
+		Groupname: groupname,
+	}
 	if err = security.AddCommandAcl(alpaconClient, req); err != nil {
 		utils.CliErrorWithExit("Failed to add the command ACL: %v.", err)
 	}
 
-	utils.CliSuccess("Command ACL added to token %s: %s", originalToken, req.Command)
-}
-
-func promptForCommandAcl() security.CommandAclRequest {
-	return security.CommandAclRequest{
-		Token:   utils.PromptForRequiredInput("Token ID or name: "),
-		Command: utils.PromptForRequiredInput("Command: "),
-	}
+	utils.CliSuccess("Command ACL added to token %s: %s", tokenArg, command)
 }

--- a/cmd/token/acl_command_add.go
+++ b/cmd/token/acl_command_add.go
@@ -30,6 +30,7 @@ func init() {
 	aclCommandAddCmd.Flags().StringP("command", "c", "", "Server-side shell command (supports * wildcard)")
 	aclCommandAddCmd.Flags().String("username", "", `Username restriction: "" = token owner only, "*" = any user`)
 	aclCommandAddCmd.Flags().String("groupname", "", `Groupname restriction: "" = no restriction, "*" = any group`)
+	_ = aclCommandAddCmd.MarkFlagRequired("command")
 }
 
 func runCommandAclAdd(cmd *cobra.Command, args []string) {
@@ -37,10 +38,6 @@ func runCommandAclAdd(cmd *cobra.Command, args []string) {
 	command, _ := cmd.Flags().GetString("command")
 	username, _ := cmd.Flags().GetString("username")
 	groupname, _ := cmd.Flags().GetString("groupname")
-
-	if command == "" {
-		utils.CliErrorWithExit("--command is required.")
-	}
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {

--- a/cmd/token/acl_command_add.go
+++ b/cmd/token/acl_command_add.go
@@ -55,6 +55,7 @@ func runCommandAclAdd(cmd *cobra.Command, _ []string) {
 		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 	}
 
+	originalToken := req.Token
 	req.Token, err = auth.ResolveTokenID(alpaconClient, req.Token)
 	if err != nil {
 		utils.CliErrorWithExit("Failed to add the command ACL: %v.", err)
@@ -64,7 +65,7 @@ func runCommandAclAdd(cmd *cobra.Command, _ []string) {
 		utils.CliErrorWithExit("Failed to add the command ACL: %v.", err)
 	}
 
-	utils.CliSuccess("Command ACL added to token %s: %s", req.Token, req.Command)
+	utils.CliSuccess("Command ACL added to token %s: %s", originalToken, req.Command)
 }
 
 func promptForCommandAcl() security.CommandAclRequest {

--- a/cmd/token/acl_command_delete.go
+++ b/cmd/token/acl_command_delete.go
@@ -35,7 +35,7 @@ func runCommandAclDelete(cmd *cobra.Command, args []string) {
 	}
 
 	if err = security.DeleteCommandAcl(alpaconClient, aclID); err != nil {
-		utils.CliErrorWithExit("Failed to delete command ACL: %s.", err)
+		utils.CliErrorWithExit("Failed to delete command ACL: %v.", err)
 	}
 
 	utils.CliSuccess("Command ACL deleted: %s", aclID)

--- a/cmd/token/acl_command_delete.go
+++ b/cmd/token/acl_command_delete.go
@@ -31,7 +31,7 @@ func runCommandAclDelete(cmd *cobra.Command, args []string) {
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
 	}
 
 	if err = security.DeleteCommandAcl(alpaconClient, aclID); err != nil {

--- a/cmd/token/acl_command_delete.go
+++ b/cmd/token/acl_command_delete.go
@@ -1,0 +1,42 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var aclCommandDeleteCmd = &cobra.Command{
+	Use:     "delete ACL-ID",
+	Aliases: []string{"rm"},
+	Short:   "Delete a command ACL rule by ID",
+	Example: `  alpacon token acl command delete 550e8400-e29b-41d4-a716-446655440000
+  alpacon token acl command rm 550e8400-e29b-41d4-a716-446655440000`,
+	Args: cobra.ExactArgs(1),
+	Run:  runCommandAclDelete,
+}
+
+func init() {
+	aclCommandDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+}
+
+func runCommandAclDelete(cmd *cobra.Command, args []string) {
+	aclID := args[0]
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	if !yes {
+		utils.ConfirmAction("Delete command ACL '%s'?", aclID)
+	}
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	if err = security.DeleteCommandAcl(alpaconClient, aclID); err != nil {
+		utils.CliErrorWithExit("Failed to delete command ACL: %s.", err)
+	}
+
+	utils.CliSuccess("Command ACL deleted: %s", aclID)
+}

--- a/cmd/token/acl_command_list.go
+++ b/cmd/token/acl_command_list.go
@@ -23,7 +23,7 @@ func runCommandAclList(_ *cobra.Command, args []string) {
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
 	}
 
 	tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)

--- a/cmd/token/acl_command_list.go
+++ b/cmd/token/acl_command_list.go
@@ -1,0 +1,42 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/auth"
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var aclCommandListCmd = &cobra.Command{
+	Use:     "ls TOKEN",
+	Aliases: []string{"list"},
+	Short:   "List command ACL rules for a token",
+	Example: `  alpacon token acl command ls my-api-token
+  alpacon token acl command list my-api-token`,
+	Args: cobra.ExactArgs(1),
+	Run:  runCommandAclList,
+}
+
+func runCommandAclList(_ *cobra.Command, args []string) {
+	tokenID := args[0]
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	if !utils.IsUUID(tokenID) {
+		tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenID)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve command ACLs: %s.", err)
+		}
+	}
+
+	acls, err := security.GetCommandAclList(alpaconClient, tokenID)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to retrieve command ACLs: %s.", err)
+	}
+
+	utils.PrintTable(acls)
+}

--- a/cmd/token/acl_command_list.go
+++ b/cmd/token/acl_command_list.go
@@ -28,12 +28,12 @@ func runCommandAclList(_ *cobra.Command, args []string) {
 
 	tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
 	if err != nil {
-		utils.CliErrorWithExit("Failed to retrieve command ACLs: %s.", err)
+		utils.CliErrorWithExit("Failed to resolve token: %v.", err)
 	}
 
 	acls, err := security.GetCommandAclList(alpaconClient, tokenID)
 	if err != nil {
-		utils.CliErrorWithExit("Failed to retrieve command ACLs: %s.", err)
+		utils.CliErrorWithExit("Failed to retrieve command ACLs: %v.", err)
 	}
 
 	utils.PrintTable(acls)

--- a/cmd/token/acl_command_list.go
+++ b/cmd/token/acl_command_list.go
@@ -26,11 +26,9 @@ func runCommandAclList(_ *cobra.Command, args []string) {
 		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 	}
 
-	if !utils.IsUUID(tokenID) {
-		tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenID)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve command ACLs: %s.", err)
-		}
+	tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to retrieve command ACLs: %s.", err)
 	}
 
 	acls, err := security.GetCommandAclList(alpaconClient, tokenID)

--- a/cmd/token/acl_delete.go
+++ b/cmd/token/acl_delete.go
@@ -2,8 +2,6 @@ package token
 
 import "github.com/spf13/cobra"
 
-// aclDeleteCmd is kept for backward compatibility.
-// Delegates to the same handler as 'acl command delete'.
 var aclDeleteCmd = &cobra.Command{
 	Use:        "delete ACL-ID",
 	Aliases:    []string{"rm"},

--- a/cmd/token/acl_delete.go
+++ b/cmd/token/acl_delete.go
@@ -1,45 +1,17 @@
 package token
 
-import (
-	"github.com/alpacax/alpacon-cli/api/security"
-	"github.com/alpacax/alpacon-cli/client"
-	"github.com/alpacax/alpacon-cli/utils"
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
+// aclDeleteCmd is kept for backward compatibility.
+// Delegates to the same handler as 'acl command delete'.
 var aclDeleteCmd = &cobra.Command{
-	Use:     "delete",
-	Aliases: []string{"rm"},
-	Short:   "Delete the specified command ACL from an API token",
-	Long: `
-	Removes an existing command ACL from the API token.
-	This command requires the command ACL ID to identify the command ACL to be deleted.
-	`,
-	Example: `
-	alpacon token acl delete 550e8400-e29b-41d4-a716-446655440000
-	alpacon token acl rm 550e8400-e29b-41d4-a716-446655440000
-	`,
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		commandAclId := args[0]
-
-		yes, _ := cmd.Flags().GetBool("yes")
-		if !yes {
-			utils.ConfirmAction("Delete command ACL '%s'?", commandAclId)
-		}
-
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		err = security.DeleteCommandAcl(alpaconClient, commandAclId)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to delete the command acl: %s.", err)
-		}
-
-		utils.CliSuccess("Command ACL deleted: %s", commandAclId)
-	},
+	Use:        "delete ACL-ID",
+	Aliases:    []string{"rm"},
+	Short:      "Delete a command ACL rule (deprecated: use 'acl command delete')",
+	Deprecated: "use 'alpacon token acl command delete' instead",
+	Hidden:     true,
+	Args:       cobra.ExactArgs(1),
+	Run:        runCommandAclDelete,
 }
 
 func init() {

--- a/cmd/token/acl_file.go
+++ b/cmd/token/acl_file.go
@@ -1,0 +1,25 @@
+package token
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var aclFileCmd = &cobra.Command{
+	Use:   "file",
+	Short: "Manage file ACL rules for a token",
+	Long: `Control which file paths an API token can access via cp.
+
+Deny-by-default: if no file ACL exists for a token, all file transfers are denied.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_ = cmd.Help()
+		return errors.New("a subcommand is required")
+	},
+}
+
+func init() {
+	aclFileCmd.AddCommand(aclFileAddCmd)
+	aclFileCmd.AddCommand(aclFileListCmd)
+	aclFileCmd.AddCommand(aclFileDeleteCmd)
+}

--- a/cmd/token/acl_file_add.go
+++ b/cmd/token/acl_file_add.go
@@ -47,7 +47,7 @@ func runFileAclAdd(cmd *cobra.Command, args []string) {
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
 	}
 
 	tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)

--- a/cmd/token/acl_file_add.go
+++ b/cmd/token/acl_file_add.go
@@ -22,42 +22,7 @@ Groupname semantics: "" = no group restriction, "*" = any group, exact name = ma
   alpacon token acl file add my-api-token --path "/var/log/*" --action download --username root
   alpacon token acl file add my-api-token --path "*" --action "*" --username "*" --groupname "*"`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		tokenArg := args[0]
-		path, _ := cmd.Flags().GetString("path")
-		action, _ := cmd.Flags().GetString("action")
-		username, _ := cmd.Flags().GetString("username")
-		groupname, _ := cmd.Flags().GetString("groupname")
-
-		if path == "" || action == "" {
-			utils.CliErrorWithExit("--path and --action are required.")
-		}
-		if action != security.FileAclActionUpload && action != security.FileAclActionDownload && action != security.FileAclActionAll {
-			utils.CliErrorWithExit("--action must be one of: upload, download, *")
-		}
-
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to resolve token: %v.", err)
-		}
-
-		if err = security.AddFileAcl(alpaconClient, security.FileAclRequest{
-			Token:     tokenID,
-			Path:      path,
-			Action:    action,
-			Username:  username,
-			Groupname: groupname,
-		}); err != nil {
-			utils.CliErrorWithExit("Failed to add file ACL: %v.", err)
-		}
-
-		utils.CliSuccess("File ACL added to token %s: %s [%s]", tokenArg, path, action)
-	},
+	Run:  runFileAclAdd,
 }
 
 func init() {
@@ -65,4 +30,41 @@ func init() {
 	aclFileAddCmd.Flags().String("action", "", "Allowed action: upload, download, or *")
 	aclFileAddCmd.Flags().String("username", "", `Username restriction: "" = token owner only, "*" = any user`)
 	aclFileAddCmd.Flags().String("groupname", "", `Groupname restriction: "" = no restriction, "*" = any group`)
+}
+
+func runFileAclAdd(cmd *cobra.Command, args []string) {
+	tokenArg := args[0]
+	path, _ := cmd.Flags().GetString("path")
+	action, _ := cmd.Flags().GetString("action")
+	username, _ := cmd.Flags().GetString("username")
+	groupname, _ := cmd.Flags().GetString("groupname")
+
+	if path == "" || action == "" {
+		utils.CliErrorWithExit("--path and --action are required.")
+	}
+	if action != security.FileAclActionUpload && action != security.FileAclActionDownload && action != security.FileAclActionAll {
+		utils.CliErrorWithExit("--action must be one of: upload, download, *")
+	}
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to resolve token: %v.", err)
+	}
+
+	if err = security.AddFileAcl(alpaconClient, security.FileAclRequest{
+		Token:     tokenID,
+		Path:      path,
+		Action:    action,
+		Username:  username,
+		Groupname: groupname,
+	}); err != nil {
+		utils.CliErrorWithExit("Failed to add file ACL: %v.", err)
+	}
+
+	utils.CliSuccess("File ACL added to token %s: %s [%s]", tokenArg, path, action)
 }

--- a/cmd/token/acl_file_add.go
+++ b/cmd/token/acl_file_add.go
@@ -32,7 +32,7 @@ Groupname semantics: "" = no group restriction, "*" = any group, exact name = ma
 		if path == "" || action == "" {
 			utils.CliErrorWithExit("--path and --action are required.")
 		}
-		if action != "upload" && action != "download" && action != "*" {
+		if action != security.FileAclActionUpload && action != security.FileAclActionDownload && action != security.FileAclActionAll {
 			utils.CliErrorWithExit("--action must be one of: upload, download, *")
 		}
 

--- a/cmd/token/acl_file_add.go
+++ b/cmd/token/acl_file_add.go
@@ -1,0 +1,71 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/auth"
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var aclFileAddCmd = &cobra.Command{
+	Use:   "add TOKEN",
+	Short: "Add a file ACL rule to a token",
+	Long: `Define which file paths an API token is allowed to access via cp.
+
+Path supports wildcard matching (* = any characters).
+Action: upload, download, or * for both.
+
+Username semantics: "" = token owner only, "*" = any user, exact name = match only.
+Groupname semantics: "" = no group restriction, "*" = any group, exact name = match only.`,
+	Example: `  alpacon token acl file add my-api-token --path "/home/deploy/*" --action upload
+  alpacon token acl file add my-api-token --path "/var/log/*" --action download --username root
+  alpacon token acl file add my-api-token --path "*" --action "*" --username "*" --groupname "*"`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		tokenArg := args[0]
+		path, _ := cmd.Flags().GetString("path")
+		action, _ := cmd.Flags().GetString("action")
+		username, _ := cmd.Flags().GetString("username")
+		groupname, _ := cmd.Flags().GetString("groupname")
+
+		if path == "" || action == "" {
+			utils.CliErrorWithExit("--path and --action are required.")
+		}
+		if action != "upload" && action != "download" && action != "*" {
+			utils.CliErrorWithExit("--action must be one of: upload, download, *")
+		}
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		tokenID := tokenArg
+		if !utils.IsUUID(tokenID) {
+			tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenArg)
+			if err != nil {
+				utils.CliErrorWithExit("Failed to resolve token: %v.", err)
+			}
+		}
+
+		if err = security.AddFileAcl(alpaconClient, security.FileAclRequest{
+			Token:     tokenID,
+			Path:      path,
+			Action:    action,
+			Username:  username,
+			Groupname: groupname,
+		}); err != nil {
+			utils.CliErrorWithExit("Failed to add file ACL: %v.", err)
+		}
+
+		utils.CliSuccess("File ACL added to token %s: %s [%s]", tokenArg, path, action)
+	},
+}
+
+func init() {
+	aclFileAddCmd.Flags().String("path", "", "File path pattern (supports * wildcard)")
+	aclFileAddCmd.Flags().String("action", "", "Allowed action: upload, download, or *")
+	aclFileAddCmd.Flags().String("username", "", `Username restriction: "" = token owner only, "*" = any user`)
+	aclFileAddCmd.Flags().String("groupname", "", `Groupname restriction: "" = no restriction, "*" = any group`)
+}

--- a/cmd/token/acl_file_add.go
+++ b/cmd/token/acl_file_add.go
@@ -41,12 +41,9 @@ Groupname semantics: "" = no group restriction, "*" = any group, exact name = ma
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		tokenID := tokenArg
-		if !utils.IsUUID(tokenID) {
-			tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenArg)
-			if err != nil {
-				utils.CliErrorWithExit("Failed to resolve token: %v.", err)
-			}
+		tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to resolve token: %v.", err)
 		}
 
 		if err = security.AddFileAcl(alpaconClient, security.FileAclRequest{

--- a/cmd/token/acl_file_add.go
+++ b/cmd/token/acl_file_add.go
@@ -30,6 +30,8 @@ func init() {
 	aclFileAddCmd.Flags().String("action", "", "Allowed action: upload, download, or *")
 	aclFileAddCmd.Flags().String("username", "", `Username restriction: "" = token owner only, "*" = any user`)
 	aclFileAddCmd.Flags().String("groupname", "", `Groupname restriction: "" = no restriction, "*" = any group`)
+	_ = aclFileAddCmd.MarkFlagRequired("path")
+	_ = aclFileAddCmd.MarkFlagRequired("action")
 }
 
 func runFileAclAdd(cmd *cobra.Command, args []string) {
@@ -39,9 +41,6 @@ func runFileAclAdd(cmd *cobra.Command, args []string) {
 	username, _ := cmd.Flags().GetString("username")
 	groupname, _ := cmd.Flags().GetString("groupname")
 
-	if path == "" || action == "" {
-		utils.CliErrorWithExit("--path and --action are required.")
-	}
 	if action != security.FileAclActionUpload && action != security.FileAclActionDownload && action != security.FileAclActionAll {
 		utils.CliErrorWithExit("--action must be one of: upload, download, *")
 	}

--- a/cmd/token/acl_file_add.go
+++ b/cmd/token/acl_file_add.go
@@ -42,7 +42,7 @@ func runFileAclAdd(cmd *cobra.Command, args []string) {
 	groupname, _ := cmd.Flags().GetString("groupname")
 
 	if action != security.FileAclActionUpload && action != security.FileAclActionDownload && action != security.FileAclActionAll {
-		utils.CliErrorWithExit("--action must be one of: upload, download, *")
+		utils.CliErrorWithExit("--action must be one of: upload, download, *.")
 	}
 
 	alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/token/acl_file_delete.go
+++ b/cmd/token/acl_file_delete.go
@@ -1,0 +1,40 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var aclFileDeleteCmd = &cobra.Command{
+	Use:     "delete ACL-ID",
+	Aliases: []string{"rm"},
+	Short:   "Delete a file ACL rule by ID",
+	Example: `  alpacon token acl file delete 550e8400-e29b-41d4-a716-446655440000
+  alpacon token acl file rm 550e8400-e29b-41d4-a716-446655440000`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		aclID := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		if !yes {
+			utils.ConfirmAction("Delete file ACL '%s'?", aclID)
+		}
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if err = security.DeleteFileAcl(alpaconClient, aclID); err != nil {
+			utils.CliErrorWithExit("Failed to delete file ACL: %s.", err)
+		}
+
+		utils.CliSuccess("File ACL deleted: %s", aclID)
+	},
+}
+
+func init() {
+	aclFileDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+}

--- a/cmd/token/acl_file_delete.go
+++ b/cmd/token/acl_file_delete.go
@@ -28,7 +28,7 @@ var aclFileDeleteCmd = &cobra.Command{
 		}
 
 		if err = security.DeleteFileAcl(alpaconClient, aclID); err != nil {
-			utils.CliErrorWithExit("Failed to delete file ACL: %s.", err)
+			utils.CliErrorWithExit("Failed to delete file ACL: %v.", err)
 		}
 
 		utils.CliSuccess("File ACL deleted: %s", aclID)

--- a/cmd/token/acl_file_delete.go
+++ b/cmd/token/acl_file_delete.go
@@ -31,7 +31,7 @@ func runFileAclDelete(cmd *cobra.Command, args []string) {
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
 	}
 
 	if err = security.DeleteFileAcl(alpaconClient, aclID); err != nil {

--- a/cmd/token/acl_file_delete.go
+++ b/cmd/token/acl_file_delete.go
@@ -14,27 +14,29 @@ var aclFileDeleteCmd = &cobra.Command{
 	Example: `  alpacon token acl file delete 550e8400-e29b-41d4-a716-446655440000
   alpacon token acl file rm 550e8400-e29b-41d4-a716-446655440000`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		aclID := args[0]
-		yes, _ := cmd.Flags().GetBool("yes")
-
-		if !yes {
-			utils.ConfirmAction("Delete file ACL '%s'?", aclID)
-		}
-
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		if err = security.DeleteFileAcl(alpaconClient, aclID); err != nil {
-			utils.CliErrorWithExit("Failed to delete file ACL: %v.", err)
-		}
-
-		utils.CliSuccess("File ACL deleted: %s", aclID)
-	},
+	Run:  runFileAclDelete,
 }
 
 func init() {
 	aclFileDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+}
+
+func runFileAclDelete(cmd *cobra.Command, args []string) {
+	aclID := args[0]
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	if !yes {
+		utils.ConfirmAction("Delete file ACL '%s'?", aclID)
+	}
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	if err = security.DeleteFileAcl(alpaconClient, aclID); err != nil {
+		utils.CliErrorWithExit("Failed to delete file ACL: %v.", err)
+	}
+
+	utils.CliSuccess("File ACL deleted: %s", aclID)
 }

--- a/cmd/token/acl_file_list.go
+++ b/cmd/token/acl_file_list.go
@@ -1,0 +1,40 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/auth"
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var aclFileListCmd = &cobra.Command{
+	Use:     "ls TOKEN",
+	Aliases: []string{"list"},
+	Short:   "List file ACL rules for a token",
+	Example: `  alpacon token acl file ls my-api-token
+  alpacon token acl file list my-api-token`,
+	Args: cobra.ExactArgs(1),
+	Run: func(_ *cobra.Command, args []string) {
+		tokenID := args[0]
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if !utils.IsUUID(tokenID) {
+			tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenID)
+			if err != nil {
+				utils.CliErrorWithExit("Failed to retrieve file ACLs: %s.", err)
+			}
+		}
+
+		acls, err := security.GetFileAclList(alpaconClient, tokenID)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve file ACLs: %s.", err)
+		}
+
+		utils.PrintTable(acls)
+	},
+}

--- a/cmd/token/acl_file_list.go
+++ b/cmd/token/acl_file_list.go
@@ -23,7 +23,7 @@ func runFileAclList(_ *cobra.Command, args []string) {
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
 	}
 
 	tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)

--- a/cmd/token/acl_file_list.go
+++ b/cmd/token/acl_file_list.go
@@ -15,24 +15,26 @@ var aclFileListCmd = &cobra.Command{
 	Example: `  alpacon token acl file ls my-api-token
   alpacon token acl file list my-api-token`,
 	Args: cobra.ExactArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		tokenID := args[0]
+	Run:  runFileAclList,
+}
 
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
+func runFileAclList(_ *cobra.Command, args []string) {
+	tokenID := args[0]
 
-		tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to resolve token: %v.", err)
-		}
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
 
-		acls, err := security.GetFileAclList(alpaconClient, tokenID)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve file ACLs: %v.", err)
-		}
+	tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to resolve token: %v.", err)
+	}
 
-		utils.PrintTable(acls)
-	},
+	acls, err := security.GetFileAclList(alpaconClient, tokenID)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to retrieve file ACLs: %v.", err)
+	}
+
+	utils.PrintTable(acls)
 }

--- a/cmd/token/acl_file_list.go
+++ b/cmd/token/acl_file_list.go
@@ -23,11 +23,9 @@ var aclFileListCmd = &cobra.Command{
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		if !utils.IsUUID(tokenID) {
-			tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenID)
-			if err != nil {
-				utils.CliErrorWithExit("Failed to retrieve file ACLs: %s.", err)
-			}
+		tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve file ACLs: %s.", err)
 		}
 
 		acls, err := security.GetFileAclList(alpaconClient, tokenID)

--- a/cmd/token/acl_file_list.go
+++ b/cmd/token/acl_file_list.go
@@ -25,12 +25,12 @@ var aclFileListCmd = &cobra.Command{
 
 		tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve file ACLs: %s.", err)
+			utils.CliErrorWithExit("Failed to resolve token: %v.", err)
 		}
 
 		acls, err := security.GetFileAclList(alpaconClient, tokenID)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve file ACLs: %s.", err)
+			utils.CliErrorWithExit("Failed to retrieve file ACLs: %v.", err)
 		}
 
 		utils.PrintTable(acls)

--- a/cmd/token/acl_list.go
+++ b/cmd/token/acl_list.go
@@ -2,8 +2,6 @@ package token
 
 import "github.com/spf13/cobra"
 
-// aclListCmd is kept for backward compatibility.
-// Delegates to the same handler as 'acl command ls'.
 var aclListCmd = &cobra.Command{
 	Use:        "ls TOKEN",
 	Aliases:    []string{"list"},

--- a/cmd/token/acl_list.go
+++ b/cmd/token/acl_list.go
@@ -1,46 +1,15 @@
 package token
 
-import (
-	"github.com/alpacax/alpacon-cli/api/auth"
-	"github.com/alpacax/alpacon-cli/api/security"
-	"github.com/alpacax/alpacon-cli/client"
-	"github.com/alpacax/alpacon-cli/utils"
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
+// aclListCmd is kept for backward compatibility.
+// Delegates to the same handler as 'acl command ls'.
 var aclListCmd = &cobra.Command{
-	Use:     "ls",
-	Aliases: []string{"list"},
-	Short:   "Display all command ACLs for an API token",
-	Long: `
-	This command displays all command access control lists (ACLs) registered to an API token. 
-	It shows details such as the token name and the commands associated with each ACL.
-	`,
-	Example: `
-	alpacon token acl ls my-api-token
-	alpacon token acl list my-api-token
-	`,
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		tokenId := args[0]
-
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		if !utils.IsUUID(tokenId) {
-			tokenId, err = auth.GetAPITokenIDByName(alpaconClient, tokenId)
-			if err != nil {
-				utils.CliErrorWithExit("Failed to retrieve the command acl: %s.", err)
-			}
-		}
-
-		commandAcl, err := security.GetCommandAclList(alpaconClient, tokenId)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve the command acl: %s.", err)
-		}
-
-		utils.PrintTable(commandAcl)
-	},
+	Use:        "ls TOKEN",
+	Aliases:    []string{"list"},
+	Short:      "List command ACL rules for a token (deprecated: use 'acl command ls')",
+	Deprecated: "use 'alpacon token acl command ls' instead",
+	Hidden:     true,
+	Args:       cobra.ExactArgs(1),
+	Run:        runCommandAclList,
 }

--- a/cmd/token/acl_server.go
+++ b/cmd/token/acl_server.go
@@ -2,9 +2,42 @@ package token
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 
+	serverapi "github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
+
+func resolveServerIDs(ac *client.AlpaconClient, names []string) []string {
+	serverIDs := make([]string, len(names))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var firstErr error
+
+	for i, name := range names {
+		wg.Add(1)
+		go func(idx int, n string) {
+			defer wg.Done()
+			id, err := serverapi.GetServerIDByName(ac, n)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil && firstErr == nil {
+				firstErr = fmt.Errorf("failed to resolve server '%s': %w", n, err)
+				return
+			}
+			serverIDs[idx] = id
+		}(i, name)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		utils.CliErrorWithExit("%v.", firstErr)
+	}
+	return serverIDs
+}
 
 var aclServerCmd = &cobra.Command{
 	Use:   "server",

--- a/cmd/token/acl_server.go
+++ b/cmd/token/acl_server.go
@@ -1,0 +1,25 @@
+package token
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var aclServerCmd = &cobra.Command{
+	Use:   "server",
+	Short: "Manage server ACL rules for a token",
+	Long: `Control which servers an API token can access.
+
+Deny-by-default: if no server ACL exists for a token, access to all servers is denied.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_ = cmd.Help()
+		return errors.New("a subcommand is required")
+	},
+}
+
+func init() {
+	aclServerCmd.AddCommand(aclServerAddCmd)
+	aclServerCmd.AddCommand(aclServerListCmd)
+	aclServerCmd.AddCommand(aclServerDeleteCmd)
+}

--- a/cmd/token/acl_server.go
+++ b/cmd/token/acl_server.go
@@ -7,11 +7,10 @@ import (
 
 	serverapi "github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/client"
-	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
 
-func resolveServerIDs(ac *client.AlpaconClient, names []string) []string {
+func resolveServerIDs(ac *client.AlpaconClient, names []string) ([]string, error) {
 	serverIDs := make([]string, len(names))
 	var mu sync.Mutex
 	var wg sync.WaitGroup
@@ -24,8 +23,10 @@ func resolveServerIDs(ac *client.AlpaconClient, names []string) []string {
 			id, err := serverapi.GetServerIDByName(ac, n)
 			mu.Lock()
 			defer mu.Unlock()
-			if err != nil && firstErr == nil {
-				firstErr = fmt.Errorf("failed to resolve server '%s': %w", n, err)
+			if err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("failed to resolve server '%s': %w", n, err)
+				}
 				return
 			}
 			serverIDs[idx] = id
@@ -33,10 +34,7 @@ func resolveServerIDs(ac *client.AlpaconClient, names []string) []string {
 	}
 	wg.Wait()
 
-	if firstErr != nil {
-		utils.CliErrorWithExit("%v.", firstErr)
-	}
-	return serverIDs
+	return serverIDs, firstErr
 }
 
 var aclServerCmd = &cobra.Command{

--- a/cmd/token/acl_server.go
+++ b/cmd/token/acl_server.go
@@ -10,6 +10,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var aclServerCmd = &cobra.Command{
+	Use:   "server",
+	Short: "Manage server ACL rules for a token",
+	Long: `Control which servers an API token can access.
+
+Deny-by-default: if no server ACL exists for a token, access to all servers is denied.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_ = cmd.Help()
+		return errors.New("a subcommand is required")
+	},
+}
+
+func init() {
+	aclServerCmd.AddCommand(aclServerAddCmd)
+	aclServerCmd.AddCommand(aclServerListCmd)
+	aclServerCmd.AddCommand(aclServerDeleteCmd)
+}
+
 func resolveServerIDs(ac *client.AlpaconClient, names []string) ([]string, error) {
 	serverIDs := make([]string, len(names))
 	var mu sync.Mutex
@@ -35,22 +53,4 @@ func resolveServerIDs(ac *client.AlpaconClient, names []string) ([]string, error
 	wg.Wait()
 
 	return serverIDs, firstErr
-}
-
-var aclServerCmd = &cobra.Command{
-	Use:   "server",
-	Short: "Manage server ACL rules for a token",
-	Long: `Control which servers an API token can access.
-
-Deny-by-default: if no server ACL exists for a token, access to all servers is denied.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		_ = cmd.Help()
-		return errors.New("a subcommand is required")
-	},
-}
-
-func init() {
-	aclServerCmd.AddCommand(aclServerAddCmd)
-	aclServerCmd.AddCommand(aclServerListCmd)
-	aclServerCmd.AddCommand(aclServerDeleteCmd)
 }

--- a/cmd/token/acl_server_add.go
+++ b/cmd/token/acl_server_add.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/alpacax/alpacon-cli/api/auth"
-	serverapi "github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/api/security"
+	serverapi "github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"

--- a/cmd/token/acl_server_add.go
+++ b/cmd/token/acl_server_add.go
@@ -1,0 +1,91 @@
+package token
+
+import (
+	"fmt"
+
+	"github.com/alpacax/alpacon-cli/api/auth"
+	serverapi "github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var aclServerAddCmd = &cobra.Command{
+	Use:   "add TOKEN",
+	Short: "Grant a token access to one or more servers",
+	Long: `Grant an API token access to servers. Without a ServerACL entry,
+the token is denied access to all servers (deny-by-default).
+
+Use --server for a single server or --servers for bulk operations.`,
+	Example: `  alpacon token acl server add my-api-token --server my-server
+  alpacon token acl server add my-api-token --servers web-01,web-02,web-03`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		tokenArg := args[0]
+		serverName, _ := cmd.Flags().GetString("server")
+		serversCSV, _ := cmd.Flags().GetString("servers")
+
+		if serverName == "" && serversCSV == "" {
+			utils.CliErrorWithExit("One of --server or --servers is required.")
+		}
+		if serverName != "" && serversCSV != "" {
+			utils.CliErrorWithExit("Use either --server or --servers, not both.")
+		}
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		tokenID := tokenArg
+		if !utils.IsUUID(tokenID) {
+			tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenArg)
+			if err != nil {
+				utils.CliErrorWithExit("Failed to resolve token: %v.", err)
+			}
+		}
+
+		if serverName != "" {
+			serverID, err := serverapi.GetServerIDByName(alpaconClient, serverName)
+			if err != nil {
+				utils.CliErrorWithExit("Failed to resolve server '%s': %v.", serverName, err)
+			}
+			if err = security.AddServerAcl(alpaconClient, security.ServerAclRequest{
+				Token:  tokenID,
+				Server: serverID,
+			}); err != nil {
+				utils.CliErrorWithExit("Failed to add server ACL: %v.", err)
+			}
+			utils.CliSuccess("Server ACL added: token %s can access %s", tokenArg, serverName)
+			return
+		}
+
+		names := utils.SplitAndTrim(serversCSV, ",")
+		if len(names) == 0 {
+			utils.CliErrorWithExit("--servers must contain at least one server name.")
+		}
+
+		serverIDs := make([]string, 0, len(names))
+		for _, name := range names {
+			id, err := serverapi.GetServerIDByName(alpaconClient, name)
+			if err != nil {
+				utils.CliErrorWithExit("Failed to resolve server '%s': %v.", name, err)
+			}
+			serverIDs = append(serverIDs, id)
+		}
+
+		if err = security.BulkAddServerAcl(alpaconClient, security.ServerAclBulkRequest{
+			Token:   tokenID,
+			Servers: serverIDs,
+		}); err != nil {
+			utils.CliErrorWithExit("Failed to bulk-add server ACLs: %v.", err)
+		}
+		utils.CliSuccess("Server ACLs added: token %s can access %s", tokenArg, fmt.Sprintf("[%s]", serversCSV))
+	},
+}
+
+func init() {
+	aclServerAddCmd.Flags().String("server", "", "Server name (single)")
+	aclServerAddCmd.Flags().String("servers", "", "Comma-separated server names (bulk)")
+}

--- a/cmd/token/acl_server_add.go
+++ b/cmd/token/acl_server_add.go
@@ -1,7 +1,7 @@
 package token
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/alpacax/alpacon-cli/api/auth"
 	"github.com/alpacax/alpacon-cli/api/security"
@@ -71,7 +71,7 @@ Use --server for a single server or --servers for bulk operations.`,
 		}); err != nil {
 			utils.CliErrorWithExit("Failed to bulk-add server ACLs: %v.", err)
 		}
-		utils.CliSuccess("Server ACLs added: token %s can access %s", tokenArg, fmt.Sprintf("[%s]", serversCSV))
+		utils.CliSuccess("Server ACLs added: token %s can access [%s]", tokenArg, strings.Join(names, ", "))
 	},
 }
 

--- a/cmd/token/acl_server_add.go
+++ b/cmd/token/acl_server_add.go
@@ -38,12 +38,9 @@ Use --server for a single server or --servers for bulk operations.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		tokenID := tokenArg
-		if !utils.IsUUID(tokenID) {
-			tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenArg)
-			if err != nil {
-				utils.CliErrorWithExit("Failed to resolve token: %v.", err)
-			}
+		tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to resolve token: %v.", err)
 		}
 
 		if serverName != "" {

--- a/cmd/token/acl_server_add.go
+++ b/cmd/token/acl_server_add.go
@@ -63,7 +63,10 @@ Use --server for a single server or --servers for bulk operations.`,
 			utils.CliErrorWithExit("--servers must contain at least one server name.")
 		}
 
-		serverIDs := resolveServerIDs(alpaconClient, names)
+		serverIDs, err := resolveServerIDs(alpaconClient, names)
+		if err != nil {
+			utils.CliErrorWithExit("%v.", err)
+		}
 
 		if err = security.BulkAddServerAcl(alpaconClient, security.ServerAclBulkRequest{
 			Token:   tokenID,

--- a/cmd/token/acl_server_add.go
+++ b/cmd/token/acl_server_add.go
@@ -63,14 +63,7 @@ Use --server for a single server or --servers for bulk operations.`,
 			utils.CliErrorWithExit("--servers must contain at least one server name.")
 		}
 
-		serverIDs := make([]string, 0, len(names))
-		for _, name := range names {
-			id, err := serverapi.GetServerIDByName(alpaconClient, name)
-			if err != nil {
-				utils.CliErrorWithExit("Failed to resolve server '%s': %v.", name, err)
-			}
-			serverIDs = append(serverIDs, id)
-		}
+		serverIDs := resolveServerIDs(alpaconClient, names)
 
 		if err = security.BulkAddServerAcl(alpaconClient, security.ServerAclBulkRequest{
 			Token:   tokenID,

--- a/cmd/token/acl_server_add.go
+++ b/cmd/token/acl_server_add.go
@@ -21,64 +21,66 @@ Use --server for a single server or --servers for bulk operations.`,
 	Example: `  alpacon token acl server add my-api-token --server my-server
   alpacon token acl server add my-api-token --servers web-01,web-02,web-03`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		tokenArg := args[0]
-		serverName, _ := cmd.Flags().GetString("server")
-		serversCSV, _ := cmd.Flags().GetString("servers")
-
-		if serverName == "" && serversCSV == "" {
-			utils.CliErrorWithExit("One of --server or --servers is required.")
-		}
-		if serverName != "" && serversCSV != "" {
-			utils.CliErrorWithExit("Use either --server or --servers, not both.")
-		}
-
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to resolve token: %v.", err)
-		}
-
-		if serverName != "" {
-			serverID, err := serverapi.GetServerIDByName(alpaconClient, serverName)
-			if err != nil {
-				utils.CliErrorWithExit("Failed to resolve server '%s': %v.", serverName, err)
-			}
-			if err = security.AddServerAcl(alpaconClient, security.ServerAclRequest{
-				Token:  tokenID,
-				Server: serverID,
-			}); err != nil {
-				utils.CliErrorWithExit("Failed to add server ACL: %v.", err)
-			}
-			utils.CliSuccess("Server ACL added: token %s can access %s", tokenArg, serverName)
-			return
-		}
-
-		names := utils.SplitAndTrim(serversCSV, ",")
-		if len(names) == 0 {
-			utils.CliErrorWithExit("--servers must contain at least one server name.")
-		}
-
-		serverIDs, err := resolveServerIDs(alpaconClient, names)
-		if err != nil {
-			utils.CliErrorWithExit("%v.", err)
-		}
-
-		if err = security.BulkAddServerAcl(alpaconClient, security.ServerAclBulkRequest{
-			Token:   tokenID,
-			Servers: serverIDs,
-		}); err != nil {
-			utils.CliErrorWithExit("Failed to bulk-add server ACLs: %v.", err)
-		}
-		utils.CliSuccess("Server ACLs added: token %s can access [%s]", tokenArg, strings.Join(names, ", "))
-	},
+	Run:  runServerAclAdd,
 }
 
 func init() {
 	aclServerAddCmd.Flags().String("server", "", "Server name (single)")
 	aclServerAddCmd.Flags().String("servers", "", "Comma-separated server names (bulk)")
+}
+
+func runServerAclAdd(cmd *cobra.Command, args []string) {
+	tokenArg := args[0]
+	serverName, _ := cmd.Flags().GetString("server")
+	serversCSV, _ := cmd.Flags().GetString("servers")
+
+	if serverName == "" && serversCSV == "" {
+		utils.CliErrorWithExit("One of --server or --servers is required.")
+	}
+	if serverName != "" && serversCSV != "" {
+		utils.CliErrorWithExit("Use either --server or --servers, not both.")
+	}
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to resolve token: %v.", err)
+	}
+
+	if serverName != "" {
+		serverID, err := serverapi.GetServerIDByName(alpaconClient, serverName)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to resolve server '%s': %v.", serverName, err)
+		}
+		if err = security.AddServerAcl(alpaconClient, security.ServerAclRequest{
+			Token:  tokenID,
+			Server: serverID,
+		}); err != nil {
+			utils.CliErrorWithExit("Failed to add server ACL: %v.", err)
+		}
+		utils.CliSuccess("Server ACL added: token %s can access %s", tokenArg, serverName)
+		return
+	}
+
+	names := utils.SplitAndTrim(serversCSV, ",")
+	if len(names) == 0 {
+		utils.CliErrorWithExit("--servers must contain at least one server name.")
+	}
+
+	serverIDs, err := resolveServerIDs(alpaconClient, names)
+	if err != nil {
+		utils.CliErrorWithExit("%v.", err)
+	}
+
+	if err = security.BulkAddServerAcl(alpaconClient, security.ServerAclBulkRequest{
+		Token:   tokenID,
+		Servers: serverIDs,
+	}); err != nil {
+		utils.CliErrorWithExit("Failed to bulk-add server ACLs: %v.", err)
+	}
+	utils.CliSuccess("Server ACLs added: token %s can access [%s]", tokenArg, strings.Join(names, ", "))
 }

--- a/cmd/token/acl_server_add.go
+++ b/cmd/token/acl_server_add.go
@@ -43,7 +43,7 @@ func runServerAclAdd(cmd *cobra.Command, args []string) {
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
 	}
 
 	tokenID, err := auth.ResolveTokenID(alpaconClient, tokenArg)

--- a/cmd/token/acl_server_delete.go
+++ b/cmd/token/acl_server_delete.go
@@ -41,7 +41,10 @@ to multiple servers at once using --servers (bulk delete).`,
 			}
 
 			names := utils.SplitAndTrim(serversCSV, ",")
-			serverIDs := resolveServerIDs(alpaconClient, names)
+			serverIDs, err := resolveServerIDs(alpaconClient, names)
+			if err != nil {
+				utils.CliErrorWithExit("%v.", err)
+			}
 
 			if err = security.BulkDeleteServerAcl(alpaconClient, security.ServerAclBulkRequest{
 				Token:   tokenID,
@@ -57,7 +60,7 @@ to multiple servers at once using --servers (bulk delete).`,
 			utils.ConfirmAction("Delete server ACL '%s'?", arg)
 		}
 		if err = security.DeleteServerAcl(alpaconClient, arg); err != nil {
-			utils.CliErrorWithExit("Failed to delete server ACL: %s.", err)
+			utils.CliErrorWithExit("Failed to delete server ACL: %v.", err)
 		}
 		utils.CliSuccess("Server ACL deleted: %s", arg)
 	},

--- a/cmd/token/acl_server_delete.go
+++ b/cmd/token/acl_server_delete.go
@@ -35,7 +35,7 @@ func runServerAclDelete(cmd *cobra.Command, args []string) {
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
 	}
 
 	if serversCSV != "" {

--- a/cmd/token/acl_server_delete.go
+++ b/cmd/token/acl_server_delete.go
@@ -3,7 +3,6 @@ package token
 import (
 	"github.com/alpacax/alpacon-cli/api/auth"
 	"github.com/alpacax/alpacon-cli/api/security"
-	serverapi "github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
@@ -42,14 +41,7 @@ to multiple servers at once using --servers (bulk delete).`,
 			}
 
 			names := utils.SplitAndTrim(serversCSV, ",")
-			serverIDs := make([]string, 0, len(names))
-			for _, name := range names {
-				id, err := serverapi.GetServerIDByName(alpaconClient, name)
-				if err != nil {
-					utils.CliErrorWithExit("Failed to resolve server '%s': %v.", name, err)
-				}
-				serverIDs = append(serverIDs, id)
-			}
+			serverIDs := resolveServerIDs(alpaconClient, names)
 
 			if err = security.BulkDeleteServerAcl(alpaconClient, security.ServerAclBulkDeleteRequest{
 				Token:   tokenID,

--- a/cmd/token/acl_server_delete.go
+++ b/cmd/token/acl_server_delete.go
@@ -36,12 +36,9 @@ to multiple servers at once using --servers (bulk delete).`,
 				utils.ConfirmAction("Revoke server ACLs for token '%s' on servers [%s]?", arg, serversCSV)
 			}
 
-			tokenID := arg
-			if !utils.IsUUID(tokenID) {
-				tokenID, err = auth.GetAPITokenIDByName(alpaconClient, arg)
-				if err != nil {
-					utils.CliErrorWithExit("Failed to resolve token: %v.", err)
-				}
+			tokenID, err := auth.ResolveTokenID(alpaconClient, arg)
+			if err != nil {
+				utils.CliErrorWithExit("Failed to resolve token: %v.", err)
 			}
 
 			names := utils.SplitAndTrim(serversCSV, ",")

--- a/cmd/token/acl_server_delete.go
+++ b/cmd/token/acl_server_delete.go
@@ -20,56 +20,58 @@ to multiple servers at once using --servers (bulk delete).`,
   # Bulk delete: revoke token access to named servers
   alpacon token acl server delete my-api-token --servers web-01,web-02`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		arg := args[0]
-		serversCSV, _ := cmd.Flags().GetString("servers")
-		yes, _ := cmd.Flags().GetBool("yes")
-
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		if serversCSV != "" {
-			if !yes {
-				utils.ConfirmAction("Revoke server ACLs for token '%s' on servers [%s]?", arg, serversCSV)
-			}
-
-			tokenID, err := auth.ResolveTokenID(alpaconClient, arg)
-			if err != nil {
-				utils.CliErrorWithExit("Failed to resolve token: %v.", err)
-			}
-
-			names := utils.SplitAndTrim(serversCSV, ",")
-			if len(names) == 0 {
-				utils.CliErrorWithExit("--servers must contain at least one server name.")
-			}
-			serverIDs, err := resolveServerIDs(alpaconClient, names)
-			if err != nil {
-				utils.CliErrorWithExit("%v.", err)
-			}
-
-			if err = security.BulkDeleteServerAcl(alpaconClient, security.ServerAclBulkRequest{
-				Token:   tokenID,
-				Servers: serverIDs,
-			}); err != nil {
-				utils.CliErrorWithExit("Failed to bulk-delete server ACLs: %v.", err)
-			}
-			utils.CliSuccess("Server ACLs revoked: token %s no longer has access to [%s]", arg, serversCSV)
-			return
-		}
-
-		if !yes {
-			utils.ConfirmAction("Delete server ACL '%s'?", arg)
-		}
-		if err = security.DeleteServerAcl(alpaconClient, arg); err != nil {
-			utils.CliErrorWithExit("Failed to delete server ACL: %v.", err)
-		}
-		utils.CliSuccess("Server ACL deleted: %s", arg)
-	},
+	Run:  runServerAclDelete,
 }
 
 func init() {
 	aclServerDeleteCmd.Flags().String("servers", "", "Comma-separated server names (bulk delete)")
 	aclServerDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+}
+
+func runServerAclDelete(cmd *cobra.Command, args []string) {
+	arg := args[0]
+	serversCSV, _ := cmd.Flags().GetString("servers")
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	if serversCSV != "" {
+		if !yes {
+			utils.ConfirmAction("Revoke server ACLs for token '%s' on servers [%s]?", arg, serversCSV)
+		}
+
+		tokenID, err := auth.ResolveTokenID(alpaconClient, arg)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to resolve token: %v.", err)
+		}
+
+		names := utils.SplitAndTrim(serversCSV, ",")
+		if len(names) == 0 {
+			utils.CliErrorWithExit("--servers must contain at least one server name.")
+		}
+		serverIDs, err := resolveServerIDs(alpaconClient, names)
+		if err != nil {
+			utils.CliErrorWithExit("%v.", err)
+		}
+
+		if err = security.BulkDeleteServerAcl(alpaconClient, security.ServerAclBulkRequest{
+			Token:   tokenID,
+			Servers: serverIDs,
+		}); err != nil {
+			utils.CliErrorWithExit("Failed to bulk-delete server ACLs: %v.", err)
+		}
+		utils.CliSuccess("Server ACLs revoked: token %s no longer has access to [%s]", arg, serversCSV)
+		return
+	}
+
+	if !yes {
+		utils.ConfirmAction("Delete server ACL '%s'?", arg)
+	}
+	if err = security.DeleteServerAcl(alpaconClient, arg); err != nil {
+		utils.CliErrorWithExit("Failed to delete server ACL: %v.", err)
+	}
+	utils.CliSuccess("Server ACL deleted: %s", arg)
 }

--- a/cmd/token/acl_server_delete.go
+++ b/cmd/token/acl_server_delete.go
@@ -2,8 +2,8 @@ package token
 
 import (
 	"github.com/alpacax/alpacon-cli/api/auth"
-	serverapi "github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/api/security"
+	serverapi "github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"

--- a/cmd/token/acl_server_delete.go
+++ b/cmd/token/acl_server_delete.go
@@ -41,6 +41,9 @@ to multiple servers at once using --servers (bulk delete).`,
 			}
 
 			names := utils.SplitAndTrim(serversCSV, ",")
+			if len(names) == 0 {
+				utils.CliErrorWithExit("--servers must contain at least one server name.")
+			}
 			serverIDs, err := resolveServerIDs(alpaconClient, names)
 			if err != nil {
 				utils.CliErrorWithExit("%v.", err)

--- a/cmd/token/acl_server_delete.go
+++ b/cmd/token/acl_server_delete.go
@@ -43,7 +43,7 @@ to multiple servers at once using --servers (bulk delete).`,
 			names := utils.SplitAndTrim(serversCSV, ",")
 			serverIDs := resolveServerIDs(alpaconClient, names)
 
-			if err = security.BulkDeleteServerAcl(alpaconClient, security.ServerAclBulkDeleteRequest{
+			if err = security.BulkDeleteServerAcl(alpaconClient, security.ServerAclBulkRequest{
 				Token:   tokenID,
 				Servers: serverIDs,
 			}); err != nil {

--- a/cmd/token/acl_server_delete.go
+++ b/cmd/token/acl_server_delete.go
@@ -1,0 +1,80 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/auth"
+	serverapi "github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var aclServerDeleteCmd = &cobra.Command{
+	Use:     "delete ACL-ID-OR-TOKEN",
+	Aliases: []string{"rm"},
+	Short:   "Delete server ACL rule(s)",
+	Long: `Delete a server ACL by its ID (single delete), or revoke a token's access
+to multiple servers at once using --servers (bulk delete).`,
+	Example: `  # Single delete by ACL ID
+  alpacon token acl server delete 550e8400-e29b-41d4-a716-446655440000
+
+  # Bulk delete: revoke token access to named servers
+  alpacon token acl server delete my-api-token --servers web-01,web-02`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		arg := args[0]
+		serversCSV, _ := cmd.Flags().GetString("servers")
+		yes, _ := cmd.Flags().GetBool("yes")
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if serversCSV != "" {
+			if !yes {
+				utils.ConfirmAction("Revoke server ACLs for token '%s' on servers [%s]?", arg, serversCSV)
+			}
+
+			tokenID := arg
+			if !utils.IsUUID(tokenID) {
+				tokenID, err = auth.GetAPITokenIDByName(alpaconClient, arg)
+				if err != nil {
+					utils.CliErrorWithExit("Failed to resolve token: %v.", err)
+				}
+			}
+
+			names := utils.SplitAndTrim(serversCSV, ",")
+			serverIDs := make([]string, 0, len(names))
+			for _, name := range names {
+				id, err := serverapi.GetServerIDByName(alpaconClient, name)
+				if err != nil {
+					utils.CliErrorWithExit("Failed to resolve server '%s': %v.", name, err)
+				}
+				serverIDs = append(serverIDs, id)
+			}
+
+			if err = security.BulkDeleteServerAcl(alpaconClient, security.ServerAclBulkDeleteRequest{
+				Token:   tokenID,
+				Servers: serverIDs,
+			}); err != nil {
+				utils.CliErrorWithExit("Failed to bulk-delete server ACLs: %v.", err)
+			}
+			utils.CliSuccess("Server ACLs revoked: token %s no longer has access to [%s]", arg, serversCSV)
+			return
+		}
+
+		if !yes {
+			utils.ConfirmAction("Delete server ACL '%s'?", arg)
+		}
+		if err = security.DeleteServerAcl(alpaconClient, arg); err != nil {
+			utils.CliErrorWithExit("Failed to delete server ACL: %s.", err)
+		}
+		utils.CliSuccess("Server ACL deleted: %s", arg)
+	},
+}
+
+func init() {
+	aclServerDeleteCmd.Flags().String("servers", "", "Comma-separated server names (bulk delete)")
+	aclServerDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+}

--- a/cmd/token/acl_server_list.go
+++ b/cmd/token/acl_server_list.go
@@ -23,7 +23,7 @@ func runServerAclList(_ *cobra.Command, args []string) {
 
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %v. Consider re-logging.", err)
 	}
 
 	tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)

--- a/cmd/token/acl_server_list.go
+++ b/cmd/token/acl_server_list.go
@@ -23,11 +23,9 @@ var aclServerListCmd = &cobra.Command{
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		if !utils.IsUUID(tokenID) {
-			tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenID)
-			if err != nil {
-				utils.CliErrorWithExit("Failed to retrieve server ACLs: %s.", err)
-			}
+		tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve server ACLs: %s.", err)
 		}
 
 		acls, err := security.GetServerAclList(alpaconClient, tokenID)

--- a/cmd/token/acl_server_list.go
+++ b/cmd/token/acl_server_list.go
@@ -15,24 +15,26 @@ var aclServerListCmd = &cobra.Command{
 	Example: `  alpacon token acl server ls my-api-token
   alpacon token acl server list my-api-token`,
 	Args: cobra.ExactArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		tokenID := args[0]
+	Run:  runServerAclList,
+}
 
-		alpaconClient, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
+func runServerAclList(_ *cobra.Command, args []string) {
+	tokenID := args[0]
 
-		tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to resolve token: %v.", err)
-		}
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
 
-		acls, err := security.GetServerAclList(alpaconClient, tokenID)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve server ACLs: %v.", err)
-		}
+	tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to resolve token: %v.", err)
+	}
 
-		utils.PrintTable(acls)
-	},
+	acls, err := security.GetServerAclList(alpaconClient, tokenID)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to retrieve server ACLs: %v.", err)
+	}
+
+	utils.PrintTable(acls)
 }

--- a/cmd/token/acl_server_list.go
+++ b/cmd/token/acl_server_list.go
@@ -25,12 +25,12 @@ var aclServerListCmd = &cobra.Command{
 
 		tokenID, err = auth.ResolveTokenID(alpaconClient, tokenID)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve server ACLs: %s.", err)
+			utils.CliErrorWithExit("Failed to resolve token: %v.", err)
 		}
 
 		acls, err := security.GetServerAclList(alpaconClient, tokenID)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve server ACLs: %s.", err)
+			utils.CliErrorWithExit("Failed to retrieve server ACLs: %v.", err)
 		}
 
 		utils.PrintTable(acls)

--- a/cmd/token/acl_server_list.go
+++ b/cmd/token/acl_server_list.go
@@ -1,0 +1,40 @@
+package token
+
+import (
+	"github.com/alpacax/alpacon-cli/api/auth"
+	"github.com/alpacax/alpacon-cli/api/security"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var aclServerListCmd = &cobra.Command{
+	Use:     "ls TOKEN",
+	Aliases: []string{"list"},
+	Short:   "List server ACL rules for a token",
+	Example: `  alpacon token acl server ls my-api-token
+  alpacon token acl server list my-api-token`,
+	Args: cobra.ExactArgs(1),
+	Run: func(_ *cobra.Command, args []string) {
+		tokenID := args[0]
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if !utils.IsUUID(tokenID) {
+			tokenID, err = auth.GetAPITokenIDByName(alpaconClient, tokenID)
+			if err != nil {
+				utils.CliErrorWithExit("Failed to retrieve server ACLs: %s.", err)
+			}
+		}
+
+		acls, err := security.GetServerAclList(alpaconClient, tokenID)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve server ACLs: %s.", err)
+		}
+
+		utils.PrintTable(acls)
+	},
+}


### PR DESCRIPTION
## Summary

- Add `token acl command`, `token acl server`, and `token acl file` subcommand groups, each with `add`, `ls`, and `delete` subcommands
- Extend `CommandAclRequest/Response` with `username` and `groupname` fields
- Add full API support for ServerACL (single + bulk add/delete) and FileACL
- Refactor token name→UUID resolution into a shared `auth.ResolveTokenID` helper used across 7 files

## New commands

```
alpacon token acl command add   TOKEN --command CMD [--username] [--groupname]
alpacon token acl command ls    TOKEN
alpacon token acl command delete ACL-ID

alpacon token acl server add    TOKEN (--server NAME | --servers NAME,NAME,...)
alpacon token acl server ls     TOKEN
alpacon token acl server delete ACL-ID-OR-TOKEN [--servers NAME,...] [-y]

alpacon token acl file add      TOKEN --path PATH --action ACTION [--username] [--groupname]
alpacon token acl file ls       TOKEN
alpacon token acl file delete   ACL-ID [-y]
```

The existing top-level `acl add / acl ls / acl delete` commands are preserved as legacy aliases for CommandACL.

## API changes

- `api/security/types.go`: added `ServerAclRequest`, `ServerAclBulkRequest`, `ServerAclAttributes`, `FileAclRequest`, `FileAclResponse`, `FileAclAction*` constants; removed duplicate `ServerAclBulkDeleteRequest`
- `api/security/security.go`: added `GetServerAclList`, `AddServerAcl`, `BulkAddServerAcl`, `DeleteServerAcl`, `BulkDeleteServerAcl`, `GetFileAclList`, `AddFileAcl`, `DeleteFileAcl`
- `api/auth/auth.go`: added `ResolveTokenID` to encapsulate UUID-check + name lookup

## Refactoring

- `resolveServerIDs` in `cmd/token/acl_server.go`: resolves server names to UUIDs in parallel using `sync.WaitGroup` + `sync.Mutex`; returns `([]string, error)` — error handling delegated to the cmd layer
- `originalToken` preserved before `ResolveTokenID` mutates `req.Token` to UUID, so success messages show the user-supplied name
- `FileAclAction*` constants replace magic strings in validation logic
- Error format verb normalized to `%v` across delete commands

## Test plan

- [ ] `alpacon token acl command add <name> --command "whoami"` — add by token name (ResolveTokenID path)
- [ ] `alpacon token acl command add <uuid> --command "docker *" --username=root` — add by UUID
- [ ] `alpacon token acl command ls <name>` — list command ACLs
- [ ] `alpacon token acl command delete <acl-id>` — delete with confirmation prompt
- [ ] `alpacon token acl server add <token> --server <name>` — single server grant
- [ ] `alpacon token acl server add <token> --servers web-01,web-02` — bulk grant
- [ ] `alpacon token acl server delete <token> --servers web-01 -y` — bulk revoke
- [ ] `alpacon token acl server delete <acl-id>` — single delete by ACL ID
- [ ] `alpacon token acl file add <name> --path /data --action upload`
- [ ] `alpacon token acl file add <name> --path /data --action invalid` — should error
- [ ] `alpacon token acl file ls <name>` — list file ACLs
- [ ] `alpacon token acl file delete <acl-id> -y`
- [ ] `go test -race -v ./...` passes
- [ ] `golangci-lint run ./...` passes