### PR TITLE
feat(root): replace ASCII logo with Pacabot welcome banner

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
-	"strings"
+	"os"
 
 	"github.com/alpacax/alpacon-cli/cmd/agent"
 	"github.com/alpacax/alpacon-cli/cmd/audit"
@@ -150,10 +151,10 @@ func buildWelcomeLines() []string {
 
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		// "file does not exist" → expected case, treat as not logged in.
+		// Missing config file → expected case, treat as not logged in.
 		// Other errors (permissions, malformed JSON) surface so the user
 		// can act on them instead of seeing a misleading login prompt.
-		if strings.Contains(err.Error(), "does not exist") {
+		if errors.Is(err, os.ErrNotExist) {
 			return []string{header, "Not logged in — run 'alpacon login'", helpHint}
 		}
 		return []string{header, "Config read error — run 'alpacon login' to reset", helpHint}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,14 +156,14 @@ func buildWelcomeLines() []string {
 		}
 	}
 
-	host := stripScheme(cfg.WorkspaceURL)
+	host := hostFromURL(cfg.WorkspaceURL)
 	if host == "" {
 		host = cfg.WorkspaceName
 	}
 	return []string{header, host, helpHint}
 }
 
-func stripScheme(rawURL string) string {
+func hostFromURL(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil || u.Host == "" {
 		return rawURL

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/alpacax/alpacon-cli/cmd/agent"
 	"github.com/alpacax/alpacon-cli/cmd/audit"
@@ -142,18 +143,23 @@ func init() {
 
 // buildWelcomeLines composes the right-side text lines rendered next to the
 // Pacabot art when `alpacon` is invoked with no subcommand. Three lines:
-// version, workspace URL (or login prompt), help hint.
+// version, workspace URL (or login prompt / config error), help hint.
 func buildWelcomeLines() []string {
 	header := fmt.Sprintf("alpacon %s", utils.GetCLIVersion())
 	helpHint := "'alpacon --help' for commands"
 
 	cfg, err := config.LoadConfig()
-	if err != nil || (cfg.AccessToken == "" && cfg.Token == "") {
-		return []string{
-			header,
-			"Not logged in — run 'alpacon login'",
-			helpHint,
+	if err != nil {
+		// "file does not exist" → expected case, treat as not logged in.
+		// Other errors (permissions, malformed JSON) surface so the user
+		// can act on them instead of seeing a misleading login prompt.
+		if strings.Contains(err.Error(), "does not exist") {
+			return []string{header, "Not logged in — run 'alpacon login'", helpHint}
 		}
+		return []string{header, "Config read error — run 'alpacon login' to reset", helpHint}
+	}
+	if cfg.AccessToken == "" && cfg.Token == "" {
+		return []string{header, "Not logged in — run 'alpacon login'", helpHint}
 	}
 
 	host := hostFromURL(cfg.WorkspaceURL)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
+	"net/url"
 
 	"github.com/alpacax/alpacon-cli/cmd/agent"
 	"github.com/alpacax/alpacon-cli/cmd/audit"
@@ -24,6 +24,7 @@ import (
 	"github.com/alpacax/alpacon-cli/cmd/webhook"
 	"github.com/alpacax/alpacon-cli/cmd/websh"
 	"github.com/alpacax/alpacon-cli/cmd/workspace"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -48,8 +49,7 @@ Designed to be used by engineers, AI coding agents, and CI/CD platforms alike.`,
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		utils.ShowLogo()
-		fmt.Fprintln(os.Stderr, "Welcome to Alpacon CLI! Use 'alpacon [command]' to execute a specific command or 'alpacon help' to see all available commands.")
+		utils.ShowLogo(buildWelcomeLines())
 	},
 }
 
@@ -138,4 +138,35 @@ func init() {
 
 	// whoami
 	RootCmd.AddCommand(whoamiCmd)
+}
+
+// buildWelcomeLines composes the right-side text lines rendered next to the
+// Pacabot art when `alpacon` is invoked with no subcommand. Three lines:
+// version, workspace URL (or login prompt), help hint.
+func buildWelcomeLines() []string {
+	header := fmt.Sprintf("alpacon %s", utils.GetCLIVersion())
+	helpHint := "'alpacon --help' for commands"
+
+	cfg, err := config.LoadConfig()
+	if err != nil || (cfg.AccessToken == "" && cfg.Token == "") {
+		return []string{
+			header,
+			"Not logged in — run 'alpacon login'",
+			helpHint,
+		}
+	}
+
+	host := stripScheme(cfg.WorkspaceURL)
+	if host == "" {
+		host = cfg.WorkspaceName
+	}
+	return []string{header, host, helpHint}
+}
+
+func stripScheme(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return rawURL
+	}
+	return u.Host
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildWelcomeLines(t *testing.T) {
+	t.Run("not logged in (no config file)", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		lines := buildWelcomeLines()
+		require.Len(t, lines, 3)
+		assert.Contains(t, lines[0], "alpacon")
+		assert.Contains(t, lines[1], "Not logged in")
+		assert.Contains(t, lines[2], "--help")
+	})
+
+	t.Run("logged in via Auth0 — workspace host shown", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		cfgDir := filepath.Join(home, ".alpacon")
+		require.NoError(t, os.MkdirAll(cfgDir, 0700))
+		cfg := `{"workspace_url":"https://myws.us1.alpacon.io","workspace_name":"myws","access_token":"a"}`
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(cfg), 0600))
+
+		lines := buildWelcomeLines()
+		require.Len(t, lines, 3)
+		assert.Equal(t, "myws.us1.alpacon.io", lines[1])
+	})
+
+	t.Run("logged in via legacy token — workspace host shown", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		cfgDir := filepath.Join(home, ".alpacon")
+		require.NoError(t, os.MkdirAll(cfgDir, 0700))
+		cfg := `{"workspace_url":"https://myws.alpacon.io","workspace_name":"myws","token":"t"}`
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(cfg), 0600))
+
+		lines := buildWelcomeLines()
+		assert.Equal(t, "myws.alpacon.io", lines[1])
+	})
+
+	t.Run("config malformed — surfaces config error, not 'not logged in'", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		cfgDir := filepath.Join(home, ".alpacon")
+		require.NoError(t, os.MkdirAll(cfgDir, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte("{not-json"), 0600))
+
+		lines := buildWelcomeLines()
+		assert.Contains(t, lines[1], "Config read error")
+		assert.NotContains(t, lines[1], "Not logged in")
+	})
+
+	t.Run("config exists but no tokens — treated as not logged in", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		cfgDir := filepath.Join(home, ".alpacon")
+		require.NoError(t, os.MkdirAll(cfgDir, 0700))
+		cfg := `{"workspace_url":"https://x.alpacon.io","workspace_name":"x"}`
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(cfg), 0600))
+
+		lines := buildWelcomeLines()
+		assert.Contains(t, lines[1], "Not logged in")
+	})
+}
+
+func TestHostFromURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"https with subdomain", "https://myws.us1.alpacon.io", "myws.us1.alpacon.io"},
+		{"http", "http://example.com", "example.com"},
+		{"with path and query", "https://myws.alpacon.io/some/path?x=1", "myws.alpacon.io"},
+		{"with port", "https://localhost:8080", "localhost:8080"},
+		{"no scheme falls back to raw input", "myws.alpacon.io", "myws.alpacon.io"},
+		{"empty", "", ""},
+		{"malformed url with scheme returns input", "https://", "https://"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hostFromURL(tt.input))
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -115,7 +115,9 @@ func LoadConfig() (Config, error) {
 	file, err := os.Open(configFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return Config{}, fmt.Errorf("config file does not exist: %v", configFile)
+			// Wrap with %w so callers can detect the missing-config case
+			// via errors.Is(err, os.ErrNotExist).
+			return Config{}, fmt.Errorf("config file does not exist: %s: %w", configFile, err)
 		}
 		return Config{}, fmt.Errorf("failed to open config file: %v", err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,20 +17,23 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/term"
 )
 
-// ShowLogo renders the Pacabot mascot with up to 4 lines of text. When the
-// terminal is wide enough the text sits to the right of the art; otherwise
-// it falls back to rendering text below the art so wrapped lines don't
-// break the half-block pixel art rendering.
+// ShowLogo renders the Pacabot mascot with up to 3 lines of text. When the
+// terminal is wide enough the text sits to the right of the art (lines 1-3
+// align with art rows 1-3); otherwise it falls back to rendering text below
+// the art so wrapped lines don't break the half-block pixel art rendering.
 //
-// Pixel art ported from strategy/brand-assets/pacabot/pacabot.sh. Body cells
-// (full-block █) use FG+BG cyan so the cell background fills any inter-line
-// gap. Edges (▄ ▀) stay FG-only — ▄ glyph extends below the em-box in most
-// fonts (filling the gap below), while ▀ is reserved for the eye and mouth
-// where the half-pixel gap is intentional.
+// Pixel art ported from strategy/brand-assets/pacabot/pacabot.sh. In color
+// mode, body cells render as spaces with BG=cyan so the cell background
+// fills any inter-line gap. In plain mode (no TTY / NO_COLOR), body cells
+// substitute █ glyphs so the silhouette stays visible without ANSI codes.
+// Edge half-blocks (▄ ▀) are kept in both modes — they define the shape:
+// ▄ corners and ! bar bottom (FG cyan, glyph extends below the em-box in
+// most fonts), and ▀ for the eye (grey on cyan) and the mouth (grey FG).
 // Brand colors: primary #27AAE1, secondary #58595B.
 func ShowLogo(rightLines []string) {
 	useColor := os.Getenv("NO_COLOR") == "" && term.IsTerminal(int(os.Stderr.Fd()))
@@ -67,7 +70,7 @@ func ShowLogo(rightLines []string) {
 	const artWidth = 22
 	maxRight := 0
 	for _, line := range rightLines {
-		if n := len(line); n > maxRight {
+		if n := utf8.RuneCountInString(line); n > maxRight {
 			maxRight = n
 		}
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -79,8 +79,11 @@ func ShowLogo(rightLines []string) {
 			maxRight = n
 		}
 	}
+	// Default to the stacked layout when terminal size is unknown — we'd
+	// rather print a clean vertical layout than risk wrapping text into
+	// the middle of the pixel art.
 	cols, _, err := term.GetSize(int(os.Stderr.Fd()))
-	inline := err != nil || cols >= artWidth+maxRight+1
+	inline := err == nil && cols >= artWidth+maxRight+1
 
 	// Body cells render as spaces with BG=cyan in color mode; in plain mode
 	// we substitute █ glyphs so the art stays visible without ANSI codes.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,18 +21,87 @@ import (
 	"golang.org/x/term"
 )
 
-func ShowLogo() {
-	alpaconLogo := `
-     (` + "`" + `-')  _           _  (` + "`" + `-') (` + "`" + `-')  _                      <-. (` + "`" + `-')_
-     (OO ).-/    <-.    \-.(OO ) (OO ).-/  _             .->      \( OO) )
-     / ,---.   ,--. )   _.'    \ / ,---.   \-,-----.(` + "`" + `-')----. ,--./ ,--/
-     | \ /` + ".`" + `\  |  (` + "`" + `-')(_...--'' | \ /` + ".`" + `\   |  .--./( OO).-.  '|   \ |  |
-     '-'|_.' | |  |OO )|  |_.' | '-'|_.' | /_) (` + "`" + `-')( _) | |  ||  . '|  |)
-    (|  .-.  |(|  '__ ||  .___.'(|  .-.  | ||  |OO ) \|  |)|  ||  |\    |
-     |  | |  | |     |'|  |      |  | |  |(_'  '--'\  '  '-'  '|  | \   |
-     ` + "`" + `--' ` + "`" + `--' ` + "`" + `-----' ` + "`" + `--'      ` + "`" + `--' ` + "`" + `--'   ` + "`" + `-----'   ` + "`" + `-----' ` + "`" + `--'  ` + "`" + `--'
-    `
-	fmt.Fprintln(os.Stderr, alpaconLogo)
+// ShowLogo renders the Pacabot mascot with up to 4 lines of text. When the
+// terminal is wide enough the text sits to the right of the art; otherwise
+// it falls back to rendering text below the art so wrapped lines don't
+// break the half-block pixel art rendering.
+//
+// Pixel art ported from strategy/brand-assets/pacabot/pacabot.sh. Body cells
+// (full-block █) use FG+BG cyan so the cell background fills any inter-line
+// gap. Edges (▄ ▀) stay FG-only — ▄ glyph extends below the em-box in most
+// fonts (filling the gap below), while ▀ is reserved for the eye and mouth
+// where the half-pixel gap is intentional.
+// Brand colors: primary #27AAE1, secondary #58595B.
+func ShowLogo(rightLines []string) {
+	useColor := os.Getenv("NO_COLOR") == "" && term.IsTerminal(int(os.Stderr.Fd()))
+
+	var p, pb, s, a, b, r string
+	if useColor {
+		p = "\033[38;2;39;170;225m"               // primary cyan FG (edges)
+		pb = "\033[48;2;39;170;225m"              // primary cyan BG (solid body — applied to spaces)
+		s = "\033[38;2;88;89;91m"                 // secondary grey FG (mouth + tagline)
+		a = "\033[38;2;88;89;91;48;2;39;170;225m" // grey on cyan (eye)
+		b = "\033[1m"                             // bold
+		r = "\033[0m"
+	}
+
+	for len(rightLines) < 3 {
+		rightLines = append(rightLines, "")
+	}
+
+	header := rightLines[0]
+	if header != "" {
+		header = b + p + header + r
+	}
+	tinted := func(line string) string {
+		if line == "" {
+			return ""
+		}
+		return s + line + r
+	}
+
+	// Art occupies columns 0..22 (visual). If the terminal is too narrow to
+	// fit the longest right-side line beside the art, wrapped text would
+	// render between art rows and break the pixel art. Detect and fall back
+	// to printing text below the art.
+	const artWidth = 22
+	maxRight := 0
+	for _, line := range rightLines {
+		if n := len(line); n > maxRight {
+			maxRight = n
+		}
+	}
+	cols, _, err := term.GetSize(int(os.Stderr.Fd()))
+	inline := err != nil || cols >= artWidth+maxRight+1
+
+	// Body cells render as spaces with BG=cyan in color mode; in plain mode
+	// we substitute █ glyphs so the art stays visible without ANSI codes.
+	bodyEar, bodyEleven, bodyTen, bodyEight, bodyTwo, bodyBar := "  ", "           ", "          ", "        ", "  ", " "
+	if !useColor {
+		bodyEar, bodyEleven, bodyTen, bodyEight, bodyTwo, bodyBar = "██", "███████████", "██████████", "████████", "██", "█"
+	}
+
+	fmt.Fprintln(os.Stderr)
+	if inline {
+		fmt.Fprintf(os.Stderr, "   %s%s%s  %s%s%s      %s%s%s      %s\n", pb, bodyEar, r, pb, bodyEar, r, pb, bodyBar, r, header)
+		fmt.Fprintf(os.Stderr, " %s%s%s   %s▄%s      %s\n", pb, bodyEleven, r, p, r, tinted(rightLines[1]))
+		fmt.Fprintf(os.Stderr, " %s%s%s%s▀%s%s%s%s%s▄%s         %s\n", pb, bodyEight, r, a, r, pb, bodyTwo, r, p, r, tinted(rightLines[2]))
+		fmt.Fprintf(os.Stderr, "  %s%s%s%s▀%s\n", pb, bodyTen, r, s, r)
+	} else {
+		fmt.Fprintf(os.Stderr, "   %s%s%s  %s%s%s      %s%s%s\n", pb, bodyEar, r, pb, bodyEar, r, pb, bodyBar, r)
+		fmt.Fprintf(os.Stderr, " %s%s%s   %s▄%s\n", pb, bodyEleven, r, p, r)
+		fmt.Fprintf(os.Stderr, " %s%s%s%s▀%s%s%s%s%s▄%s\n", pb, bodyEight, r, a, r, pb, bodyTwo, r, p, r)
+		fmt.Fprintf(os.Stderr, "  %s%s%s%s▀%s\n", pb, bodyTen, r, s, r)
+		if header != "" {
+			fmt.Fprintf(os.Stderr, "\n  %s\n", header)
+		}
+		for _, line := range rightLines[1:] {
+			if line != "" {
+				fmt.Fprintf(os.Stderr, "  %s\n", tinted(line))
+			}
+		}
+	}
+	fmt.Fprintln(os.Stderr)
 }
 
 func ReadFileFromPath(filePath string) ([]byte, error) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -48,6 +48,11 @@ func ShowLogo(rightLines []string) {
 		r = "\033[0m"
 	}
 
+	// Clamp to 3 lines so inline and stacked layouts behave consistently
+	// regardless of how many lines the caller provides.
+	if len(rightLines) > 3 {
+		rightLines = rightLines[:3]
+	}
 	for len(rightLines) < 3 {
 		rightLines = append(rightLines, "")
 	}


### PR DESCRIPTION
## Summary
- Replace the legacy `alpaconLogo` ASCII art on bare `alpacon` with the Pacabot mascot + a 3-line status panel (version / workspace host / help hint).
- When not logged in, the status flips to `Not logged in — run 'alpacon login'`.
- Body cells use BG=cyan on spaces (not `█` FG-cyan) so the cell background fills the inter-line gap and stays solid on fonts where `█` doesn't extend to the em-box edges (e.g. Monaco). Edge half-blocks `▄`/`▀` stay FG-only — `▄` naturally extends below the em-box; `▀` is reserved for the eye and mouth where the half-pixel gap is intentional.
- Falls back to plain `█` glyphs on non-TTY / `NO_COLOR=1`, and to a vertical layout when the terminal is too narrow to fit the longest status line beside the art.

Output (logged in):
```
   ██  ██      █      alpacon vX.Y.Z
 ███████████   ▄      myws.us1.alpacon.io
 ████████▀██▄         'alpacon --help' for commands
  ██████████▀
```

Output (not logged in):
```
   ██  ██      █      alpacon vX.Y.Z
 ███████████   ▄      Not logged in — run 'alpacon login'
 ████████▀██▄         'alpacon --help' for commands
  ██████████▀
```

## Test plan
- [ ] `alpacon` (no args) on iTerm2 with light theme — body solid, no horizontal stripes
- [ ] `alpacon` while logged out — shows login prompt
- [ ] `NO_COLOR=1 alpacon` — plain `█` art, no ANSI codes
- [ ] `alpacon | cat` — still readable when piped
- [ ] Narrow terminal (<60 cols) — status text falls below the art
- [ ] `alpacon --help`, `alpacon <subcommand>` — banner does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)