### PR TITLE
fix(goreleaser): add build id, binary name, and nfpm package name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,9 @@ before:
     - go generate ./...
 
 builds:
-  - env:
+  - id: alpacon
+    binary: alpacon
+    env:
       - CGO_ENABLED=0
     flags:
       - -trimpath
@@ -60,7 +62,8 @@ dockers:
     dockerfile: Dockerfile
 
 nfpms:
-  - file_name_template: '{{ .PackageName }}_{{ trimprefix .Version "v" }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+  - package_name: alpacon-cli
+    file_name_template: '{{ .PackageName }}_{{ trimprefix .Version "v" }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     maintainer: AlpacaX <support@alpacax.com>
     description: "Alpacon CLI"
     homepage: https://github.com/alpacax/alpacon-cli


### PR DESCRIPTION
## Summary
- Add `id: alpacon` and `binary: alpacon` to `builds` — ensures `dockers.ids: alpacon` can correctly reference the build artifact (previously unset, defaulted to repo directory name)
- Add `package_name: alpacon-cli` to `nfpms` — aligns deb/rpm package name with the Homebrew formula name (`alpacon-cli`)

## Background
These were pre-existing issues identified during the `perf/binary-size-optimization` review. Without `id: alpacon`, the Docker build step could silently fail to find the correct binary. Without `package_name`, the deb/rpm packages would be named `alpacon` (from `project_name`) while Homebrew installs as `alpacon-cli`.