### PR TITLE
feat(worksession): add approve, reject, and revoke subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,8 +343,6 @@ $ alpacon work-session reject ses-abc123
 $ alpacon work-session revoke ses-abc123
 ```
 
-
-
 #### Identity and access management (IAM)
 Efficiently manage user and group resources:
 ```bash

--- a/README.md
+++ b/README.md
@@ -326,6 +326,23 @@ $ alpacon exec my-server "uptime"
 
 Session resolution order: `--work-session` flag > `ALPACON_WORK_SESSION` env var > active session set via `work-session use`.
 
+Superusers can manage pending and active sessions from the CLI:
+
+```bash
+# Approve a pending session (grants access as originally requested)
+$ alpacon work-session approve ses-abc123
+
+# Approve with scope or server adjustments (narrows granted access)
+$ alpacon work-session approve ses-abc123 --scope command --scope websh
+$ alpacon work-session approve ses-abc123 --scope command,websh --server web-01
+
+# Reject a pending session
+$ alpacon work-session reject ses-abc123
+
+# Force-terminate an active or approved session
+$ alpacon work-session revoke ses-abc123
+```
+
 
 
 #### Identity and access management (IAM)

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -45,3 +45,8 @@ type WorkSessionCreateRequest struct {
 type WorkSessionExtendRequest struct {
 	ExpiresAt string `json:"expires_at"`
 }
+
+type WorkSessionApproveRequest struct {
+	AdjustedScopes  []string `json:"adjusted_scopes,omitempty"`
+	AdjustedServers []string `json:"adjusted_servers,omitempty"`
+}

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -89,6 +89,11 @@ func ExtendWorkSession(ac *client.AlpaconClient, id string, req WorkSessionExten
 	return err
 }
 
+func ApproveWorkSession(ac *client.AlpaconClient, id string, req WorkSessionApproveRequest) error {
+	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "approve"), nil), req)
+	return err
+}
+
 func RejectWorkSession(ac *client.AlpaconClient, id string) error {
 	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "reject"), nil), struct{}{})
 	return err
@@ -96,11 +101,6 @@ func RejectWorkSession(ac *client.AlpaconClient, id string) error {
 
 func RevokeWorkSession(ac *client.AlpaconClient, id string) error {
 	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "revoke"), nil), struct{}{})
-	return err
-}
-
-func ApproveWorkSession(ac *client.AlpaconClient, id string, req WorkSessionApproveRequest) error {
-	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "approve"), nil), req)
 	return err
 }
 

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -99,6 +99,11 @@ func RevokeWorkSession(ac *client.AlpaconClient, id string) error {
 	return err
 }
 
+func ApproveWorkSession(ac *client.AlpaconClient, id string, req WorkSessionApproveRequest) error {
+	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "approve"), nil), req)
+	return err
+}
+
 func GetWorkSessionRaw(ac *client.AlpaconClient, id string) ([]byte, error) {
 	return ac.SendGetRequest(utils.BuildURL(workSessionURL, id, nil))
 }

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -89,6 +89,16 @@ func ExtendWorkSession(ac *client.AlpaconClient, id string, req WorkSessionExten
 	return err
 }
 
+func RejectWorkSession(ac *client.AlpaconClient, id string) error {
+	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "reject"), nil), struct{}{})
+	return err
+}
+
+func RevokeWorkSession(ac *client.AlpaconClient, id string) error {
+	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "revoke"), nil), struct{}{})
+	return err
+}
+
 func GetWorkSessionRaw(ac *client.AlpaconClient, id string) ([]byte, error) {
 	return ac.SendGetRequest(utils.BuildURL(workSessionURL, id, nil))
 }

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -180,3 +180,29 @@ func TestGetWorkSessionList_ScopesJoined(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "command, websh, webftp", list[0].Scopes)
 }
+
+func TestRejectWorkSession(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/reject/"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "rejected"})
+	}))
+	defer ts.Close()
+
+	err := RejectWorkSession(newTestClient(ts), "ses-abc")
+	assert.NoError(t, err)
+}
+
+func TestRevokeWorkSession(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/revoke/"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "revoked"})
+	}))
+	defer ts.Close()
+
+	err := RevokeWorkSession(newTestClient(ts), "ses-abc")
+	assert.NoError(t, err)
+}

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -206,3 +206,45 @@ func TestRevokeWorkSession(t *testing.T) {
 	err := RevokeWorkSession(newTestClient(ts), "ses-abc")
 	assert.NoError(t, err)
 }
+
+func TestApproveWorkSession_NoAdjustments(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/approve/"))
+
+		var req WorkSessionApproveRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		assert.Nil(t, req.AdjustedScopes)
+		assert.Nil(t, req.AdjustedServers)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "approved"})
+	}))
+	defer ts.Close()
+
+	err := ApproveWorkSession(newTestClient(ts), "ses-abc", WorkSessionApproveRequest{})
+	assert.NoError(t, err)
+}
+
+func TestApproveWorkSession_WithAdjustments(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/approve/"))
+
+		var req WorkSessionApproveRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		assert.Equal(t, []string{"command"}, req.AdjustedScopes)
+		assert.Equal(t, []string{"srv-uuid-1"}, req.AdjustedServers)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "approved"})
+	}))
+	defer ts.Close()
+
+	req := WorkSessionApproveRequest{
+		AdjustedScopes:  []string{"command"},
+		AdjustedServers: []string{"srv-uuid-1"},
+	}
+	err := ApproveWorkSession(newTestClient(ts), "ses-abc", req)
+	assert.NoError(t, err)
+}

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -213,7 +213,7 @@ func TestApproveWorkSession_NoAdjustments(t *testing.T) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/approve/"))
 
 		var req WorkSessionApproveRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 		assert.Nil(t, req.AdjustedScopes)
 		assert.Nil(t, req.AdjustedServers)
 
@@ -232,7 +232,7 @@ func TestApproveWorkSession_WithAdjustments(t *testing.T) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/approve/"))
 
 		var req WorkSessionApproveRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 		assert.Equal(t, []string{"command"}, req.AdjustedScopes)
 		assert.Equal(t, []string{"srv-uuid-1"}, req.AdjustedServers)
 

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -20,7 +20,7 @@ var WorkSessionCmd = &cobra.Command{
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', or 'alpacon work-session extend'. Run 'alpacon work-session --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session reject', or 'alpacon work-session revoke'. Run 'alpacon work-session --help' for more information")
 	},
 }
 
@@ -33,4 +33,6 @@ func init() {
 	WorkSessionCmd.AddCommand(workSessionExtendCmd)
 	WorkSessionCmd.AddCommand(workSessionUseCmd)
 	WorkSessionCmd.AddCommand(workSessionCurrentCmd)
+	WorkSessionCmd.AddCommand(workSessionRejectCmd)
+	WorkSessionCmd.AddCommand(workSessionRevokeCmd)
 }

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -20,7 +20,7 @@ var WorkSessionCmd = &cobra.Command{
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session reject', or 'alpacon work-session revoke'. Run 'alpacon work-session --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session approve', 'alpacon work-session reject', or 'alpacon work-session revoke'. Run 'alpacon work-session --help' for more information")
 	},
 }
 
@@ -33,6 +33,7 @@ func init() {
 	WorkSessionCmd.AddCommand(workSessionExtendCmd)
 	WorkSessionCmd.AddCommand(workSessionUseCmd)
 	WorkSessionCmd.AddCommand(workSessionCurrentCmd)
+	WorkSessionCmd.AddCommand(workSessionApproveCmd)
 	WorkSessionCmd.AddCommand(workSessionRejectCmd)
 	WorkSessionCmd.AddCommand(workSessionRevokeCmd)
 }

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -30,10 +30,8 @@ Use --scope and --server to narrow down the granted access at approval time.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		req := wsapi.WorkSessionApproveRequest{}
-
-		if len(approveScopes) > 0 {
-			req.AdjustedScopes = approveScopes
+		req := wsapi.WorkSessionApproveRequest{
+			AdjustedScopes: approveScopes,
 		}
 
 		if len(approveServers) > 0 {

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -30,8 +30,14 @@ Use --scope and --server to narrow down the granted access at approval time.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
+		filteredScopes := make([]string, 0, len(approveScopes))
+		for _, s := range approveScopes {
+			if s != "" {
+				filteredScopes = append(filteredScopes, s)
+			}
+		}
 		req := wsapi.WorkSessionApproveRequest{
-			AdjustedScopes: approveScopes,
+			AdjustedScopes: filteredScopes,
 		}
 
 		if len(approveServers) > 0 {

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -15,7 +15,7 @@ var (
 
 var workSessionApproveCmd = &cobra.Command{
 	Use:   "approve SESSION_ID",
-	Short: "Approve a pending work session",
+	Short: "Approve a pending work session (superuser only)",
 	Long: `Approve a pending work session. Superuser only.
 
 Without flags, approves the session as originally requested.

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -30,7 +30,7 @@ Use --scope and --server to narrow down the granted access at approval time.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		filteredScopes := make([]string, 0, len(approveScopes))
+		var filteredScopes []string
 		for _, s := range approveScopes {
 			if s != "" {
 				filteredScopes = append(filteredScopes, s)

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -1,0 +1,62 @@
+package worksession
+
+import (
+	"github.com/alpacax/alpacon-cli/api/server"
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	approveScopes  []string
+	approveServers []string
+)
+
+var workSessionApproveCmd = &cobra.Command{
+	Use:   "approve SESSION_ID",
+	Short: "Approve a pending work session",
+	Long: `Approve a pending work session. Superuser only.
+
+Without flags, approves the session as originally requested.
+Use --scope and --server to narrow down the granted access at approval time.`,
+	Args: cobra.ExactArgs(1),
+	Example: `  alpacon work-session approve ses-abc123
+  alpacon work-session approve ses-abc123 --scope command --scope websh
+  alpacon work-session approve ses-abc123 --scope command,websh --server web-01`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		req := wsapi.WorkSessionApproveRequest{}
+
+		if len(approveScopes) > 0 {
+			req.AdjustedScopes = approveScopes
+		}
+
+		if len(approveServers) > 0 {
+			serverIDs := make([]string, 0, len(approveServers))
+			for _, name := range approveServers {
+				id, err := server.GetServerIDByName(ac, name)
+				if err != nil {
+					utils.CliErrorWithExit("Server %q not found: %s.", name, err)
+				}
+				serverIDs = append(serverIDs, id)
+			}
+			req.AdjustedServers = serverIDs
+		}
+
+		if err := wsapi.ApproveWorkSession(ac, args[0], req); err != nil {
+			utils.CliErrorWithExit("Failed to approve work session: %s.", err)
+		}
+
+		utils.CliSuccess("Work session %s approved.", args[0])
+	},
+}
+
+func init() {
+	workSessionApproveCmd.Flags().StringSliceVar(&approveScopes, "scope", nil, "Adjust granted scopes (repeatable; comma-separated values also accepted)")
+	workSessionApproveCmd.Flags().StringSliceVar(&approveServers, "server", nil, "Adjust target servers by name (repeatable; comma-separated values also accepted)")
+}

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -17,7 +17,7 @@ var (
 
 var workSessionApproveCmd = &cobra.Command{
 	Use:   "approve SESSION_ID",
-	Short: "Approve a pending work session (superuser only)",
+	Short: "Approve a pending work session",
 	Long: `Approve a pending work session. Superuser only.
 
 Without flags, approves the session as originally requested.

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -1,6 +1,8 @@
 package worksession
 
 import (
+	"strings"
+
 	"github.com/alpacax/alpacon-cli/api/server"
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
@@ -43,6 +45,10 @@ Use --scope and --server to narrow down the granted access at approval time.`,
 		if len(approveServers) > 0 {
 			serverIDs := make([]string, 0, len(approveServers))
 			for _, name := range approveServers {
+				name = strings.TrimSpace(name)
+				if name == "" {
+					continue
+				}
 				id, err := server.GetServerIDByName(ac, name)
 				if err != nil {
 					utils.CliErrorWithExit("Server %q not found: %s.", name, err)

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -34,6 +34,7 @@ Use --scope and --server to narrow down the granted access at approval time.`,
 
 		var filteredScopes []string
 		for _, s := range approveScopes {
+			s = strings.TrimSpace(s)
 			if s != "" {
 				filteredScopes = append(filteredScopes, s)
 			}

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -16,8 +16,8 @@ import (
 
 var (
 	purpose       string
-	scopes        string
-	servers       string
+	createScopes  []string
+	createServers []string
 	expiresIn     string
 	expiresAt     string
 	requesterType string
@@ -27,8 +27,8 @@ var (
 var workSessionCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new work session",
-	Example: `  alpacon work-session create --purpose "nginx fix" --scopes command,websh --servers web-01 --expires-in 2h
-  alpacon work-session create --purpose "deploy" --scopes command --servers web-01,db-01 --expires-at 2026-05-09T10:00:00Z --wait`,
+	Example: `  alpacon work-session create --purpose "nginx fix" --scope command,websh --server web-01 --expires-in 2h
+  alpacon work-session create --purpose "deploy" --scope command --server web-01,db-01 --expires-at 2026-05-09T10:00:00Z --wait`,
 	Run: func(cmd *cobra.Command, args []string) {
 		purpose = strings.TrimSpace(purpose)
 		if purpose == "" {
@@ -37,19 +37,17 @@ var workSessionCreateCmd = &cobra.Command{
 			}
 			purpose = utils.PromptForRequiredInput("Purpose: ")
 		}
-		scopes = strings.TrimSpace(scopes)
-		if scopes == "" {
+		if len(createScopes) == 0 {
 			if !utils.IsInteractiveShell() {
-				utils.CliErrorWithExit("Non-interactive mode requires --scopes.")
+				utils.CliErrorWithExit("Non-interactive mode requires --scope.")
 			}
-			scopes = utils.PromptForRequiredInput("Scopes (comma-separated, e.g. command,websh): ")
+			createScopes = splitCSV(utils.PromptForRequiredInput("Scopes (comma-separated, e.g. command,websh): "))
 		}
-		servers = strings.TrimSpace(servers)
-		if servers == "" {
+		if len(createServers) == 0 {
 			if !utils.IsInteractiveShell() {
-				utils.CliErrorWithExit("Non-interactive mode requires --servers.")
+				utils.CliErrorWithExit("Non-interactive mode requires --server.")
 			}
-			servers = utils.PromptForRequiredInput("Servers (comma-separated server names): ")
+			createServers = splitCSV(utils.PromptForRequiredInput("Servers (comma-separated server names): "))
 		}
 
 		expiresAtVal, err := parseExpiryFlag(expiresIn, expiresAt)
@@ -72,12 +70,17 @@ var workSessionCreateCmd = &cobra.Command{
 			utils.CliErrorWithExit("Invalid --requester-type %q: must be \"user\" or \"agent\".", requesterType)
 		}
 
-		scopeList := splitCSV(scopes)
+		var scopeList []string
+		for _, s := range createScopes {
+			if s = strings.TrimSpace(s); s != "" {
+				scopeList = append(scopeList, s)
+			}
+		}
 		if len(scopeList) == 0 {
-			utils.CliErrorWithExit("--scopes must contain at least one valid scope.")
+			utils.CliErrorWithExit("--scope must contain at least one valid scope.")
 		}
 		if err := validateAgentScopes(requesterType, scopeList); err != nil {
-			utils.CliErrorWithExit("Invalid --scopes: %s", err)
+			utils.CliErrorWithExit("Invalid --scope: %s", err)
 		}
 
 		ac, err := client.NewAlpaconAPIClient()
@@ -85,12 +88,17 @@ var workSessionCreateCmd = &cobra.Command{
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		serverList := splitCSV(servers)
-		if len(serverList) == 0 {
-			utils.CliErrorWithExit("--servers must contain at least one valid server name.")
+		var serverNames []string
+		for _, s := range createServers {
+			if s = strings.TrimSpace(s); s != "" {
+				serverNames = append(serverNames, s)
+			}
 		}
-		serverIDs := make([]string, 0, len(serverList))
-		for _, name := range serverList {
+		if len(serverNames) == 0 {
+			utils.CliErrorWithExit("--server must contain at least one valid server name.")
+		}
+		serverIDs := make([]string, 0, len(serverNames))
+		for _, name := range serverNames {
 			id, err := server.GetServerIDByName(ac, name)
 			if err != nil {
 				utils.CliErrorWithExit("Server %q not found: %s.", name, err)
@@ -207,8 +215,8 @@ func pollForApproval(ac *client.AlpaconClient, id string) error {
 
 func init() {
 	workSessionCreateCmd.Flags().StringVar(&purpose, "purpose", "", "Session purpose")
-	workSessionCreateCmd.Flags().StringVar(&scopes, "scopes", "", "Comma-separated scopes (command, websh, webftp, editor, tunnel, sudo)")
-	workSessionCreateCmd.Flags().StringVar(&servers, "servers", "", "Comma-separated server names")
+	workSessionCreateCmd.Flags().StringSliceVar(&createScopes, "scope", nil, "Scopes to request (repeatable; comma-separated values also accepted)")
+	workSessionCreateCmd.Flags().StringSliceVar(&createServers, "server", nil, "Target server names (repeatable; comma-separated values also accepted)")
 	workSessionCreateCmd.Flags().StringVar(&expiresIn, "expires-in", "", "Session duration (e.g. 1h, 2h, 4h)")
 	workSessionCreateCmd.Flags().StringVar(&expiresAt, "expires-at", "", "Absolute expiry time (RFC3339)")
 	workSessionCreateCmd.Flags().StringVar(&requesterType, "requester-type", "user", "Requester type: user or agent")

--- a/cmd/worksession/worksession_reject.go
+++ b/cmd/worksession/worksession_reject.go
@@ -9,7 +9,7 @@ import (
 
 var workSessionRejectCmd = &cobra.Command{
 	Use:     "reject SESSION_ID",
-	Short:   "Reject a pending work session",
+	Short:   "Reject a pending work session (superuser only)",
 	Args:    cobra.ExactArgs(1),
 	Example: `  alpacon work-session reject ses-abc123`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/worksession/worksession_reject.go
+++ b/cmd/worksession/worksession_reject.go
@@ -1,0 +1,27 @@
+package worksession
+
+import (
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workSessionRejectCmd = &cobra.Command{
+	Use:     "reject SESSION_ID",
+	Short:   "Reject a pending work session",
+	Args:    cobra.ExactArgs(1),
+	Example: `  alpacon work-session reject ses-abc123`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if err := wsapi.RejectWorkSession(ac, args[0]); err != nil {
+			utils.CliErrorWithExit("Failed to reject work session: %s.", err)
+		}
+
+		utils.CliSuccess("Work session %s rejected.", args[0])
+	},
+}

--- a/cmd/worksession/worksession_reject.go
+++ b/cmd/worksession/worksession_reject.go
@@ -9,7 +9,8 @@ import (
 
 var workSessionRejectCmd = &cobra.Command{
 	Use:     "reject SESSION_ID",
-	Short:   "Reject a pending work session (superuser only)",
+	Short:   "Reject a pending work session",
+	Long:    "Reject a pending work session. Superuser only.",
 	Args:    cobra.ExactArgs(1),
 	Example: `  alpacon work-session reject ses-abc123`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/worksession/worksession_revoke.go
+++ b/cmd/worksession/worksession_revoke.go
@@ -1,0 +1,27 @@
+package worksession
+
+import (
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workSessionRevokeCmd = &cobra.Command{
+	Use:     "revoke SESSION_ID",
+	Short:   "Force-terminate an active or approved work session",
+	Args:    cobra.ExactArgs(1),
+	Example: `  alpacon work-session revoke ses-abc123`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if err := wsapi.RevokeWorkSession(ac, args[0]); err != nil {
+			utils.CliErrorWithExit("Failed to revoke work session: %s.", err)
+		}
+
+		utils.CliSuccess("Work session %s revoked.", args[0])
+	},
+}

--- a/cmd/worksession/worksession_revoke.go
+++ b/cmd/worksession/worksession_revoke.go
@@ -9,7 +9,7 @@ import (
 
 var workSessionRevokeCmd = &cobra.Command{
 	Use:     "revoke SESSION_ID",
-	Short:   "Force-terminate an active or approved work session",
+	Short:   "Force-terminate an active or approved work session (superuser only)",
 	Args:    cobra.ExactArgs(1),
 	Example: `  alpacon work-session revoke ses-abc123`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/worksession/worksession_revoke.go
+++ b/cmd/worksession/worksession_revoke.go
@@ -9,7 +9,8 @@ import (
 
 var workSessionRevokeCmd = &cobra.Command{
 	Use:     "revoke SESSION_ID",
-	Short:   "Force-terminate an active or approved work session (superuser only)",
+	Short:   "Force-terminate an active or approved work session",
+	Long:    "Force-terminate an active or approved work session. Superuser only.",
 	Args:    cobra.ExactArgs(1),
 	Example: `  alpacon work-session revoke ses-abc123`,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Summary

- Add three superuser-only subcommands to the \`work-session\` command group: \`approve\`, \`reject\`, and \`revoke\`
- These mirror existing server-side approval workflow endpoints, bringing them to the CLI for automation and rapid operational response
- All permission checks are enforced server-side; no client-side guards needed
- Align \`work-session create\` flag names with \`approve\`: rename \`--scopes\`/\`--servers\` to \`--scope\`/\`--server\` (singular, \`StringSliceVar\`) for consistency

## New commands

**\`work-session approve SESSION_ID [--scope SCOPE...] [--server SERVER...]\`**
Approves a pending session. Without flags, grants access as originally requested. \`--scope\` and \`--server\` let the approver narrow the granted scopes or target servers at approval time.

**\`work-session reject SESSION_ID\`**
Rejects a pending session (no flags).

**\`work-session revoke SESSION_ID\`**
Force-terminates an active or approved session (no flags).

## Implementation notes

- \`--scope\`: supports both \`--scope a --scope b\` and \`--scope a,b\` via \`StringSliceVar\`; empty strings are filtered before sending
- \`--server\`: accepts server names, resolved to UUIDs client-side (same pattern as \`work-session create\`)
- \`work-session create\` migrated from \`StringVar\` (\`--scopes\`/\`--servers\`) to \`StringSliceVar\` (\`--scope\`/\`--server\`) to match \`approve\` conventions
- Follows existing leaf command conventions: \`Run\` + \`utils.CliErrorWithExit\`

## Test plan

- [ ] \`go test -race -v ./api/worksession/...\` — 4 new API-layer tests (reject, revoke, approve without adjustments, approve with adjustments)
- [ ] \`go build -o alpacon .\` — clean build
- [ ] \`golangci-lint run ./...\` — no lint errors
- [ ] Manual: \`alpacon work-session approve/reject/revoke <id>\`
- [ ] Manual: \`alpacon work-session approve <id> --scope command,websh --server my-server\`
- [ ] Manual: \`alpacon work-session create --scope command --server web-editor --expires-in 1h --purpose "test"\`

Closes #163