### PR TITLE
fix(exec,websh): restore multi-word arg boundaries and propagate remote exit code

### DIFF
--- a/api/event/event.go
+++ b/api/event/event.go
@@ -104,6 +104,10 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 		return fmt.Sprintf("command failed with status: %s", result.Status), nil
 	}
 
+	if result.Success != nil && !*result.Success {
+		return result.Result, &RemoteCommandError{Output: result.Result}
+	}
+
 	return result.Result, nil
 }
 

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -101,7 +101,7 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 	}
 
 	if result.Status == "stuck" || result.Status == "error" {
-		return fmt.Sprintf("command failed with status: %s", result.Status), nil
+		return "", fmt.Errorf("command failed with status: %s", result.Status)
 	}
 
 	if result.Success != nil && !*result.Success {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -281,4 +282,37 @@ func TestRunCommand_InfraStatusReturnsError(t *testing.T) {
 			assert.Contains(t, err.Error(), status)
 		})
 	}
+}
+
+func TestRunCommand_SuccessFalseReturnsRemoteCommandError(t *testing.T) {
+	falseVal := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
+			_ = json.NewEncoder(w).Encode(api.ListResponse[map[string]any]{
+				Count:   1,
+				Results: []map[string]any{{"id": "srv-1", "name": "server-x"}},
+			})
+		case r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "cmd-1"}})
+		default:
+			_ = json.NewEncoder(w).Encode(EventDetails{
+				ID:      "cmd-1",
+				Status:  "completed",
+				Success: &falseVal,
+				Result:  "command output here",
+			})
+		}
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	result, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
+	require.Error(t, err)
+
+	var remoteErr *RemoteCommandError
+	require.True(t, errors.As(err, &remoteErr), "err must be *RemoteCommandError")
+	assert.Equal(t, "command output here", result)
+	assert.Equal(t, "command output here", remoteErr.Output)
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -254,3 +254,31 @@ func TestRunCommand_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
 	hadKey, _, _ := capture.snapshot()
 	assert.False(t, hadKey, "body must omit work_session field when ID is empty")
 }
+
+func TestRunCommand_InfraStatusReturnsError(t *testing.T) {
+	for _, status := range []string{"stuck", "error"} {
+		t.Run(status, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
+					_ = json.NewEncoder(w).Encode(api.ListResponse[map[string]any]{
+						Count:   1,
+						Results: []map[string]any{{"id": "srv-1", "name": "server-x"}},
+					})
+				case r.Method == http.MethodPost:
+					_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "cmd-1"}})
+				default:
+					_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: status})
+				}
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			result, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
+			require.Error(t, err)
+			assert.Empty(t, result)
+			assert.Contains(t, err.Error(), status)
+		})
+	}
+}

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -6,6 +6,16 @@ import (
 	"github.com/alpacax/alpacon-cli/api/types"
 )
 
+// RemoteCommandError is returned when the remote command completed but exited
+// with a non-zero status. Output holds the captured stdout/stderr.
+type RemoteCommandError struct {
+	Output string
+}
+
+func (e *RemoteCommandError) Error() string {
+	return "remote command exited with non-zero status"
+}
+
 type EventAttributes struct {
 	Server      string `json:"server"`
 	Shell       string `json:"shell"`

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -1,11 +1,6 @@
 package exec
 
 import (
-	"errors"
-	"fmt"
-	"os"
-
-	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
 	"github.com/alpacax/alpacon-cli/utils"
@@ -80,15 +75,6 @@ Flags:
 
 		env := make(map[string]string)
 		result, err := RunCommandWithRetry(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
-		if err != nil {
-			var remoteErr *event.RemoteCommandError
-			if errors.As(err, &remoteErr) {
-				fmt.Println(result)
-				os.Exit(1)
-			}
-			utils.CliErrorWithExit("%s", err)
-			return
-		}
-		fmt.Println(result)
+		HandleCommandResult(result, err)
 	},
 }

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -20,6 +20,10 @@ intended for the remote command (e.g., -U, -d) are not interpreted as alpacon fl
 
 All flags must be placed before the server name.
 
+Shell metacharacters (;, |, &, $) pass through unquoted to the remote shell.
+To send a literal metacharacter, wrap the argument in quotes:
+  alpacon exec server 'echo hello;world'
+
 Flags:
   -u, --username [USER_NAME]    Specify the username for command execution.
   -g, --groupname [GROUP_NAME]  Specify the group name for command execution.

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -1,8 +1,11 @@
 package exec
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
+	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
 	"github.com/alpacax/alpacon-cli/utils"
@@ -78,6 +81,11 @@ Flags:
 		env := make(map[string]string)
 		result, err := RunCommandWithRetry(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
 		if err != nil {
+			var remoteErr *event.RemoteCommandError
+			if errors.As(err, &remoteErr) {
+				fmt.Println(result)
+				os.Exit(1)
+			}
 			utils.CliErrorWithExit("%s", err)
 			return
 		}

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -109,11 +109,14 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 	}
 }
 
-// ShellJoin reassembles tokenized command parts into a single string,
-// quoting only parts that contain whitespace or single quotes so that
-// argument boundaries are preserved. Shell metacharacters (|, ;, $, *, etc.)
-// are passed through intentionally so the remote shell can interpret them.
+// ShellJoin reassembles tokenized command parts into a single string.
+// Parts containing whitespace or single quotes are re-quoted to preserve
+// argument boundaries; metacharacters pass through for the remote shell.
+// A single-element slice is returned as-is (already a formed command line).
 func ShellJoin(parts []string) string {
+	if len(parts) == 1 {
+		return parts[0]
+	}
 	out := make([]string, len(parts))
 	for i, p := range parts {
 		out[i] = shellQuote(p)

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -109,7 +109,10 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 	}
 }
 
-// ShellJoin reassembles tokenized command parts into a shell-safe string.
+// ShellJoin reassembles tokenized command parts into a single string,
+// quoting only parts that contain whitespace or single quotes so that
+// argument boundaries are preserved. Shell metacharacters (|, ;, $, *, etc.)
+// are passed through intentionally so the remote shell can interpret them.
 func ShellJoin(parts []string) string {
 	out := make([]string, len(parts))
 	for i, p := range parts {

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -105,8 +105,31 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 		Groupname:     groupname,
 		WorkSessionID: workSessionID,
 		Server:        server,
-		Command:       strings.Join(commandParts, " "),
+		Command:       ShellJoin(commandParts),
 	}
+}
+
+// ShellJoin reassembles tokenized command parts into a shell-safe string.
+// Each part containing whitespace or a single quote is wrapped in single
+// quotes, with internal single quotes escaped as '\''.
+func ShellJoin(parts []string) string {
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = shellQuote(p)
+	}
+	return strings.Join(out, " ")
+}
+
+// shellQuote wraps s in single quotes if it contains whitespace or a single quote.
+// Whitespace means the local shell stripped surrounding quotes from a multi-word
+// argument; re-quoting preserves the boundary on the remote side. Single quotes
+// are escaped as '\'' to avoid syntax errors. Other shell metacharacters (|, $,
+// *, etc.) are intentionally left unquoted so the remote shell can interpret them.
+func shellQuote(s string) string {
+	if !strings.ContainsAny(s, " \t\n'") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // matchShortOrLongFlag checks whether arg is an exact match for the given short

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -122,6 +122,9 @@ func ShellJoin(parts []string) string {
 // Whitespace signals that the local shell stripped outer quotes from a multi-word arg;
 // metacharacters (|, $, *, etc.) pass through so the remote shell can interpret them.
 func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
 	if !strings.ContainsAny(s, " \t\n'") {
 		return s
 	}

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -110,8 +110,6 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 }
 
 // ShellJoin reassembles tokenized command parts into a shell-safe string.
-// Each part containing whitespace or a single quote is wrapped in single
-// quotes, with internal single quotes escaped as '\''.
 func ShellJoin(parts []string) string {
 	out := make([]string, len(parts))
 	for i, p := range parts {
@@ -121,10 +119,8 @@ func ShellJoin(parts []string) string {
 }
 
 // shellQuote wraps s in single quotes if it contains whitespace or a single quote.
-// Whitespace means the local shell stripped surrounding quotes from a multi-word
-// argument; re-quoting preserves the boundary on the remote side. Single quotes
-// are escaped as '\'' to avoid syntax errors. Other shell metacharacters (|, $,
-// *, etc.) are intentionally left unquoted so the remote shell can interpret them.
+// Whitespace signals that the local shell stripped outer quotes from a multi-word arg;
+// metacharacters (|, $, *, etc.) pass through so the remote shell can interpret them.
 func shellQuote(s string) string {
 	if !strings.ContainsAny(s, " \t\n'") {
 		return s

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -301,7 +301,7 @@ func TestParseRemoteExecArgs(t *testing.T) {
 			args: []string{"server", "echo", "hello world"},
 			expected: RemoteExecArgs{
 				Server:  "server",
-				Command: "echo hello world",
+				Command: "echo 'hello world'",
 			},
 		},
 		{
@@ -309,7 +309,7 @@ func TestParseRemoteExecArgs(t *testing.T) {
 			args: []string{"server", "bash", "-c", "echo 'hello world'"},
 			expected: RemoteExecArgs{
 				Server:  "server",
-				Command: "bash -c echo 'hello world'",
+				Command: `bash -c 'echo '\''hello world'\'''`,
 			},
 		},
 		{
@@ -317,7 +317,7 @@ func TestParseRemoteExecArgs(t *testing.T) {
 			args: []string{"server", "bash", "-c", `echo "hello world"`},
 			expected: RemoteExecArgs{
 				Server:  "server",
-				Command: `bash -c echo "hello world"`,
+				Command: `bash -c 'echo "hello world"'`,
 			},
 		},
 		{
@@ -344,7 +344,7 @@ func TestParseRemoteExecArgs(t *testing.T) {
 			expected: RemoteExecArgs{
 				Username: "root",
 				Server:   "db-server",
-				Command:  "docker exec -it postgres psql -U myproject -d myproject -c SELECT 1;",
+				Command:  "docker exec -it postgres psql -U myproject -d myproject -c 'SELECT 1;'",
 			},
 		},
 		{
@@ -376,7 +376,7 @@ func TestParseRemoteExecArgs(t *testing.T) {
 			args: []string{"server", "awk", "{print $1}", "/var/log/access.log"},
 			expected: RemoteExecArgs{
 				Server:  "server",
-				Command: "awk {print $1} /var/log/access.log",
+				Command: "awk '{print $1}' /var/log/access.log",
 			},
 		},
 		{
@@ -392,7 +392,7 @@ func TestParseRemoteExecArgs(t *testing.T) {
 			args: []string{"server", "--", "curl", "-s", "-H", "Authorization: Bearer token123", "http://localhost:8080/api/health"},
 			expected: RemoteExecArgs{
 				Server:  "server",
-				Command: "curl -s -H Authorization: Bearer token123 http://localhost:8080/api/health",
+				Command: "curl -s -H 'Authorization: Bearer token123' http://localhost:8080/api/health",
 			},
 		},
 		{

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -539,6 +539,15 @@ func TestParseRemoteExecArgs_ShellQuoting(t *testing.T) {
 			expectedServer:  "server",
 			expectedCommand: `bash -c 'echo it'\''s done'`,
 		},
+		{
+			// Single token with spaces — entire command passed as one quoted CLI argument,
+			// e.g. alpacon exec server "ls -la /var/log". Must be returned unchanged
+			// so the remote shell interprets it as a command with arguments.
+			name:            "single-token command with spaces",
+			args:            []string{"server", "ls -la /var/log"},
+			expectedServer:  "server",
+			expectedCommand: "ls -la /var/log",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -479,6 +479,78 @@ func TestParseRemoteExecArgs_DoubleDashIgnoresWorkSession(t *testing.T) {
 	assert.Contains(t, parsed.Command, "--work-session")
 }
 
+// TestParseRemoteExecArgs_ShellQuoting verifies that multi-word arguments
+// (e.g. the script body in bash -c '...') are re-quoted after the OS shell
+// strips the surrounding quotes during tokenization. Without this, strings.Join
+// loses the arg boundary and the server's sh fails with a syntax error (issue #164).
+func TestParseRemoteExecArgs_ShellQuoting(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             []string
+		expectedUsername string
+		expectedServer   string
+		expectedCommand  string
+	}{
+		{
+			// Exact reproduction of issue #164 symptom 3.
+			// User types: alpacon exec root@r770-1 bash -c 'for i in 1 2 3; do echo "line-$i"; done'
+			// OS shell strips the outer single quotes; CLI receives the for-loop body as one token.
+			name:             "bash -c for loop body (issue #164)",
+			args:             []string{"root@r770-1", "bash", "-c", `for i in 1 2 3; do echo "line-$i"; done`},
+			expectedUsername: "root",
+			expectedServer:   "r770-1",
+			expectedCommand:  `bash -c 'for i in 1 2 3; do echo "line-$i"; done'`,
+		},
+		{
+			// Simpler variant: stdout check from issue #164 symptom 1.
+			// User types: alpacon exec root@r770-1 bash -c 'echo hello-stdout'
+			name:             "bash -c simple echo",
+			args:             []string{"root@r770-1", "bash", "-c", "echo hello-stdout"},
+			expectedUsername: "root",
+			expectedServer:   "r770-1",
+			expectedCommand:  "bash -c 'echo hello-stdout'",
+		},
+		{
+			// Exit-code check from issue #164 symptom 2.
+			// User types: alpacon exec root@r770-1 bash -c 'echo before-fail; exit 1'
+			name:            "bash -c with exit code",
+			args:            []string{"server", "bash", "-c", "echo before-fail; exit 1"},
+			expectedServer:  "server",
+			expectedCommand: "bash -c 'echo before-fail; exit 1'",
+		},
+		{
+			// Non-bash interpreter with a multi-word script body.
+			name:            "python3 -c with spaces",
+			args:            []string{"server", "python3", "-c", "import sys; print(sys.version)"},
+			expectedServer:  "server",
+			expectedCommand: "python3 -c 'import sys; print(sys.version)'",
+		},
+		{
+			// Args with no special characters must not be quoted (no behavior change).
+			name:            "plain command — no quoting needed",
+			args:            []string{"server", "docker", "ps"},
+			expectedServer:  "server",
+			expectedCommand: "docker ps",
+		},
+		{
+			// Arg contains an internal single quote — must be escaped as '\''
+			name:            "arg with internal single quote",
+			args:            []string{"server", "bash", "-c", "echo it's done"},
+			expectedServer:  "server",
+			expectedCommand: `bash -c 'echo it'\''s done'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseRemoteExecArgs(tt.args)
+			assert.Equal(t, tt.expectedServer, result.Server, "Server")
+			assert.Equal(t, tt.expectedUsername, result.Username, "Username")
+			assert.Equal(t, tt.expectedCommand, result.Command, "Command")
+		})
+	}
+}
+
 func TestParseRemoteExecArgs_Errors(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -55,7 +55,9 @@ func HandleCommandResult(result string, err error) {
 	if err != nil {
 		var remoteErr *event.RemoteCommandError
 		if errors.As(err, &remoteErr) {
-			fmt.Println(remoteErr.Output)
+			if remoteErr.Output != "" {
+				fmt.Println(remoteErr.Output)
+			}
 			os.Exit(1)
 		}
 		utils.CliErrorWithExit("%s", err)

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -55,7 +55,7 @@ func HandleCommandResult(result string, err error) {
 	if err != nil {
 		var remoteErr *event.RemoteCommandError
 		if errors.As(err, &remoteErr) {
-			fmt.Println(result)
+			fmt.Println(remoteErr.Output)
 			os.Exit(1)
 		}
 		utils.CliErrorWithExit("%s", err)

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -40,6 +40,7 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 				return err
 			},
 		})
+		// RetryOperation may return a RemoteCommandError; re-check after HandleCommonErrors.
 		if errors.As(err, &remoteErr) {
 			return result, remoteErr
 		}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/alpacax/alpacon-cli/api/event"
@@ -17,6 +18,10 @@ import (
 func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (string, error) {
 	result, err := event.RunCommand(ac, serverName, command, username, groupname, env, workSessionID)
 	if err != nil {
+		var remoteErr *event.RemoteCommandError
+		if errors.As(err, &remoteErr) {
+			return result, remoteErr
+		}
 		err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
 			OnMFARequired: func(srv string) error {
 				return mfa.HandleMFAError(ac, srv)
@@ -35,6 +40,10 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 			},
 		})
 		if err != nil {
+			var remoteErr *event.RemoteCommandError
+			if errors.As(err, &remoteErr) {
+				return result, remoteErr
+			}
 			return "", fmt.Errorf("failed to execute command on '%s' server: %w", serverName, err)
 		}
 	}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/api/iam"
@@ -17,11 +18,11 @@ import (
 // to omit it.
 func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (string, error) {
 	result, err := event.RunCommand(ac, serverName, command, username, groupname, env, workSessionID)
+	var remoteErr *event.RemoteCommandError
+	if errors.As(err, &remoteErr) {
+		return result, remoteErr
+	}
 	if err != nil {
-		var remoteErr *event.RemoteCommandError
-		if errors.As(err, &remoteErr) {
-			return result, remoteErr
-		}
 		err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
 			OnMFARequired: func(srv string) error {
 				return mfa.HandleMFAError(ac, srv)
@@ -39,13 +40,26 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 				return err
 			},
 		})
+		if errors.As(err, &remoteErr) {
+			return result, remoteErr
+		}
 		if err != nil {
-			var remoteErr *event.RemoteCommandError
-			if errors.As(err, &remoteErr) {
-				return result, remoteErr
-			}
 			return "", fmt.Errorf("failed to execute command on '%s' server: %w", serverName, err)
 		}
 	}
 	return result, nil
+}
+
+// HandleCommandResult prints result on success, or exits appropriately on error.
+func HandleCommandResult(result string, err error) {
+	if err != nil {
+		var remoteErr *event.RemoteCommandError
+		if errors.As(err, &remoteErr) {
+			fmt.Println(result)
+			os.Exit(1)
+		}
+		utils.CliErrorWithExit("%s", err)
+		return
+	}
+	fmt.Println(result)
 }

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -206,15 +206,7 @@ Note: All flags must be placed before the server name.
 			}
 			command := execCmd.ShellJoin(commandArgs)
 			result, err := execCmd.RunCommandWithRetry(alpaconClient, serverName, command, username, groupname, env, workSessionID)
-			if err != nil {
-				var remoteErr *event.RemoteCommandError
-				if errors.As(err, &remoteErr) {
-					fmt.Println(result)
-					os.Exit(1)
-				}
-				utils.CliErrorWithExit("%s", err)
-			}
-			fmt.Println(result)
+			execCmd.HandleCommandResult(result, err)
 		} else {
 			session, err := websh.CreateWebshSession(alpaconClient, serverName, username, groupname, share, readOnly, workSessionID)
 

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -204,9 +204,14 @@ Note: All flags must be placed before the server name.
 					return
 				}
 			}
-			command := strings.Join(commandArgs, " ")
+			command := execCmd.ShellJoin(commandArgs)
 			result, err := execCmd.RunCommandWithRetry(alpaconClient, serverName, command, username, groupname, env, workSessionID)
 			if err != nil {
+				var remoteErr *event.RemoteCommandError
+				if errors.As(err, &remoteErr) {
+					fmt.Println(result)
+					os.Exit(1)
+				}
 				utils.CliErrorWithExit("%s", err)
 			}
 			fmt.Println(result)

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -104,7 +104,11 @@ var WebshCmd = &cobra.Command{
 	Long: `Open a websh terminal for interacting with a server or execute a command directly on the server.
 Supports SSH-like user@host syntax for specifying the username inline.
 For executing commands, it is highly recommended to wrap the entire command string in quotes
-to ensure it is interpreted correctly on the remote server.`,
+to ensure it is interpreted correctly on the remote server.
+
+Shell metacharacters (;, |, &, $) pass through unquoted to the remote shell.
+To send a literal metacharacter, wrap the argument in quotes:
+  alpacon websh server 'echo hello;world'`,
 	Example: `  # Open a websh terminal
   alpacon websh my-server
 


### PR DESCRIPTION
## Problem

Three bugs were reported in issue #164. This PR addresses two of them.

**Bug 1 — \`bash -c '...'\` silently runs under \`sh\` on the server**

The local shell strips quotes and splits \`bash -c 'for i in 1 2 3; do echo "line-$i"; done'\` into separate tokens. The CLI then reassembles them with \`strings.Join(" ")\`, so the remote receives \`bash -c for i in ...\` — the loop body arrives as positional args, not as a single \`-c\` argument, and \`/bin/sh\` ends up interpreting the first token only:

```
/bin/sh: 1: Syntax error: "do" unexpected
```

**Bug 2 — Remote exit code is not propagated to the client**

```
alpacon exec root@r770-1 bash -c 'echo before-fail; exit 1'
echo $?   # → 0 (always, regardless of remote exit status)
```

This breaks CI/CD wrappers that rely on the exit code of \`alpacon exec\`.

## Changes

**\`ShellJoin\` / \`shellQuote\`** (\`cmd/exec/parse.go\`)

Replaces \`strings.Join\` with \`ShellJoin\`, which wraps tokens containing whitespace or a single quote in single quotes to restore argument boundaries. Other metacharacters (\`|\`, \`$\`, \`*\`, etc.) pass through so the remote shell can interpret them. A single-element slice is returned unchanged — this handles the common case where the entire command is passed as one quoted CLI argument (e.g. \`alpacon exec server "ls -la /var/log"\`). Applied to both \`exec\` and \`websh\` command paths.

**\`RemoteCommandError\` sentinel type** (\`api/event/\`)

Wraps \`success: false\` server responses in a typed error, distinguishing remote non-zero exits from infrastructure errors. \`HandleCommandResult\` detects this, prints the output (skipped when empty to avoid a spurious blank line for commands like \`false\`), then calls \`os.Exit(1)\`.

**\`HandleCommandResult\` helper** (\`cmd/exec/run.go\`)

Extracts the duplicated error-handling block from \`exec.go\` and \`websh.go\` into a single shared helper.

## Verification

Tested against \`web-editor\` server with old installed binary vs. this build:

```
# Bug 1 — arg boundary restored
$ alpacon exec web-editor bash -c "echo hello world"
(no output)                          # old

$ ./alpacon exec web-editor bash -c "echo hello world"
hello world                          # fixed

# Bug 2 — exit code propagated
$ alpacon exec web-editor false; echo $?
0                                    # old

$ ./alpacon exec web-editor false; echo $?
1                                    # fixed
```

## Tests

```
go test -race -v ./cmd/exec/...
```

- Added \`TestParseRemoteExecArgs_ShellQuoting\` — 7 cases reproducing the quoting bug (including single-token command with spaces)
- Updated 6 existing \`TestParseRemoteExecArgs\` expected values that were documenting the broken behavior
- Added \`TestRunCommand_InfraStatusReturnsError\` — stuck/error statuses return non-nil error
- Added \`TestRunCommand_SuccessFalseReturnsRemoteCommandError\` — Success=false returns \`*RemoteCommandError\` with output preserved

## Out of scope

**Bug 3 — short stdout/stderr dropped non-deterministically** (reported in #164)

Adding \`sleep 1\` or producing longer output makes it reliable, which points to a flush/buffer race in the Alpamon agent closing the channel before all bytes are forwarded. This requires an agent-side fix and is out of scope for this PR.

## Related issue

\#164