### PR TITLE
feat(worksession): add timeline and recording subcommands

### DIFF
--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -51,7 +51,6 @@ type WorkSessionApproveRequest struct {
 	AdjustedServers []string `json:"adjusted_servers,omitempty"`
 }
 
-
 // TimelineItem represents a single event in a work session's activity timeline.
 // All event types share this struct; type-specific fields are zero-valued for other types.
 type TimelineItem struct {

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -76,7 +76,7 @@ type TimelineItem struct {
 	IsTunnel   bool  `json:"is_tunnel"`
 	TargetPort *int  `json:"target_port"`
 
-	// file_upload / file_download (path may be string or []string — rendered as-is after JSON decode)
+	// file_upload / file_download
 	Name string `json:"name"`
 	Size int64  `json:"size"`
 
@@ -89,10 +89,6 @@ type TimelineItem struct {
 	// websh_record
 	SessionID    string `json:"session_id"`
 	MaskedRecord string `json:"masked_record"`
-}
-
-type TimelineResponse struct {
-	Results []TimelineItem `json:"results"`
 }
 
 type TimelineAttributes struct {

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -45,3 +45,55 @@ type WorkSessionCreateRequest struct {
 type WorkSessionExtendRequest struct {
 	ExpiresAt string `json:"expires_at"`
 }
+
+// TimelineItem represents a single event in a work session's activity timeline.
+// All event types share this struct; type-specific fields are zero-valued for other types.
+type TimelineItem struct {
+	Type      string  `json:"type"`
+	Timestamp *string `json:"timestamp"`
+	ID        string  `json:"id"`
+	ServerID  *string `json:"server_id"`
+
+	// shared across session-like types (websh_session, tunnel_session, ftp_session)
+	Username  string  `json:"username"`
+	Groupname string  `json:"groupname"`
+	ClosedAt  *string `json:"closed_at"`
+	ClientType string `json:"client_type"`
+
+	// command
+	Shell       string   `json:"shell"`
+	Line        string   `json:"line"`
+	Success     *bool    `json:"success"`
+	Denied      bool     `json:"denied"`
+	ElapsedTime float64  `json:"elapsed_time"`
+
+	// tunnel_session
+	IsTunnel   bool  `json:"is_tunnel"`
+	TargetPort *int  `json:"target_port"`
+
+	// file_upload / file_download (path may be string or []string — rendered as-is after JSON decode)
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+
+	// sudo_grant
+	GrantType string  `json:"grant_type"`
+	Status    string  `json:"status"`
+	Command   *string `json:"command"`
+	OneTime   bool    `json:"one_time"`
+
+	// websh_record
+	SessionID    string `json:"session_id"`
+	MaskedRecord string `json:"masked_record"`
+}
+
+type TimelineResponse struct {
+	Results []TimelineItem `json:"results"`
+}
+
+type TimelineAttributes struct {
+	Time    string `json:"timestamp" table:"Time"`
+	Type    string `json:"type"      table:"Type"`
+	Server  string `json:"server"    table:"Server"`
+	User    string `json:"user"      table:"User"`
+	Details string `json:"details"   table:"Details"`
+}

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -92,3 +92,22 @@ func ExtendWorkSession(ac *client.AlpaconClient, id string, req WorkSessionExten
 func GetWorkSessionRaw(ac *client.AlpaconClient, id string) ([]byte, error) {
 	return ac.SendGetRequest(utils.BuildURL(workSessionURL, id, nil))
 }
+
+func GetWorkSessionTimeline(ac *client.AlpaconClient, id string, includeRecords bool) ([]TimelineItem, error) {
+	include := "true"
+	if !includeRecords {
+		include = "false"
+	}
+	url := utils.BuildURL(workSessionURL, path.Join(id, "timeline"), map[string]string{
+		"include_records": include,
+	})
+	body, err := ac.SendGetRequest(url)
+	if err != nil {
+		return nil, err
+	}
+	var resp TimelineResponse
+	if err = json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Results, nil
+}

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -3,6 +3,7 @@ package worksession
 import (
 	"encoding/json"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/alpacax/alpacon-cli/api"
@@ -109,12 +110,8 @@ func GetWorkSessionRaw(ac *client.AlpaconClient, id string) ([]byte, error) {
 }
 
 func GetWorkSessionTimeline(ac *client.AlpaconClient, id string, includeRecords bool) ([]TimelineItem, error) {
-	include := "true"
-	if !includeRecords {
-		include = "false"
-	}
 	url := utils.BuildURL(workSessionURL, path.Join(id, "timeline"), map[string]string{
-		"include_records": include,
+		"include_records": strconv.FormatBool(includeRecords),
 	})
 	body, err := ac.SendGetRequest(url)
 	if err != nil {

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -110,16 +110,8 @@ func GetWorkSessionRaw(ac *client.AlpaconClient, id string) ([]byte, error) {
 }
 
 func GetWorkSessionTimeline(ac *client.AlpaconClient, id string, includeRecords bool) ([]TimelineItem, error) {
-	url := utils.BuildURL(workSessionURL, path.Join(id, "timeline"), map[string]string{
+	endpoint := utils.BuildURL(workSessionURL, path.Join(id, "timeline"), nil)
+	return api.FetchAllPages[TimelineItem](ac, endpoint, map[string]string{
 		"include_records": strconv.FormatBool(includeRecords),
 	})
-	body, err := ac.SendGetRequest(url)
-	if err != nil {
-		return nil, err
-	}
-	var resp TimelineResponse
-	if err = json.Unmarshal(body, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Results, nil
 }

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -248,3 +248,41 @@ func TestApproveWorkSession_WithAdjustments(t *testing.T) {
 	err := ApproveWorkSession(newTestClient(ts), "ses-abc", req)
 	assert.NoError(t, err)
 }
+
+func TestGetWorkSessionTimeline(t *testing.T) {
+	ts := newString("2024-01-15T10:30:00Z")
+	items := []TimelineItem{
+		{Type: "command", Timestamp: ts, Line: "ls -la"},
+		{Type: "websh_session", Timestamp: ts},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/timeline/"))
+		assert.Equal(t, "true", r.URL.Query().Get("include_records"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[TimelineItem]{Count: 2, Results: items})
+	}))
+	defer srv.Close()
+
+	result, err := GetWorkSessionTimeline(newTestClient(srv), "ses-abc", true)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "command", result[0].Type)
+	assert.Equal(t, "ls -la", result[0].Line)
+}
+
+func TestGetWorkSessionTimeline_ExcludeRecords(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-xyz/timeline/"))
+		assert.Equal(t, "false", r.URL.Query().Get("include_records"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[TimelineItem]{Count: 0, Results: nil})
+	}))
+	defer srv.Close()
+
+	result, err := GetWorkSessionTimeline(newTestClient(srv), "ses-xyz", false)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func newString(s string) *string { return &s }

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -34,6 +34,7 @@ func init() {
 	WorkSessionCmd.AddCommand(workSessionUseCmd)
 	WorkSessionCmd.AddCommand(workSessionCurrentCmd)
 	WorkSessionCmd.AddCommand(workSessionTimelineCmd)
+	WorkSessionCmd.AddCommand(workSessionRecordingCmd)
 	WorkSessionCmd.AddCommand(workSessionApproveCmd)
 	WorkSessionCmd.AddCommand(workSessionRejectCmd)
 	WorkSessionCmd.AddCommand(workSessionRevokeCmd)

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -33,4 +33,5 @@ func init() {
 	WorkSessionCmd.AddCommand(workSessionExtendCmd)
 	WorkSessionCmd.AddCommand(workSessionUseCmd)
 	WorkSessionCmd.AddCommand(workSessionCurrentCmd)
+	WorkSessionCmd.AddCommand(workSessionTimelineCmd)
 }

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -20,7 +20,7 @@ var WorkSessionCmd = &cobra.Command{
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session approve', 'alpacon work-session reject', or 'alpacon work-session revoke'. Run 'alpacon work-session --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session approve', 'alpacon work-session reject', 'alpacon work-session revoke', 'alpacon work-session timeline', or 'alpacon work-session recording'. Run 'alpacon work-session --help' for more information")
 	},
 }
 

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ansiEscape matches ANSI/VT escape sequences: CSI, OSC (BEL or ST), DCS/PM/APC string controls (ST), and Fe sequences.
-var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|[P^_][^\x1b]*\x1b\\|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[@-Z\\-_])`)
+// ansiEscape matches ANSI/VT escape sequences: CSI, OSC (BEL or ST), DCS/PM/APC string controls (ST), and Fe/Fs/nF sequences.
+var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|[P^_][^\x1b]*\x1b\\|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[\x20-\x2f]*[\x40-\x7e])`)
 
 var recordingIndex int
 

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -65,11 +65,11 @@ func findRecording(recordings []wsapi.TimelineItem, index int) (*wsapi.TimelineI
 	if index < 1 || index > len(recordings) {
 		return nil, -1
 	}
-	return &recordings[index-1], index - 1
+	return &recordings[index-1], index
 }
 
 func printRecordingHeader(target *wsapi.TimelineItem, idx int, total int) {
-	header := fmt.Sprintf("Recording %d/%d", idx+1, total)
+	header := fmt.Sprintf("Recording %d/%d", idx, total)
 	if ts := resolveTimestamp(target.Timestamp); ts != "" {
 		header += " — " + ts
 	}

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ansiEscape matches ANSI/VT escape sequences: CSI (full parameter/intermediate byte ranges), OSC (BEL or ST), and Fe sequences.
-var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07]*(?:\x07|\x1b\\)|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[@-Z\\-_])`)
+// ansiEscape matches ANSI/VT escape sequences: CSI, OSC (BEL or ST), DCS/PM/APC string controls (ST), and Fe sequences.
+var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|[P^_][^\x1b]*\x1b\\|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[@-Z\\-_])`)
 
 var recordingIndex int
 

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -69,12 +69,8 @@ func findRecording(recordings []wsapi.TimelineItem, index int) (*wsapi.TimelineI
 }
 
 func printRecordingHeader(target *wsapi.TimelineItem, idx int, total int) {
-	ts := ""
-	if target.Timestamp != nil {
-		ts = formatTimestamp(*target.Timestamp)
-	}
 	header := fmt.Sprintf("Recording %d/%d", idx+1, total)
-	if ts != "" {
+	if ts := resolveTimestamp(target.Timestamp); ts != "" {
 		header += " — " + ts
 	}
 	fmt.Println(header)

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -1,0 +1,90 @@
+package worksession
+
+import (
+	"fmt"
+	"regexp"
+
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+// ansiEscape matches ANSI/VT escape sequences: CSI, OSC, and single-char Fe sequences.
+var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07]*\x07|\[[0-9;?]*[A-Za-z]|[@-Z\\-_])`)
+
+var recordingIndex int
+
+var workSessionRecordingCmd = &cobra.Command{
+	Use:     "recording SESSION_ID",
+	Aliases: []string{"rec"},
+	Short:   "Show a Websh session recording",
+	Args:    cobra.ExactArgs(1),
+	Example: `  alpacon work-session recording ses-abc123
+  alpacon work-session recording ses-abc123 --index 2
+  alpacon work-session rec ses-abc123`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		sessionID := args[0]
+
+		items, err := wsapi.GetWorkSessionTimeline(ac, sessionID, true)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve work session timeline: %s.", err)
+		}
+
+		var recordings []wsapi.TimelineItem
+		for _, item := range items {
+			if item.Type == "websh_record" {
+				recordings = append(recordings, item)
+			}
+		}
+
+		if len(recordings) == 0 {
+			utils.CliErrorWithExit("No recordings found for session %s.", sessionID)
+		}
+
+		target, idx := findRecording(recordings, recordingIndex)
+		if target == nil {
+			utils.CliErrorWithExit("Recording index %d out of range (session has %d recording(s)).", recordingIndex, len(recordings))
+		}
+
+		printRecordingHeader(target, idx, len(recordings))
+		printRecordingContent(target.MaskedRecord)
+	},
+}
+
+func init() {
+	workSessionRecordingCmd.Flags().IntVar(&recordingIndex, "index", 1, "Recording index to display (1-based)")
+}
+
+func findRecording(recordings []wsapi.TimelineItem, index int) (*wsapi.TimelineItem, int) {
+	if index < 1 || index > len(recordings) {
+		return nil, -1
+	}
+	return &recordings[index-1], index - 1
+}
+
+func printRecordingHeader(target *wsapi.TimelineItem, idx int, total int) {
+	ts := ""
+	if target.Timestamp != nil {
+		ts = formatTimestamp(*target.Timestamp)
+	}
+	header := fmt.Sprintf("Recording %d/%d", idx+1, total)
+	if ts != "" {
+		header += " — " + ts
+	}
+	fmt.Println(header)
+	fmt.Println()
+}
+
+func printRecordingContent(raw string) {
+	content := ansiEscape.ReplaceAllString(raw, "")
+	fmt.Print(content)
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		fmt.Println()
+	}
+}

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ansiEscape matches ANSI/VT escape sequences: CSI, OSC, and single-char Fe sequences.
-var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07]*\x07|\[[0-9;?]*[A-Za-z]|[@-Z\\-_])`)
+// ansiEscape matches ANSI/VT escape sequences: CSI (including ~ finals), OSC (BEL or ST), and Fe sequences.
+var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07]*(?:\x07|\x1b\\)|\[[0-9;?]*[@-~]|[@-Z\\-_])`)
 
 var recordingIndex int
 

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ansiEscape matches ANSI/VT escape sequences: CSI (including ~ finals), OSC (BEL or ST), and Fe sequences.
-var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07]*(?:\x07|\x1b\\)|\[[0-9;?]*[@-~]|[@-Z\\-_])`)
+// ansiEscape matches ANSI/VT escape sequences: CSI (full parameter/intermediate byte ranges), OSC (BEL or ST), and Fe sequences.
+var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07]*(?:\x07|\x1b\\)|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[@-Z\\-_])`)
 
 var recordingIndex int
 

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ansiEscape matches ANSI/VT escape sequences: CSI, OSC (BEL or ST), DCS/PM/APC string controls (ST), and Fe/Fs/nF sequences.
-var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|[P^_][^\x1b]*\x1b\\|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[\x20-\x2f]*[\x40-\x7e])`)
+// ansiEscape matches ANSI/VT escape sequences: CSI, OSC (BEL or ST), DCS/SOS/PM/APC string controls (ST), and Fe/Fs/nF sequences.
+var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[\x20-\x2f]*[\x40-\x7e])`)
 
 var recordingIndex int
 

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -49,9 +49,9 @@ func TestFindRecording_NegativeIndex(t *testing.T) {
 	assert.Equal(t, -1, idx)
 }
 
-// buildRecordingsBySession
+// buildRecordingIndex
 
-func TestBuildRecordingsBySession_GroupsBySessionID(t *testing.T) {
+func TestBuildRecordingIndex_GroupsBySessionID(t *testing.T) {
 	items := []wsapi.TimelineItem{
 		{Type: "websh_session", ID: "s1"},
 		{Type: "websh_record", ID: "r1", SessionID: "s1"},
@@ -59,25 +59,28 @@ func TestBuildRecordingsBySession_GroupsBySessionID(t *testing.T) {
 		{Type: "websh_session", ID: "s2"},
 		{Type: "websh_record", ID: "r3", SessionID: "s2"},
 	}
-	m := buildRecordingsBySession(items)
-	assert.Len(t, m["s1"], 2)
-	assert.Len(t, m["s2"], 1)
-	assert.Equal(t, "r1", m["s1"][0].ID)
-	assert.Equal(t, "r3", m["s2"][0].ID)
+	bySession, flat := buildRecordingIndex(items)
+	assert.Len(t, bySession["s1"], 2)
+	assert.Len(t, bySession["s2"], 1)
+	assert.Len(t, flat, 3)
+	assert.Equal(t, "r1", bySession["s1"][0].ID)
+	assert.Equal(t, "r3", bySession["s2"][0].ID)
 }
 
-func TestBuildRecordingsBySession_NoRecordings(t *testing.T) {
+func TestBuildRecordingIndex_NoRecordings(t *testing.T) {
 	items := []wsapi.TimelineItem{
 		{Type: "websh_session", ID: "s1"},
 		{Type: "ftp_session", ID: "f1"},
 	}
-	m := buildRecordingsBySession(items)
-	assert.Empty(t, m)
+	bySession, flat := buildRecordingIndex(items)
+	assert.Empty(t, bySession)
+	assert.Empty(t, flat)
 }
 
-func TestBuildRecordingsBySession_Empty(t *testing.T) {
-	m := buildRecordingsBySession(nil)
-	assert.Empty(t, m)
+func TestBuildRecordingIndex_Empty(t *testing.T) {
+	bySession, flat := buildRecordingIndex(nil)
+	assert.Empty(t, bySession)
+	assert.Empty(t, flat)
 }
 
 // recordingBadge

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -18,14 +18,14 @@ func TestFindRecording_DefaultFirst(t *testing.T) {
 	recs := []wsapi.TimelineItem{makeRecording("r1", "s1"), makeRecording("r2", "s1")}
 	target, idx := findRecording(recs, 1)
 	assert.Equal(t, "r1", target.ID)
-	assert.Equal(t, 0, idx)
+	assert.Equal(t, 1, idx)
 }
 
 func TestFindRecording_ByIndex(t *testing.T) {
 	recs := []wsapi.TimelineItem{makeRecording("r1", "s1"), makeRecording("r2", "s1"), makeRecording("r3", "s1")}
 	target, idx := findRecording(recs, 3)
 	assert.Equal(t, "r3", target.ID)
-	assert.Equal(t, 2, idx)
+	assert.Equal(t, 3, idx)
 }
 
 func TestFindRecording_IndexOutOfRange(t *testing.T) {

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -1,0 +1,119 @@
+package worksession
+
+import (
+	"testing"
+
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeRecording(id, sessionID string) wsapi.TimelineItem {
+	return wsapi.TimelineItem{Type: "websh_record", ID: id, SessionID: sessionID}
+}
+
+// findRecording
+
+func TestFindRecording_DefaultFirst(t *testing.T) {
+	recs := []wsapi.TimelineItem{makeRecording("r1", "s1"), makeRecording("r2", "s1")}
+	target, idx := findRecording(recs, 1)
+	assert.Equal(t, "r1", target.ID)
+	assert.Equal(t, 0, idx)
+}
+
+func TestFindRecording_ByIndex(t *testing.T) {
+	recs := []wsapi.TimelineItem{makeRecording("r1", "s1"), makeRecording("r2", "s1"), makeRecording("r3", "s1")}
+	target, idx := findRecording(recs, 3)
+	assert.Equal(t, "r3", target.ID)
+	assert.Equal(t, 2, idx)
+}
+
+func TestFindRecording_IndexOutOfRange(t *testing.T) {
+	recs := []wsapi.TimelineItem{makeRecording("r1", "s1")}
+	target, idx := findRecording(recs, 2)
+	assert.Nil(t, target)
+	assert.Equal(t, -1, idx)
+}
+
+func TestFindRecording_IndexZero(t *testing.T) {
+	recs := []wsapi.TimelineItem{makeRecording("r1", "s1")}
+	target, idx := findRecording(recs, 0)
+	assert.Nil(t, target)
+	assert.Equal(t, -1, idx)
+}
+
+func TestFindRecording_NegativeIndex(t *testing.T) {
+	recs := []wsapi.TimelineItem{makeRecording("r1", "s1")}
+	target, idx := findRecording(recs, -1)
+	assert.Nil(t, target)
+	assert.Equal(t, -1, idx)
+}
+
+// buildRecordingsBySession
+
+func TestBuildRecordingsBySession_GroupsBySessionID(t *testing.T) {
+	items := []wsapi.TimelineItem{
+		{Type: "websh_session", ID: "s1"},
+		{Type: "websh_record", ID: "r1", SessionID: "s1"},
+		{Type: "websh_record", ID: "r2", SessionID: "s1"},
+		{Type: "websh_session", ID: "s2"},
+		{Type: "websh_record", ID: "r3", SessionID: "s2"},
+	}
+	m := buildRecordingsBySession(items)
+	assert.Len(t, m["s1"], 2)
+	assert.Len(t, m["s2"], 1)
+	assert.Equal(t, "r1", m["s1"][0].ID)
+	assert.Equal(t, "r3", m["s2"][0].ID)
+}
+
+func TestBuildRecordingsBySession_NoRecordings(t *testing.T) {
+	items := []wsapi.TimelineItem{
+		{Type: "websh_session", ID: "s1"},
+		{Type: "ftp_session", ID: "f1"},
+	}
+	m := buildRecordingsBySession(items)
+	assert.Empty(t, m)
+}
+
+func TestBuildRecordingsBySession_Empty(t *testing.T) {
+	m := buildRecordingsBySession(nil)
+	assert.Empty(t, m)
+}
+
+// recordingBadge
+
+func TestRecordingBadge_Single(t *testing.T) {
+	assert.Equal(t, "• 1 recording", recordingBadge(1))
+}
+
+func TestRecordingBadge_Multiple(t *testing.T) {
+	assert.Equal(t, "• 3 recordings", recordingBadge(3))
+}
+
+// recordingPreview
+
+func TestRecordingPreview_StripsANSI(t *testing.T) {
+	raw := "\x1b]0;user@host:~\x07\x1b[?2004h[user@host:~]$ ls -la"
+	got := recordingPreview(raw)
+	assert.Equal(t, "[user@host:~]$ ls -la", got)
+}
+
+func TestRecordingPreview_SkipsEmptyLines(t *testing.T) {
+	raw := "\n\n  \nactual content here"
+	got := recordingPreview(raw)
+	assert.Equal(t, "actual content here", got)
+}
+
+func TestRecordingPreview_Truncates(t *testing.T) {
+	raw := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
+	got := recordingPreview(raw)
+	assert.LessOrEqual(t, len(got), 63) // 60 chars + possible "..."
+}
+
+func TestRecordingPreview_EmptyRaw(t *testing.T) {
+	assert.Equal(t, "", recordingPreview(""))
+}
+
+func TestRecordingPreview_OnlyANSI(t *testing.T) {
+	raw := "\x1b[?2004h\x1b[2J\x1b[H"
+	assert.Equal(t, "", recordingPreview(raw))
+}

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -1,6 +1,7 @@
 package worksession
 
 import (
+	"strings"
 	"testing"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
@@ -93,20 +94,21 @@ func TestRecordingBadge_Multiple(t *testing.T) {
 
 func TestRecordingPreview_StripsANSI(t *testing.T) {
 	raw := "\x1b]0;user@host:~\x07\x1b[?2004h[user@host:~]$ ls -la"
-	got := recordingPreview(raw)
-	assert.Equal(t, "[user@host:~]$ ls -la", got)
+	assert.Equal(t, "[user@host:~]$ ls -la", recordingPreview(raw))
+}
+
+func TestRecordingPreview_StripsCarriageReturns(t *testing.T) {
+	raw := "[user@host:~]$ \r\r[user@host:~]$ ls -la"
+	assert.Equal(t, "[user@host:~]$ ls -la", recordingPreview(raw))
 }
 
 func TestRecordingPreview_SkipsEmptyLines(t *testing.T) {
-	raw := "\n\n  \nactual content here"
-	got := recordingPreview(raw)
-	assert.Equal(t, "actual content here", got)
+	assert.Equal(t, "actual content here", recordingPreview("\n\n  \nactual content here"))
 }
 
 func TestRecordingPreview_Truncates(t *testing.T) {
-	raw := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
-	got := recordingPreview(raw)
-	assert.LessOrEqual(t, len(got), 63) // 60 chars + possible "..."
+	raw := strings.Repeat("a", 80)
+	assert.LessOrEqual(t, len(recordingPreview(raw)), 63) // 60 chars + possible "..."
 }
 
 func TestRecordingPreview_EmptyRaw(t *testing.T) {
@@ -114,6 +116,6 @@ func TestRecordingPreview_EmptyRaw(t *testing.T) {
 }
 
 func TestRecordingPreview_OnlyANSI(t *testing.T) {
-	raw := "\x1b[?2004h\x1b[2J\x1b[H"
-	assert.Equal(t, "", recordingPreview(raw))
+	assert.Equal(t, "", recordingPreview("\x1b[?2004h\x1b[2J\x1b[H"))
 }
+

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -3,8 +3,10 @@ package worksession
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
+	"text/tabwriter"
 	"time"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
@@ -47,7 +49,7 @@ var workSessionTimelineCmd = &cobra.Command{
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			items, timelineErr = wsapi.GetWorkSessionTimeline(ac, id, !noRecords)
+			items, timelineErr = wsapi.GetWorkSessionTimeline(ac, id, true)
 		}()
 		go func() {
 			defer wg.Done()
@@ -68,7 +70,7 @@ var workSessionTimelineCmd = &cobra.Command{
 
 		recordingsBySession, recordings := buildRecordingIndex(items)
 
-		var rows []wsapi.TimelineAttributes
+		rows := make([]wsapi.TimelineAttributes, 0)
 		for i := range items {
 			if items[i].Type == "websh_record" {
 				continue
@@ -96,9 +98,16 @@ var workSessionTimelineCmd = &cobra.Command{
 			return
 		}
 
-		utils.PrintTable(rows)
+		writer, cleanup := utils.WriteToPager()
+		defer cleanup()
+		tw := tabwriter.NewWriter(writer, 0, 0, 3, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "TIME\tTYPE\tSERVER\tUSER\tDETAILS")
+		for _, row := range rows {
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", row.Time, row.Type, row.Server, row.User, row.Details)
+		}
+		_ = tw.Flush()
 		if !noRecords && len(recordings) > 0 {
-			printRecordingsSection(recordings, serverMap)
+			printRecordingsSectionTo(writer, recordings, serverMap)
 		}
 	},
 }
@@ -159,15 +168,15 @@ func resolveServer(serverID *string, serverMap map[string]string) string {
 	return *serverID
 }
 
-func printRecordingsSection(recordings []wsapi.TimelineItem, serverMap map[string]string) {
-	fmt.Printf("\n─── Recordings (%d) %s\n", len(recordings), strings.Repeat("─", 44))
+func printRecordingsSectionTo(w io.Writer, recordings []wsapi.TimelineItem, serverMap map[string]string) {
+	_, _ = fmt.Fprintf(w, "\n─── Recordings (%d) %s\n", len(recordings), strings.Repeat("─", 44))
 	for i, rec := range recordings {
-		fmt.Printf("[%d]  %s  %s\n", i+1, resolveTimestamp(rec.Timestamp), resolveServer(rec.ServerID, serverMap))
+		_, _ = fmt.Fprintf(w, "[%d]  %s  %s\n", i+1, resolveTimestamp(rec.Timestamp), resolveServer(rec.ServerID, serverMap))
 		if preview := recordingPreview(rec.MaskedRecord); preview != "" {
-			fmt.Printf("     %s\n", preview)
+			_, _ = fmt.Fprintf(w, "     %s\n", preview)
 		}
 		if i < len(recordings)-1 {
-			fmt.Println()
+			_, _ = fmt.Fprintln(w)
 		}
 	}
 }

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -148,7 +148,7 @@ func recordingPreview(raw string) string {
 		}
 		line = strings.TrimSpace(line)
 		if line != "" {
-			return utils.TruncateString(line, 60)
+			return utils.TruncateString(stripControlChars(line), 60)
 		}
 	}
 	return ""
@@ -255,6 +255,15 @@ func ansiStrip(s string) string {
 	return ansiEscape.ReplaceAllString(s, "")
 }
 
+func stripControlChars(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 func formatDetails(item *wsapi.TimelineItem) string {
 	switch item.Type {
 	case "command":
@@ -268,7 +277,7 @@ func formatDetails(item *wsapi.TimelineItem) string {
 				status = "failed"
 			}
 		}
-		return fmt.Sprintf("[%s] %s", status, utils.TruncateString(ansiStrip(item.Line), 60))
+		return fmt.Sprintf("[%s] %s", status, utils.TruncateString(stripControlChars(ansiStrip(item.Line)), 60))
 
 	case "websh_session":
 		state := sessionState(item.ClosedAt)
@@ -288,10 +297,10 @@ func formatDetails(item *wsapi.TimelineItem) string {
 		return sessionState(item.ClosedAt)
 
 	case "file_upload":
-		return fmt.Sprintf("↑ %s (%s)", ansiStrip(item.Name), formatSize(item.Size))
+		return fmt.Sprintf("↑ %s (%s)", stripControlChars(ansiStrip(item.Name)), formatSize(item.Size))
 
 	case "file_download":
-		return fmt.Sprintf("↓ %s (%s)", ansiStrip(item.Name), formatSize(item.Size))
+		return fmt.Sprintf("↓ %s (%s)", stripControlChars(ansiStrip(item.Name)), formatSize(item.Size))
 
 	case "sudo_grant":
 		detail := fmt.Sprintf("%s: %s", item.GrantType, item.Status)

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -46,7 +46,7 @@ var workSessionTimelineCmd = &cobra.Command{
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			items, timelineErr = wsapi.GetWorkSessionTimeline(ac, id, true)
+			items, timelineErr = wsapi.GetWorkSessionTimeline(ac, id, !noRecords)
 		}()
 		go func() {
 			defer wg.Done()
@@ -87,9 +87,9 @@ var workSessionTimelineCmd = &cobra.Command{
 		}
 
 		if utils.OutputFormat == utils.OutputFormatJSON {
-			recList := recordings
-			if noRecords {
-				recList = nil
+			var recList []wsapi.TimelineItem
+			if !noRecords {
+				recList = recordings
 			}
 			outputTimelineJSON(rows, recList, serverMap)
 			return
@@ -125,8 +125,8 @@ func recordingBadge(n int) string {
 }
 
 func recordingPreview(raw string) string {
-	content := ansiEscape.ReplaceAllString(raw, "")
-	for _, line := range strings.Split(content, "\n") {
+	for _, line := range strings.SplitN(raw, "\n", 50) {
+		line = ansiEscape.ReplaceAllString(line, "")
 		// \r moves cursor to line start; take only the last overwritten segment
 		if idx := strings.LastIndex(line, "\r"); idx != -1 {
 			line = line[idx+1:]
@@ -183,7 +183,10 @@ func outputTimelineJSON(rows []wsapi.TimelineAttributes, recordings []wsapi.Time
 		"timeline":   rows,
 		"recordings": recEntries,
 	}
-	b, _ := json.MarshalIndent(out, "", "  ")
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		utils.CliErrorWithExit("Failed to serialize timeline: %s.", err)
+	}
 	fmt.Println(string(b))
 }
 
@@ -210,8 +213,6 @@ func formatTimestamp(ts string) string {
 
 func formatType(t string) string {
 	switch t {
-	case "command":
-		return "command"
 	case "websh_session":
 		return "websh"
 	case "tunnel_session":

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -1,6 +1,7 @@
 package worksession
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -12,6 +13,13 @@ import (
 )
 
 var noRecords bool
+
+type recordingJSON struct {
+	Index   int    `json:"index"`
+	Time    string `json:"time"`
+	Server  string `json:"server"`
+	Preview string `json:"preview"`
+}
 
 var workSessionTimelineCmd = &cobra.Command{
 	Use:     "timeline SESSION_ID",
@@ -38,7 +46,7 @@ var workSessionTimelineCmd = &cobra.Command{
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			items, timelineErr = wsapi.GetWorkSessionTimeline(ac, id, !noRecords)
+			items, timelineErr = wsapi.GetWorkSessionTimeline(ac, id, true)
 		}()
 		go func() {
 			defer wg.Done()
@@ -58,16 +66,143 @@ var workSessionTimelineCmd = &cobra.Command{
 			}
 		}
 
-		rows := make([]wsapi.TimelineAttributes, len(items))
+		recordingsBySession := buildRecordingsBySession(items)
+		recordings := extractRecordings(items)
+
+		var rows []wsapi.TimelineAttributes
 		for i := range items {
-			rows[i] = projectTimelineAttributes(&items[i], serverMap)
+			if items[i].Type == "websh_record" {
+				continue
+			}
+			row := projectTimelineAttributes(&items[i], serverMap)
+			if items[i].Type == "websh_session" {
+				if recs := recordingsBySession[items[i].ID]; len(recs) > 0 {
+					badge := recordingBadge(len(recs))
+					if row.Details != "" {
+						row.Details += " " + badge
+					} else {
+						row.Details = badge
+					}
+				}
+			}
+			rows = append(rows, row)
 		}
+
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			recList := recordings
+			if noRecords {
+				recList = nil
+			}
+			outputTimelineJSON(rows, recList, serverMap)
+			return
+		}
+
 		utils.PrintTable(rows)
+		if !noRecords && len(recordings) > 0 {
+			printRecordingsSection(recordings, serverMap)
+		}
 	},
 }
 
 func init() {
-	workSessionTimelineCmd.Flags().BoolVar(&noRecords, "no-records", false, "Exclude Websh session recordings from the timeline")
+	workSessionTimelineCmd.Flags().BoolVar(&noRecords, "no-records", false, "Hide the recordings section below the timeline")
+}
+
+func buildRecordingsBySession(items []wsapi.TimelineItem) map[string][]wsapi.TimelineItem {
+	m := map[string][]wsapi.TimelineItem{}
+	for _, item := range items {
+		if item.Type == "websh_record" {
+			m[item.SessionID] = append(m[item.SessionID], item)
+		}
+	}
+	return m
+}
+
+func extractRecordings(items []wsapi.TimelineItem) []wsapi.TimelineItem {
+	var out []wsapi.TimelineItem
+	for _, item := range items {
+		if item.Type == "websh_record" {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func recordingBadge(n int) string {
+	if n == 1 {
+		return "• 1 recording"
+	}
+	return fmt.Sprintf("• %d recordings", n)
+}
+
+func recordingPreview(raw string) string {
+	content := ansiEscape.ReplaceAllString(raw, "")
+	for _, line := range strings.Split(content, "\n") {
+		// \r moves cursor to line start; take only the last overwritten segment
+		if idx := strings.LastIndex(line, "\r"); idx != -1 {
+			line = line[idx+1:]
+		}
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return utils.TruncateString(line, 60)
+		}
+	}
+	return ""
+}
+
+func printRecordingsSection(recordings []wsapi.TimelineItem, serverMap map[string]string) {
+	fmt.Printf("\n─── Recordings (%d) %s\n", len(recordings), strings.Repeat("─", 44))
+	for i, rec := range recordings {
+		ts := ""
+		if rec.Timestamp != nil {
+			ts = formatTimestamp(*rec.Timestamp)
+		}
+		server := ""
+		if rec.ServerID != nil {
+			if name, ok := serverMap[*rec.ServerID]; ok {
+				server = name
+			} else {
+				server = *rec.ServerID
+			}
+		}
+		fmt.Printf("[%d]  %s  %s\n", i+1, ts, server)
+		if preview := recordingPreview(rec.MaskedRecord); preview != "" {
+			fmt.Printf("     %s\n", preview)
+		}
+		if i < len(recordings)-1 {
+			fmt.Println()
+		}
+	}
+}
+
+func outputTimelineJSON(rows []wsapi.TimelineAttributes, recordings []wsapi.TimelineItem, serverMap map[string]string) {
+	recEntries := make([]recordingJSON, len(recordings))
+	for i, rec := range recordings {
+		ts := ""
+		if rec.Timestamp != nil {
+			ts = formatTimestamp(*rec.Timestamp)
+		}
+		server := ""
+		if rec.ServerID != nil {
+			if name, ok := serverMap[*rec.ServerID]; ok {
+				server = name
+			} else {
+				server = *rec.ServerID
+			}
+		}
+		recEntries[i] = recordingJSON{
+			Index:   i + 1,
+			Time:    ts,
+			Server:  server,
+			Preview: recordingPreview(rec.MaskedRecord),
+		}
+	}
+	out := map[string]any{
+		"timeline":   rows,
+		"recordings": recEntries,
+	}
+	b, _ := json.MarshalIndent(out, "", "  ")
+	fmt.Println(string(b))
 }
 
 func projectTimelineAttributes(item *wsapi.TimelineItem, serverMap map[string]string) wsapi.TimelineAttributes {

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
@@ -127,6 +128,8 @@ func recordingBadge(n int) string {
 func recordingPreview(raw string) string {
 	for _, line := range strings.SplitN(raw, "\n", 50) {
 		line = ansiEscape.ReplaceAllString(line, "")
+		// Strip trailing CR from CRLF line endings before overwrite handling.
+		line = strings.TrimRight(line, "\r")
 		// \r moves cursor to line start; take only the last overwritten segment
 		if idx := strings.LastIndex(line, "\r"); idx != -1 {
 			line = line[idx+1:]
@@ -201,6 +204,10 @@ func projectTimelineAttributes(item *wsapi.TimelineItem, serverMap map[string]st
 }
 
 func formatTimestamp(ts string) string {
+	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+		return t.Local().Format("2006-01-02 15:04:05")
+	}
+	// fallback for non-RFC-3339 formats
 	date, rest, found := strings.Cut(ts, "T")
 	if !found {
 		return ts

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -58,7 +58,6 @@ var workSessionTimelineCmd = &cobra.Command{
 			utils.CliErrorWithExit("Failed to retrieve work session timeline: %s.", timelineErr)
 		}
 
-		// Build server name map from session detail for human-readable server names.
 		serverMap := map[string]string{}
 		if session != nil {
 			for _, s := range session.Servers {
@@ -66,8 +65,7 @@ var workSessionTimelineCmd = &cobra.Command{
 			}
 		}
 
-		recordingsBySession := buildRecordingsBySession(items)
-		recordings := extractRecordings(items)
+		recordingsBySession, recordings := buildRecordingIndex(items)
 
 		var rows []wsapi.TimelineAttributes
 		for i := range items {
@@ -108,24 +106,15 @@ func init() {
 	workSessionTimelineCmd.Flags().BoolVar(&noRecords, "no-records", false, "Hide the recordings section below the timeline")
 }
 
-func buildRecordingsBySession(items []wsapi.TimelineItem) map[string][]wsapi.TimelineItem {
-	m := map[string][]wsapi.TimelineItem{}
+func buildRecordingIndex(items []wsapi.TimelineItem) (bySession map[string][]wsapi.TimelineItem, flat []wsapi.TimelineItem) {
+	bySession = map[string][]wsapi.TimelineItem{}
 	for _, item := range items {
 		if item.Type == "websh_record" {
-			m[item.SessionID] = append(m[item.SessionID], item)
+			bySession[item.SessionID] = append(bySession[item.SessionID], item)
+			flat = append(flat, item)
 		}
 	}
-	return m
-}
-
-func extractRecordings(items []wsapi.TimelineItem) []wsapi.TimelineItem {
-	var out []wsapi.TimelineItem
-	for _, item := range items {
-		if item.Type == "websh_record" {
-			out = append(out, item)
-		}
-	}
-	return out
+	return
 }
 
 func recordingBadge(n int) string {
@@ -150,22 +139,27 @@ func recordingPreview(raw string) string {
 	return ""
 }
 
+func resolveTimestamp(ts *string) string {
+	if ts == nil {
+		return ""
+	}
+	return formatTimestamp(*ts)
+}
+
+func resolveServer(serverID *string, serverMap map[string]string) string {
+	if serverID == nil {
+		return ""
+	}
+	if name, ok := serverMap[*serverID]; ok {
+		return name
+	}
+	return *serverID
+}
+
 func printRecordingsSection(recordings []wsapi.TimelineItem, serverMap map[string]string) {
 	fmt.Printf("\n─── Recordings (%d) %s\n", len(recordings), strings.Repeat("─", 44))
 	for i, rec := range recordings {
-		ts := ""
-		if rec.Timestamp != nil {
-			ts = formatTimestamp(*rec.Timestamp)
-		}
-		server := ""
-		if rec.ServerID != nil {
-			if name, ok := serverMap[*rec.ServerID]; ok {
-				server = name
-			} else {
-				server = *rec.ServerID
-			}
-		}
-		fmt.Printf("[%d]  %s  %s\n", i+1, ts, server)
+		fmt.Printf("[%d]  %s  %s\n", i+1, resolveTimestamp(rec.Timestamp), resolveServer(rec.ServerID, serverMap))
 		if preview := recordingPreview(rec.MaskedRecord); preview != "" {
 			fmt.Printf("     %s\n", preview)
 		}
@@ -178,22 +172,10 @@ func printRecordingsSection(recordings []wsapi.TimelineItem, serverMap map[strin
 func outputTimelineJSON(rows []wsapi.TimelineAttributes, recordings []wsapi.TimelineItem, serverMap map[string]string) {
 	recEntries := make([]recordingJSON, len(recordings))
 	for i, rec := range recordings {
-		ts := ""
-		if rec.Timestamp != nil {
-			ts = formatTimestamp(*rec.Timestamp)
-		}
-		server := ""
-		if rec.ServerID != nil {
-			if name, ok := serverMap[*rec.ServerID]; ok {
-				server = name
-			} else {
-				server = *rec.ServerID
-			}
-		}
 		recEntries[i] = recordingJSON{
 			Index:   i + 1,
-			Time:    ts,
-			Server:  server,
+			Time:    resolveTimestamp(rec.Timestamp),
+			Server:  resolveServer(rec.ServerID, serverMap),
 			Preview: recordingPreview(rec.MaskedRecord),
 		}
 	}
@@ -206,24 +188,10 @@ func outputTimelineJSON(rows []wsapi.TimelineAttributes, recordings []wsapi.Time
 }
 
 func projectTimelineAttributes(item *wsapi.TimelineItem, serverMap map[string]string) wsapi.TimelineAttributes {
-	ts := ""
-	if item.Timestamp != nil {
-		ts = formatTimestamp(*item.Timestamp)
-	}
-
-	server := ""
-	if item.ServerID != nil {
-		if name, ok := serverMap[*item.ServerID]; ok {
-			server = name
-		} else {
-			server = *item.ServerID
-		}
-	}
-
 	return wsapi.TimelineAttributes{
-		Time:    ts,
+		Time:    resolveTimestamp(item.Timestamp),
 		Type:    formatType(item.Type),
-		Server:  server,
+		Server:  resolveServer(item.ServerID, serverMap),
 		User:    item.Username,
 		Details: formatDetails(item),
 	}

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -42,7 +42,7 @@ var workSessionTimelineCmd = &cobra.Command{
 		}()
 		go func() {
 			defer wg.Done()
-			session, _ = wsapi.GetWorkSession(ac, id)
+			session, _ = wsapi.GetWorkSession(ac, id) // best-effort: server names degrade to IDs on failure
 		}()
 		wg.Wait()
 

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -305,7 +305,7 @@ func formatDetails(item *wsapi.TimelineItem) string {
 	case "sudo_grant":
 		detail := fmt.Sprintf("%s: %s", item.GrantType, item.Status)
 		if item.Command != nil && *item.Command != "" {
-			detail += fmt.Sprintf(" — %s", utils.TruncateString(ansiStrip(*item.Command), 40))
+			detail += fmt.Sprintf(" — %s", utils.TruncateString(stripControlChars(ansiStrip(*item.Command)), 40))
 		}
 		return detail
 

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -1,6 +1,7 @@
 package worksession
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -135,8 +136,9 @@ func recordingBadge(n int) string {
 }
 
 func recordingPreview(raw string) string {
-	for _, line := range strings.SplitN(raw, "\n", 50) {
-		line = ansiEscape.ReplaceAllString(line, "")
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for i := 0; i < 50 && scanner.Scan(); i++ {
+		line := ansiEscape.ReplaceAllString(scanner.Text(), "")
 		// Strip trailing CR from CRLF line endings before overwrite handling.
 		line = strings.TrimRight(line, "\r")
 		// \r moves cursor to line start; take only the last overwritten segment
@@ -248,16 +250,24 @@ func formatType(t string) string {
 	}
 }
 
+func ansiStrip(s string) string {
+	return ansiEscape.ReplaceAllString(s, "")
+}
+
 func formatDetails(item *wsapi.TimelineItem) string {
 	switch item.Type {
 	case "command":
-		status := "ok"
+		status := "unknown"
 		if item.Denied {
 			status = "denied"
-		} else if item.Success != nil && !*item.Success {
-			status = "failed"
+		} else if item.Success != nil {
+			if *item.Success {
+				status = "ok"
+			} else {
+				status = "failed"
+			}
 		}
-		return fmt.Sprintf("[%s] %s", status, utils.TruncateString(item.Line, 60))
+		return fmt.Sprintf("[%s] %s", status, utils.TruncateString(ansiStrip(item.Line), 60))
 
 	case "websh_session":
 		state := sessionState(item.ClosedAt)
@@ -277,15 +287,15 @@ func formatDetails(item *wsapi.TimelineItem) string {
 		return sessionState(item.ClosedAt)
 
 	case "file_upload":
-		return fmt.Sprintf("↑ %s (%s)", item.Name, formatSize(item.Size))
+		return fmt.Sprintf("↑ %s (%s)", ansiStrip(item.Name), formatSize(item.Size))
 
 	case "file_download":
-		return fmt.Sprintf("↓ %s (%s)", item.Name, formatSize(item.Size))
+		return fmt.Sprintf("↓ %s (%s)", ansiStrip(item.Name), formatSize(item.Size))
 
 	case "sudo_grant":
 		detail := fmt.Sprintf("%s: %s", item.GrantType, item.Status)
 		if item.Command != nil && *item.Command != "" {
-			detail += fmt.Sprintf(" — %s", utils.TruncateString(*item.Command, 40))
+			detail += fmt.Sprintf(" — %s", utils.TruncateString(ansiStrip(*item.Command), 40))
 		}
 		return detail
 

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -1,0 +1,180 @@
+package worksession
+
+import (
+	"fmt"
+	"strings"
+
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var noRecords bool
+
+var workSessionTimelineCmd = &cobra.Command{
+	Use:     "timeline SESSION_ID",
+	Aliases: []string{"tl"},
+	Short:   "Show the activity timeline for a work session",
+	Args:    cobra.ExactArgs(1),
+	Example: `  alpacon work-session timeline ses-abc123
+  alpacon work-session timeline ses-abc123 --no-records
+  alpacon work-session tl ses-abc123 --output json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		id := args[0]
+
+		items, err := wsapi.GetWorkSessionTimeline(ac, id, !noRecords)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve work session timeline: %s.", err)
+		}
+
+		// Build server name map from session detail for human-readable server names.
+		serverMap := map[string]string{}
+		if session, serr := wsapi.GetWorkSession(ac, id); serr == nil {
+			for _, s := range session.Servers {
+				serverMap[s.ID] = s.Name
+			}
+		}
+
+		rows := make([]wsapi.TimelineAttributes, len(items))
+		for i := range items {
+			rows[i] = projectTimelineAttributes(&items[i], serverMap)
+		}
+		utils.PrintTable(rows)
+	},
+}
+
+func init() {
+	workSessionTimelineCmd.Flags().BoolVar(&noRecords, "no-records", false, "Exclude Websh session recordings from the timeline")
+}
+
+func projectTimelineAttributes(item *wsapi.TimelineItem, serverMap map[string]string) wsapi.TimelineAttributes {
+	ts := ""
+	if item.Timestamp != nil {
+		ts = formatTimestamp(*item.Timestamp)
+	}
+
+	server := ""
+	if item.ServerID != nil {
+		if name, ok := serverMap[*item.ServerID]; ok {
+			server = name
+		} else {
+			server = *item.ServerID
+		}
+	}
+
+	return wsapi.TimelineAttributes{
+		Time:    ts,
+		Type:    formatType(item.Type),
+		Server:  server,
+		User:    item.Username,
+		Details: formatDetails(item),
+	}
+}
+
+func formatTimestamp(ts string) string {
+	ts = strings.ReplaceAll(ts, "T", " ")
+	if idx := strings.IndexAny(ts, ".+Z"); idx != -1 {
+		ts = ts[:idx]
+	}
+	return ts
+}
+
+func formatType(t string) string {
+	switch t {
+	case "command":
+		return "command"
+	case "websh_session":
+		return "websh"
+	case "tunnel_session":
+		return "tunnel"
+	case "ftp_session":
+		return "ftp"
+	case "file_upload":
+		return "upload"
+	case "file_download":
+		return "download"
+	case "sudo_grant":
+		return "sudo grant"
+	case "websh_record":
+		return "recording"
+	default:
+		return t
+	}
+}
+
+func formatDetails(item *wsapi.TimelineItem) string {
+	switch item.Type {
+	case "command":
+		status := "ok"
+		if item.Denied {
+			status = "denied"
+		} else if item.Success != nil && !*item.Success {
+			status = "failed"
+		}
+		return fmt.Sprintf("[%s] %s", status, utils.TruncateString(item.Line, 60))
+
+	case "websh_session":
+		state := "opened"
+		if item.ClosedAt != nil {
+			state = "closed"
+		}
+		if item.ClientType != "" {
+			return fmt.Sprintf("%s (client: %s)", state, item.ClientType)
+		}
+		return state
+
+	case "tunnel_session":
+		state := "opened"
+		if item.ClosedAt != nil {
+			state = "closed"
+		}
+		if item.TargetPort != nil {
+			return fmt.Sprintf("port %d %s", *item.TargetPort, state)
+		}
+		return state
+
+	case "ftp_session":
+		if item.ClosedAt != nil {
+			return "closed"
+		}
+		return "opened"
+
+	case "file_upload":
+		return fmt.Sprintf("↑ %s (%s)", item.Name, formatSize(item.Size))
+
+	case "file_download":
+		return fmt.Sprintf("↓ %s (%s)", item.Name, formatSize(item.Size))
+
+	case "sudo_grant":
+		detail := fmt.Sprintf("%s: %s", item.GrantType, item.Status)
+		if item.Command != nil && *item.Command != "" {
+			detail += fmt.Sprintf(" — %s", utils.TruncateString(*item.Command, 40))
+		}
+		return detail
+
+	case "websh_record":
+		return utils.TruncateString(item.MaskedRecord, 60)
+
+	default:
+		return ""
+	}
+}
+
+func formatSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -137,6 +137,7 @@ func recordingBadge(n int) string {
 
 func recordingPreview(raw string) string {
 	scanner := bufio.NewScanner(strings.NewReader(raw))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for i := 0; i < 50 && scanner.Scan(); i++ {
 		line := ansiEscape.ReplaceAllString(scanner.Text(), "")
 		// Strip trailing CR from CRLF line endings before overwrite handling.

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -3,6 +3,7 @@ package worksession
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
@@ -28,14 +29,30 @@ var workSessionTimelineCmd = &cobra.Command{
 
 		id := args[0]
 
-		items, err := wsapi.GetWorkSessionTimeline(ac, id, !noRecords)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve work session timeline: %s.", err)
+		var (
+			items       []wsapi.TimelineItem
+			session     *wsapi.WorkSession
+			timelineErr error
+			wg          sync.WaitGroup
+		)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			items, timelineErr = wsapi.GetWorkSessionTimeline(ac, id, !noRecords)
+		}()
+		go func() {
+			defer wg.Done()
+			session, _ = wsapi.GetWorkSession(ac, id)
+		}()
+		wg.Wait()
+
+		if timelineErr != nil {
+			utils.CliErrorWithExit("Failed to retrieve work session timeline: %s.", timelineErr)
 		}
 
 		// Build server name map from session detail for human-readable server names.
 		serverMap := map[string]string{}
-		if session, serr := wsapi.GetWorkSession(ac, id); serr == nil {
+		if session != nil {
 			for _, s := range session.Servers {
 				serverMap[s.ID] = s.Name
 			}
@@ -120,30 +137,21 @@ func formatDetails(item *wsapi.TimelineItem) string {
 		return fmt.Sprintf("[%s] %s", status, utils.TruncateString(item.Line, 60))
 
 	case "websh_session":
-		state := "opened"
-		if item.ClosedAt != nil {
-			state = "closed"
-		}
+		state := sessionState(item.ClosedAt)
 		if item.ClientType != "" {
 			return fmt.Sprintf("%s (client: %s)", state, item.ClientType)
 		}
 		return state
 
 	case "tunnel_session":
-		state := "opened"
-		if item.ClosedAt != nil {
-			state = "closed"
-		}
+		state := sessionState(item.ClosedAt)
 		if item.TargetPort != nil {
 			return fmt.Sprintf("port %d %s", *item.TargetPort, state)
 		}
 		return state
 
 	case "ftp_session":
-		if item.ClosedAt != nil {
-			return "closed"
-		}
-		return "opened"
+		return sessionState(item.ClosedAt)
 
 	case "file_upload":
 		return fmt.Sprintf("↑ %s (%s)", item.Name, formatSize(item.Size))
@@ -164,6 +172,13 @@ func formatDetails(item *wsapi.TimelineItem) string {
 	default:
 		return ""
 	}
+}
+
+func sessionState(closedAt *string) string {
+	if closedAt != nil {
+		return "closed"
+	}
+	return "opened"
 }
 
 func formatSize(bytes int64) string {

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -95,11 +95,14 @@ func projectTimelineAttributes(item *wsapi.TimelineItem, serverMap map[string]st
 }
 
 func formatTimestamp(ts string) string {
-	ts = strings.ReplaceAll(ts, "T", " ")
-	if idx := strings.IndexAny(ts, ".+Z"); idx != -1 {
-		ts = ts[:idx]
+	date, rest, found := strings.Cut(ts, "T")
+	if !found {
+		return ts
 	}
-	return ts
+	if idx := strings.IndexAny(rest, ".+Z"); idx != -1 {
+		rest = rest[:idx]
+	}
+	return date + " " + rest
 }
 
 func formatType(t string) string {

--- a/cmd/worksession/worksession_timeline_test.go
+++ b/cmd/worksession/worksession_timeline_test.go
@@ -1,22 +1,48 @@
 package worksession
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
 	"testing"
+	"time"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func captureStdout(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func mustParseTime(ts string) time.Time {
+	t, _ := time.Parse(time.RFC3339Nano, ts)
+	return t
+}
 
 func TestFormatTimestamp(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
 	}{
-		{"2024-01-15T10:30:00.123456Z", "2024-01-15 10:30:00"},
-		{"2024-01-15T10:30:00+09:00", "2024-01-15 10:30:00"},
-		{"2024-01-15T10:30:00Z", "2024-01-15 10:30:00"},
+		// RFC3339 with timezone: converted to local
+		{"2024-01-15T10:30:00.123456Z", mustParseTime("2024-01-15T10:30:00.123456Z").Local().Format("2006-01-02 15:04:05")},
+		{"2024-01-15T10:30:00+09:00", mustParseTime("2024-01-15T10:30:00+09:00").Local().Format("2006-01-02 15:04:05")},
+		{"2024-01-15T10:30:00Z", mustParseTime("2024-01-15T10:30:00Z").Local().Format("2006-01-02 15:04:05")},
+		// no timezone → fallback string manipulation
 		{"2024-01-15T10:30:00", "2024-01-15 10:30:00"},
-		{"2024-01-15 10:30:00", "2024-01-15 10:30:00"}, // no T — return as-is
+		// no T separator → return as-is
+		{"2024-01-15 10:30:00", "2024-01-15 10:30:00"},
 	}
 	for _, tc := range tests {
 		assert.Equal(t, tc.want, formatTimestamp(tc.input), tc.input)
@@ -197,4 +223,28 @@ func TestFormatDetails_WebshRecord(t *testing.T) {
 func TestFormatDetails_Unknown(t *testing.T) {
 	item := wsapi.TimelineItem{Type: "unknown_event"}
 	assert.Equal(t, "", formatDetails(&item))
+}
+
+// outputTimelineJSON must emit recordings as [] not null when no recordings exist,
+// including when --no-records passes nil for recordings.
+func TestOutputTimelineJSON_RecordingsEmptyArrayNotNull(t *testing.T) {
+	out := captureStdout(func() {
+		outputTimelineJSON([]wsapi.TimelineAttributes{}, nil, nil)
+	})
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "[]", string(result["recordings"]), "recordings must be [] not null")
+}
+
+// Both timeline and recordings keys must always be present in JSON output.
+func TestOutputTimelineJSON_BothKeysPresent(t *testing.T) {
+	out := captureStdout(func() {
+		outputTimelineJSON([]wsapi.TimelineAttributes{}, nil, nil)
+	})
+	var keys map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(out), &keys))
+	_, hasTimeline := keys["timeline"]
+	_, hasRecordings := keys["recordings"]
+	assert.True(t, hasTimeline, "timeline key must be present in JSON output")
+	assert.True(t, hasRecordings, "recordings key must be present in JSON output")
 }

--- a/cmd/worksession/worksession_timeline_test.go
+++ b/cmd/worksession/worksession_timeline_test.go
@@ -117,6 +117,11 @@ func TestFormatDetails_Command(t *testing.T) {
 			wsapi.TimelineItem{Type: "command", Denied: true, Line: "sudo su"},
 			"[denied] sudo su",
 		},
+		{
+			"unknown (nil success)",
+			wsapi.TimelineItem{Type: "command", Line: "some-cmd"},
+			"[unknown] some-cmd",
+		},
 	}
 	for _, tc := range tests {
 		assert.Equal(t, tc.want, formatDetails(&tc.item), tc.name)

--- a/cmd/worksession/worksession_timeline_test.go
+++ b/cmd/worksession/worksession_timeline_test.go
@@ -1,0 +1,200 @@
+package worksession
+
+import (
+	"testing"
+
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatTimestamp(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"2024-01-15T10:30:00.123456Z", "2024-01-15 10:30:00"},
+		{"2024-01-15T10:30:00+09:00", "2024-01-15 10:30:00"},
+		{"2024-01-15T10:30:00Z", "2024-01-15 10:30:00"},
+		{"2024-01-15T10:30:00", "2024-01-15 10:30:00"},
+		{"2024-01-15 10:30:00", "2024-01-15 10:30:00"}, // no T — return as-is
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, formatTimestamp(tc.input), tc.input)
+	}
+}
+
+func TestFormatType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"command", "command"},
+		{"websh_session", "websh"},
+		{"tunnel_session", "tunnel"},
+		{"ftp_session", "ftp"},
+		{"file_upload", "upload"},
+		{"file_download", "download"},
+		{"sudo_grant", "sudo grant"},
+		{"websh_record", "recording"},
+		{"unknown_type", "unknown_type"},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, formatType(tc.input), tc.input)
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		bytes int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1073741824, "1.0 GB"},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, formatSize(tc.bytes), "%d bytes", tc.bytes)
+	}
+}
+
+func TestSessionState(t *testing.T) {
+	closed := "2024-01-15T10:30:00Z"
+	assert.Equal(t, "closed", sessionState(&closed))
+	assert.Equal(t, "opened", sessionState(nil))
+}
+
+func TestFormatDetails_Command(t *testing.T) {
+	success := true
+	failure := false
+
+	tests := []struct {
+		name string
+		item wsapi.TimelineItem
+		want string
+	}{
+		{
+			"ok",
+			wsapi.TimelineItem{Type: "command", Success: &success, Line: "ls -la"},
+			"[ok] ls -la",
+		},
+		{
+			"failed",
+			wsapi.TimelineItem{Type: "command", Success: &failure, Line: "rm -rf /"},
+			"[failed] rm -rf /",
+		},
+		{
+			"denied",
+			wsapi.TimelineItem{Type: "command", Denied: true, Line: "sudo su"},
+			"[denied] sudo su",
+		},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, formatDetails(&tc.item), tc.name)
+	}
+}
+
+func TestFormatDetails_Sessions(t *testing.T) {
+	closed := "2024-01-15T10:30:00Z"
+	port := 8080
+
+	tests := []struct {
+		name string
+		item wsapi.TimelineItem
+		want string
+	}{
+		{
+			"websh opened",
+			wsapi.TimelineItem{Type: "websh_session"},
+			"opened",
+		},
+		{
+			"websh closed with client",
+			wsapi.TimelineItem{Type: "websh_session", ClosedAt: &closed, ClientType: "vscode"},
+			"closed (client: vscode)",
+		},
+		{
+			"tunnel with port opened",
+			wsapi.TimelineItem{Type: "tunnel_session", TargetPort: &port},
+			"port 8080 opened",
+		},
+		{
+			"tunnel closed",
+			wsapi.TimelineItem{Type: "tunnel_session", ClosedAt: &closed},
+			"closed",
+		},
+		{
+			"ftp closed",
+			wsapi.TimelineItem{Type: "ftp_session", ClosedAt: &closed},
+			"closed",
+		},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, formatDetails(&tc.item), tc.name)
+	}
+}
+
+func TestFormatDetails_Files(t *testing.T) {
+	tests := []struct {
+		name string
+		item wsapi.TimelineItem
+		want string
+	}{
+		{
+			"upload",
+			wsapi.TimelineItem{Type: "file_upload", Name: "report.pdf", Size: 2048},
+			"↑ report.pdf (2.0 KB)",
+		},
+		{
+			"download",
+			wsapi.TimelineItem{Type: "file_download", Name: "backup.tar.gz", Size: 512},
+			"↓ backup.tar.gz (512 B)",
+		},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, formatDetails(&tc.item), tc.name)
+	}
+}
+
+func TestFormatDetails_SudoGrant(t *testing.T) {
+	cmd := "apt-get install vim"
+	emptyCmd := ""
+
+	tests := []struct {
+		name string
+		item wsapi.TimelineItem
+		want string
+	}{
+		{
+			"without command",
+			wsapi.TimelineItem{Type: "sudo_grant", GrantType: "temporary", Status: "approved"},
+			"temporary: approved",
+		},
+		{
+			"with command",
+			wsapi.TimelineItem{Type: "sudo_grant", GrantType: "temporary", Status: "approved", Command: &cmd},
+			"temporary: approved — apt-get install vim",
+		},
+		{
+			"empty command",
+			wsapi.TimelineItem{Type: "sudo_grant", GrantType: "permanent", Status: "approved", Command: &emptyCmd},
+			"permanent: approved",
+		},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, formatDetails(&tc.item), tc.name)
+	}
+}
+
+func TestFormatDetails_WebshRecord(t *testing.T) {
+	item := wsapi.TimelineItem{Type: "websh_record", MaskedRecord: "ls -la /home/user"}
+	assert.Equal(t, "ls -la /home/user", formatDetails(&item))
+}
+
+func TestFormatDetails_Unknown(t *testing.T) {
+	item := wsapi.TimelineItem{Type: "unknown_event"}
+	assert.Equal(t, "", formatDetails(&item))
+}


### PR DESCRIPTION
## Summary

- Add `alpacon work-session timeline SESSION_ID` (`tl`) — displays a chronological activity table for a work session, with a recordings section printed below the table when Websh recordings exist
- Add `alpacon work-session recording SESSION_ID` (`rec`) — renders a specific Websh session recording with ANSI sequences stripped
- `--no-records` flag suppresses the recordings section (table output) and empties the recordings array in JSON output
- `--output json` produces `{"timeline": [...], "recordings": [...]}` with consistent schema regardless of `--no-records`

## Details

**Timeline output**

Websh session rows show a `• N recording(s)` badge inline. After the table, a separator section lists each recording with its index, timestamp, server, and a one-line preview (ANSI stripped, carriage-return overwrite handled via `strings.LastIndex`).

**API layer**

- `GetWorkSessionTimeline(ac, id, includeRecords bool)` added to `api/worksession`
- `TimelineItem` flat struct covers all event types via discriminated union; type-specific fields are zero-valued for other types
- Timeline and session-detail calls are issued concurrently via `sync.WaitGroup`; session detail is best-effort (server names degrade to raw IDs on failure)

**Implementation notes**

- `resolveTimestamp` / `resolveServer` helpers centralise nil-guard + map-lookup logic used across all rendering paths
- `buildRecordingIndex` returns both the session-keyed map (for badges) and the flat slice (for the recordings section) in a single pass
- `ansiEscape` regexp is defined once in `worksession_recording.go` and reused package-wide

## Test plan

- [ ] `go test -race ./...` passes (19 packages)
- [ ] `alpacon work-session timeline <id>` shows table + recordings section
- [ ] `alpacon work-session timeline <id> --no-records` shows table only, badge retained
- [ ] `alpacon work-session timeline <id> --output json | jq 'keys'` returns `["recordings","timeline"]`
- [ ] `alpacon work-session timeline <id> --output json --no-records | jq '.recordings'` returns `[]`
- [ ] `alpacon work-session recording <id>` renders first recording
- [ ] `alpacon work-session recording <id> --index 2` renders second recording
- [ ] Out-of-range `--index` exits with a clear error message

## Example output

**`alpacon work-session timeline <id>`**

```
TIME                  TYPE         SERVER          USER       DETAILS
2026-05-13 02:37:03   websh        staging-db-01   eunyoung   closed (client: web) • 1 recording
2026-05-13 02:37:31   ftp          staging-db-01   eunyoung   closed
2026-05-13 02:37:52   upload       staging-db-01   eunyoung   ↑ report.pdf (1.3 MB)
2026-05-13 02:38:10   command      staging-db-01   eunyoung   [ok] ls -la /home/eunyoung
2026-05-13 02:39:00   sudo grant   staging-db-01   eunyoung   temporary: approved — apt-get install vim
2026-05-13 02:40:15   tunnel       staging-db-01   eunyoung   port 8080 closed

─── Recordings (1) ────────────────────────────────────────────────────────
[1]  2026-05-13 02:37:03  staging-db-01
     [eunyoung@ip-172-31-36-144 ~]$ ls -la /home/eunyoung
```

**`alpacon work-session timeline <id> --no-records`**

```
TIME                  TYPE         SERVER          USER       DETAILS
2026-05-13 02:37:03   websh        staging-db-01   eunyoung   closed (client: web) • 1 recording
2026-05-13 02:37:31   ftp          staging-db-01   eunyoung   closed
2026-05-13 02:37:52   upload       staging-db-01   eunyoung   ↑ report.pdf (1.3 MB)
2026-05-13 02:38:10   command      staging-db-01   eunyoung   [ok] ls -la /home/eunyoung
2026-05-13 02:39:00   sudo grant   staging-db-01   eunyoung   temporary: approved — apt-get install vim
2026-05-13 02:40:15   tunnel       staging-db-01   eunyoung   port 8080 closed
```

**`alpacon work-session timeline <id> --output json | jq 'keys'`**

```json
[
  "recordings",
  "timeline"
]
```

**`alpacon work-session recording <id>`**

```
Recording 1/1 — 2026-05-13 02:37:03

[eunyoung@ip-172-31-36-144 ~]$ ls -la /home/eunyoung
total 32
drwxr-xr-x 4 eunyoung eunyoung 4096 May 13 02:36 .
drwxr-xr-x 5 root     root     4096 May 12 09:00 ..
-rw-r--r-- 1 eunyoung eunyoung  220 May 12 09:00 .bash_logout
-rw-r--r-- 1 eunyoung eunyoung 3526 May 12 09:00 .bashrc
drwx------ 2 eunyoung eunyoung 4096 May 12 09:00 .ssh
```