### PR TITLE
ci(release): allow Go toolchain auto-download in goreleaser job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,9 @@ jobs:
         with:
           go-version: 1.25.x
 
+      - name: Allow Go toolchain auto-download
+        run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary

- Add `GOTOOLCHAIN=auto` step in the `goreleaser` job of `release.yaml`, matching the existing pattern in `build-and-test.yaml`
- Fixes GoReleaser `go mod tidy` hook failure caused by Go version mismatch: `go.mod` requires `>= 1.25.10` but `setup-go` with `1.25.x` installs `1.25.9`
- With `GOTOOLCHAIN=local` (default), Go refuses to run if the installed version is older than required; `auto` allows it to auto-download the required patch version

## Root cause

`release.yaml`'s goreleaser job was missing the `GOTOOLCHAIN=auto` environment setup that already exists in `build-and-test.yaml`. The `go mod tidy` before-hook in GoReleaser ran with `GOTOOLCHAIN=local`, which caused it to fail when the installed toolchain (1.25.9) was older than what `go.mod` requires (1.25.10).

## Test plan

- [ ] Trigger a release tag push and confirm the GoReleaser job passes the `go mod tidy` hook