### PR TITLE
refactor(client): lazy-load current user and remove preflight auth checks

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -120,6 +120,24 @@ func getUserPrivileges(isStaff, isSuperuser bool) string {
 	return "general"
 }
 
+func (ac *AlpaconClient) LoadCurrentUser() error {
+	if ac.userLoaded {
+		return nil
+	}
+	body, err := ac.SendGetRequest(checkPrivilegesURL)
+	if err != nil {
+		return err
+	}
+	var resp CheckPrivilegesResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return err
+	}
+	ac.Privileges = getUserPrivileges(resp.IsStaff, resp.IsSuperuser)
+	ac.Username = strings.TrimSpace(resp.Username)
+	ac.userLoaded = true
+	return nil
+}
+
 func (ac *AlpaconClient) SetWebsocketHeader() http.Header {
 	headers := http.Header{}
 	headers.Set("Origin", ac.BaseURL)

--- a/client/client.go
+++ b/client/client.go
@@ -171,6 +171,13 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 		return nil, err
 	}
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errors.New("authentication failed: please run 'alpacon login' again")
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, errors.New("permission denied")
+	}
+
 	if req.Method == http.MethodPost && (resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK) {
 		return nil, parseAPIError(respBody)
 	} else if req.Method == http.MethodDelete && resp.StatusCode != http.StatusNoContent {

--- a/client/client.go
+++ b/client/client.go
@@ -144,7 +144,7 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 		return nil, errors.New("authentication failed: please run 'alpacon login' again")
 	}
 	if resp.StatusCode == http.StatusForbidden {
-		return nil, errors.New("permission denied")
+		return nil, errors.New("permission denied: you do not have the required privileges for this action")
 	}
 
 	if req.Method == http.MethodPost && (resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK) {
@@ -230,7 +230,7 @@ func (ac *AlpaconClient) SendMultipartRequest(url string, multiPartWriter *multi
 		return nil, errors.New("authentication failed: please run 'alpacon login' again")
 	}
 	if resp.StatusCode == http.StatusForbidden {
-		return nil, errors.New("permission denied")
+		return nil, errors.New("permission denied: you do not have the required privileges for this action")
 	}
 
 	if resp.StatusCode != http.StatusCreated {
@@ -251,7 +251,8 @@ func (ac *AlpaconClient) SendGetRequestToURL(absoluteURL string) ([]byte, error)
 	return ac.sendRequest(req)
 }
 
-// This function returns response for custom error handling in each function, unlike direct error throwing in sendRequest.
+// SendGetRequestForDownload returns the raw *http.Response so callers can stream the body.
+// Auth errors (401/403) are handled here; all other status codes are left to the caller.
 func (ac *AlpaconClient) SendGetRequestForDownload(url string) (*http.Response, error) {
 	req, err := ac.createRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -261,6 +262,15 @@ func (ac *AlpaconClient) SendGetRequestForDownload(url string) (*http.Response, 
 	resp, err := ac.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		_ = resp.Body.Close()
+		return nil, errors.New("authentication failed: please run 'alpacon login' again")
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		_ = resp.Body.Close()
+		return nil, errors.New("permission denied: you do not have the required privileges for this action")
 	}
 
 	return resp, nil

--- a/client/client.go
+++ b/client/client.go
@@ -215,6 +215,13 @@ func (ac *AlpaconClient) SendMultipartRequest(url string, multiPartWriter *multi
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errors.New("authentication failed: please run 'alpacon login' again")
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, errors.New("permission denied: you do not have the required privileges for this action")
+	}
+
 	contentType := resp.Header.Get("Content-Type")
 	// Check for non-empty and non-JSON content types. Empty content type allowed for responses without content (e.g., from PATCH requests).
 	if contentType != "" && !strings.Contains(contentType, "application/json") {
@@ -226,14 +233,7 @@ func (ac *AlpaconClient) SendMultipartRequest(url string, multiPartWriter *multi
 		return nil, err
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, errors.New("authentication failed: please run 'alpacon login' again")
-	}
-	if resp.StatusCode == http.StatusForbidden {
-		return nil, errors.New("permission denied: you do not have the required privileges for this action")
-	}
-
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return nil, parseAPIError(respBody)
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -61,26 +61,6 @@ func NewAlpaconAPIClient() (*AlpaconClient, error) {
 	return client, nil
 }
 
-func checkAuthStatus(statusCode int) error {
-	switch statusCode {
-	case http.StatusUnauthorized:
-		return errors.New("authentication failed: please run 'alpacon login' again")
-	case http.StatusForbidden:
-		return errors.New("permission denied: you do not have the required privileges for this action")
-	}
-	return nil
-}
-
-func getUserPrivileges(isStaff, isSuperuser bool) string {
-	if isSuperuser {
-		return "superuser"
-	}
-	if isStaff {
-		return "staff"
-	}
-	return "general"
-}
-
 func (ac *AlpaconClient) LoadCurrentUser() error {
 	ac.loadOnce.Do(func() {
 		body, err := ac.SendGetRequest(checkPrivilegesURL)
@@ -97,6 +77,26 @@ func (ac *AlpaconClient) LoadCurrentUser() error {
 		ac.Username = strings.TrimSpace(resp.Username)
 	})
 	return ac.loadErr
+}
+
+func getUserPrivileges(isStaff, isSuperuser bool) string {
+	if isSuperuser {
+		return "superuser"
+	}
+	if isStaff {
+		return "staff"
+	}
+	return "general"
+}
+
+func checkAuthStatus(statusCode int) error {
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return errors.New("authentication failed: please run 'alpacon login' again")
+	case http.StatusForbidden:
+		return errors.New("permission denied: you do not have the required privileges for this action")
+	}
+	return nil
 }
 
 func (ac *AlpaconClient) SetWebsocketHeader() http.Header {

--- a/client/client.go
+++ b/client/client.go
@@ -61,6 +61,16 @@ func NewAlpaconAPIClient() (*AlpaconClient, error) {
 	return client, nil
 }
 
+func checkAuthStatus(statusCode int) error {
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return errors.New("authentication failed: please run 'alpacon login' again")
+	case http.StatusForbidden:
+		return errors.New("permission denied: you do not have the required privileges for this action")
+	}
+	return nil
+}
+
 func getUserPrivileges(isStaff, isSuperuser bool) string {
 	if isSuperuser {
 		return "superuser"
@@ -129,6 +139,10 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if err := checkAuthStatus(resp.StatusCode); err != nil {
+		return nil, err
+	}
+
 	contentType := resp.Header.Get("Content-Type")
 	// Check for non-empty and non-JSON content types. Empty content type allowed for responses without content (e.g., from PATCH requests).
 	if contentType != "" && !strings.Contains(contentType, "application/json") {
@@ -138,13 +152,6 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, errors.New("authentication failed: please run 'alpacon login' again")
-	}
-	if resp.StatusCode == http.StatusForbidden {
-		return nil, errors.New("permission denied: you do not have the required privileges for this action")
 	}
 
 	if req.Method == http.MethodPost && (resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK) {
@@ -215,11 +222,8 @@ func (ac *AlpaconClient) SendMultipartRequest(url string, multiPartWriter *multi
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, errors.New("authentication failed: please run 'alpacon login' again")
-	}
-	if resp.StatusCode == http.StatusForbidden {
-		return nil, errors.New("permission denied: you do not have the required privileges for this action")
+	if err := checkAuthStatus(resp.StatusCode); err != nil {
+		return nil, err
 	}
 
 	contentType := resp.Header.Get("Content-Type")
@@ -264,13 +268,9 @@ func (ac *AlpaconClient) SendGetRequestForDownload(url string) (*http.Response, 
 		return nil, err
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized {
+	if err := checkAuthStatus(resp.StatusCode); err != nil {
 		_ = resp.Body.Close()
-		return nil, errors.New("authentication failed: please run 'alpacon login' again")
-	}
-	if resp.StatusCode == http.StatusForbidden {
-		_ = resp.Body.Close()
-		return nil, errors.New("permission denied: you do not have the required privileges for this action")
+		return nil, err
 	}
 
 	return resp, nil

--- a/client/client.go
+++ b/client/client.go
@@ -72,21 +72,21 @@ func getUserPrivileges(isStaff, isSuperuser bool) string {
 }
 
 func (ac *AlpaconClient) LoadCurrentUser() error {
-	if ac.userLoaded {
-		return nil
-	}
-	body, err := ac.SendGetRequest(checkPrivilegesURL)
-	if err != nil {
-		return err
-	}
-	var resp CheckPrivilegesResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return err
-	}
-	ac.Privileges = getUserPrivileges(resp.IsStaff, resp.IsSuperuser)
-	ac.Username = strings.TrimSpace(resp.Username)
-	ac.userLoaded = true
-	return nil
+	ac.loadOnce.Do(func() {
+		body, err := ac.SendGetRequest(checkPrivilegesURL)
+		if err != nil {
+			ac.loadErr = err
+			return
+		}
+		var resp CheckPrivilegesResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			ac.loadErr = err
+			return
+		}
+		ac.Privileges = getUserPrivileges(resp.IsStaff, resp.IsSuperuser)
+		ac.Username = strings.TrimSpace(resp.Username)
+	})
+	return ac.loadErr
 }
 
 func (ac *AlpaconClient) SetWebsocketHeader() http.Header {
@@ -224,6 +224,13 @@ func (ac *AlpaconClient) SendMultipartRequest(url string, multiPartWriter *multi
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errors.New("authentication failed: please run 'alpacon login' again")
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, errors.New("permission denied")
 	}
 
 	if resp.StatusCode != http.StatusCreated {

--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	checkAuthURL       = "/api/auth/is-authenticated/"
 	checkPrivilegesURL = "/api/iam/users/-"
 )
 
@@ -59,55 +58,7 @@ func NewAlpaconAPIClient() (*AlpaconClient, error) {
 		client.AccessToken = tokenRes.AccessToken
 	}
 
-	err = client.checkAuth()
-	if err != nil {
-		return nil, err
-	}
-
-	err = client.checkPrivileges()
-	if err != nil {
-		return nil, err
-	}
-
 	return client, nil
-}
-
-func (ac *AlpaconClient) checkAuth() error {
-	body, err := ac.SendGetRequest(checkAuthURL)
-	if err != nil {
-		return err
-	}
-
-	var checkAuthResponse CheckAuthResponse
-
-	err = json.Unmarshal(body, &checkAuthResponse)
-	if err != nil {
-		return err
-	}
-	if !checkAuthResponse.Authenticated {
-		return errors.New("authentication failed: your login session has expired or is invalid. Please run 'alpacon login' to authenticate again")
-	}
-
-	return nil
-}
-
-func (ac *AlpaconClient) checkPrivileges() error {
-	body, err := ac.SendGetRequest(checkPrivilegesURL)
-	if err != nil {
-		return err
-	}
-
-	var checkPrivilegesResponse CheckPrivilegesResponse
-
-	err = json.Unmarshal(body, &checkPrivilegesResponse)
-	if err != nil {
-		return err
-	}
-
-	ac.Privileges = getUserPrivileges(checkPrivilegesResponse.IsStaff, checkPrivilegesResponse.IsSuperuser)
-	ac.Username = strings.TrimSpace(checkPrivilegesResponse.Username)
-
-	return nil
 }
 
 func getUserPrivileges(isStaff, isSuperuser bool) string {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -98,3 +98,32 @@ func TestLoadCurrentUser_GeneralPrivileges(t *testing.T) {
 	assert.NoError(t, ac.LoadCurrentUser())
 	assert.Equal(t, "general", ac.Privileges)
 }
+
+func TestLoadCurrentUser_401ReturnsAuthError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail": "invalid token"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	err := ac.LoadCurrentUser()
+	assert.ErrorContains(t, err, "authentication failed")
+	assert.Empty(t, ac.Username)
+	assert.Empty(t, ac.Privileges)
+}
+
+func TestLoadCurrentUser_InvalidJSONReturnsError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not valid json`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	err := ac.LoadCurrentUser()
+	assert.Error(t, err)
+	assert.Empty(t, ac.Username)
+	assert.Empty(t, ac.Privileges)
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -127,3 +127,22 @@ func TestLoadCurrentUser_InvalidJSONReturnsError(t *testing.T) {
 	assert.Empty(t, ac.Username)
 	assert.Empty(t, ac.Privileges)
 }
+
+func TestLoadCurrentUser_ErrorIsCachedOnFailure(t *testing.T) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail": "invalid token"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	err1 := ac.LoadCurrentUser()
+	err2 := ac.LoadCurrentUser() // second call must return cached error without hitting server
+
+	assert.ErrorContains(t, err1, "authentication failed")
+	assert.ErrorContains(t, err2, "authentication failed")
+	assert.Equal(t, 1, callCount, "LoadCurrentUser must hit the server exactly once even on failure")
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -40,4 +41,60 @@ func TestSendRequest_403ReturnsForbiddenError(t *testing.T) {
 	ac := newTestClient(ts.URL)
 	_, err := ac.SendGetRequest("/api/test/")
 	assert.ErrorContains(t, err, "permission denied")
+}
+
+func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckPrivilegesResponse{
+			Username:    " alice ",
+			IsStaff:     true,
+			IsSuperuser: false,
+		})
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+
+	err := ac.LoadCurrentUser()
+	assert.NoError(t, err)
+	assert.Equal(t, "alice", ac.Username)
+	assert.Equal(t, "staff", ac.Privileges)
+
+	_ = ac.LoadCurrentUser() // second call must be a no-op
+	assert.Equal(t, 1, callCount, "LoadCurrentUser must hit the server exactly once")
+}
+
+func TestLoadCurrentUser_SuperuserPrivileges(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckPrivilegesResponse{
+			Username:    "bob",
+			IsStaff:     true,
+			IsSuperuser: true,
+		})
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	assert.NoError(t, ac.LoadCurrentUser())
+	assert.Equal(t, "superuser", ac.Privileges)
+}
+
+func TestLoadCurrentUser_GeneralPrivileges(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CheckPrivilegesResponse{
+			Username:    "carol",
+			IsStaff:     false,
+			IsSuperuser: false,
+		})
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	assert.NoError(t, ac.LoadCurrentUser())
+	assert.Equal(t, "general", ac.Privileges)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -126,6 +128,61 @@ func TestLoadCurrentUser_InvalidJSONReturnsError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, ac.Username)
 	assert.Empty(t, ac.Privileges)
+}
+
+func TestSendGetRequestForDownload_401ReturnsAuthError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequestForDownload("/api/test/")
+	assert.ErrorContains(t, err, "authentication failed")
+}
+
+func TestSendGetRequestForDownload_403ReturnsForbiddenError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequestForDownload("/api/test/")
+	assert.ErrorContains(t, err, "permission denied")
+}
+
+func TestSendMultipartRequest_401ReturnsAuthError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendMultipartRequest("/api/test/", mw, buf)
+	assert.ErrorContains(t, err, "authentication failed")
+}
+
+func TestSendMultipartRequest_200IsSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.Close()
+
+	ac := newTestClient(ts.URL)
+	body, err := ac.SendMultipartRequest("/api/test/", mw, buf)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(`{}`), body)
 }
 
 func TestLoadCurrentUser_ErrorIsCachedOnFailure(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -116,6 +116,19 @@ func TestLoadCurrentUser_401ReturnsAuthError(t *testing.T) {
 	assert.Empty(t, ac.Privileges)
 }
 
+func TestLoadCurrentUser_403ReturnsForbiddenError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	err := ac.LoadCurrentUser()
+	assert.ErrorContains(t, err, "permission denied")
+	assert.Empty(t, ac.Username)
+	assert.Empty(t, ac.Privileges)
+}
+
 func TestLoadCurrentUser_InvalidJSONReturnsError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestClient(baseURL string) *AlpaconClient {
+	return &AlpaconClient{
+		HTTPClient: &http.Client{},
+		BaseURL:    baseURL,
+		Token:      "test-token",
+	}
+}
+
+func TestSendRequest_401ReturnsAuthError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail": "invalid token"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	assert.ErrorContains(t, err, "authentication failed")
+}
+
+func TestSendRequest_403ReturnsForbiddenError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail": "forbidden"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	assert.ErrorContains(t, err, "permission denied")
+}

--- a/client/types.go
+++ b/client/types.go
@@ -10,6 +10,7 @@ type AlpaconClient struct {
 	Privileges  string
 	Username    string
 	UserAgent   string
+	userLoaded  bool
 }
 
 type CheckAuthResponse struct {

--- a/client/types.go
+++ b/client/types.go
@@ -1,6 +1,9 @@
 package client
 
-import "net/http"
+import (
+	"net/http"
+	"sync"
+)
 
 type AlpaconClient struct {
 	HTTPClient  *http.Client
@@ -10,7 +13,8 @@ type AlpaconClient struct {
 	Privileges  string
 	Username    string
 	UserAgent   string
-	userLoaded  bool
+	loadOnce    sync.Once
+	loadErr     error
 }
 
 type CheckPrivilegesResponse struct {

--- a/client/types.go
+++ b/client/types.go
@@ -13,8 +13,9 @@ type AlpaconClient struct {
 	Privileges  string
 	Username    string
 	UserAgent   string
-	loadOnce    sync.Once
-	loadErr     error
+
+	loadOnce sync.Once
+	loadErr  error
 }
 
 type CheckPrivilegesResponse struct {

--- a/client/types.go
+++ b/client/types.go
@@ -13,10 +13,6 @@ type AlpaconClient struct {
 	userLoaded  bool
 }
 
-type CheckAuthResponse struct {
-	Authenticated bool `json:"authenticated"`
-}
-
 type CheckPrivilegesResponse struct {
 	Username    string `json:"username"`
 	IsStaff     bool   `json:"is_staff"`

--- a/cmd/iam/group_create.go
+++ b/cmd/iam/group_create.go
@@ -28,6 +28,10 @@ var groupCreateCmd = &cobra.Command{
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
+		if err := alpaconClient.LoadCurrentUser(); err != nil {
+			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+		}
+
 		if alpaconClient.Privileges == "general" {
 			utils.CliErrorWithExit("You do not have the permission to create groups.")
 		}

--- a/cmd/iam/group_create.go
+++ b/cmd/iam/group_create.go
@@ -29,7 +29,7 @@ var groupCreateCmd = &cobra.Command{
 		}
 
 		if err := alpaconClient.LoadCurrentUser(); err != nil {
-			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+			utils.CliErrorWithExit("Failed to load current user: %s", err)
 		}
 
 		if alpaconClient.Privileges == "general" {
@@ -38,14 +38,14 @@ var groupCreateCmd = &cobra.Command{
 
 		serverList, err := server.GetServerList(alpaconClient)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve the server list: %s.", err)
+			utils.CliErrorWithExit("Failed to retrieve the server list: %s", err)
 		}
 
 		groupRequest := promptForGroup(alpaconClient, serverList)
 
 		err = iam.CreateGroup(alpaconClient, groupRequest)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to create the new group: %s.", err)
+			utils.CliErrorWithExit("Failed to create the new group: %s", err)
 		}
 
 		utils.CliSuccess("Group created: %s", groupRequest.Name)

--- a/cmd/iam/group_delete.go
+++ b/cmd/iam/group_delete.go
@@ -35,6 +35,10 @@ var groupDeleteCmd = &cobra.Command{
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
+		if err := alpaconClient.LoadCurrentUser(); err != nil {
+			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+		}
+
 		if alpaconClient.Privileges == "general" {
 			utils.CliErrorWithExit("You do not have the permission to delete groups.")
 		}

--- a/cmd/iam/group_delete.go
+++ b/cmd/iam/group_delete.go
@@ -36,7 +36,7 @@ var groupDeleteCmd = &cobra.Command{
 		}
 
 		if err := alpaconClient.LoadCurrentUser(); err != nil {
-			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+			utils.CliErrorWithExit("Failed to load current user: %s", err)
 		}
 
 		if alpaconClient.Privileges == "general" {
@@ -45,7 +45,7 @@ var groupDeleteCmd = &cobra.Command{
 
 		err = iam.DeleteGroup(alpaconClient, groupName)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to delete the group: %s.", err)
+			utils.CliErrorWithExit("Failed to delete the group: %s", err)
 		}
 
 		utils.CliSuccess("Group deleted: %s", groupName)

--- a/cmd/iam/user_create.go
+++ b/cmd/iam/user_create.go
@@ -34,7 +34,7 @@ var userCreateCmd = &cobra.Command{
 		}
 
 		if err := alpaconClient.LoadCurrentUser(); err != nil {
-			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+			utils.CliErrorWithExit("Failed to load current user: %s", err)
 		}
 
 		if alpaconClient.Privileges == "general" {
@@ -45,13 +45,15 @@ var userCreateCmd = &cobra.Command{
 
 		err = iam.CreateUser(alpaconClient, userRequest)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to create the new user: %s.", err)
+			utils.CliErrorWithExit("Failed to create the new user: %s", err)
 		}
 
 		utils.CliSuccess("User created: %s", userRequest.Username)
 	},
 }
 
+// promptForUser collects user fields interactively. Callers must call LoadCurrentUser first,
+// as ac.Privileges determines which fields are presented.
 func promptForUser(ac *client.AlpaconClient) iam.UserCreateRequest {
 	var userRequest iam.UserCreateRequest
 

--- a/cmd/iam/user_create.go
+++ b/cmd/iam/user_create.go
@@ -33,6 +33,10 @@ var userCreateCmd = &cobra.Command{
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
+		if err := alpaconClient.LoadCurrentUser(); err != nil {
+			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+		}
+
 		if alpaconClient.Privileges == "general" {
 			utils.CliErrorWithExit("Insufficient permissions to create users. This action requires staff or superuser privileges. Please contact your administrator to request elevated permissions")
 		}

--- a/cmd/iam/user_create.go
+++ b/cmd/iam/user_create.go
@@ -52,8 +52,7 @@ var userCreateCmd = &cobra.Command{
 	},
 }
 
-// promptForUser collects user fields interactively. Callers must call LoadCurrentUser first,
-// as ac.Privileges determines which fields are presented.
+// Callers must call LoadCurrentUser first; ac.Privileges determines which fields are presented.
 func promptForUser(ac *client.AlpaconClient) iam.UserCreateRequest {
 	var userRequest iam.UserCreateRequest
 

--- a/cmd/iam/user_delete.go
+++ b/cmd/iam/user_delete.go
@@ -34,6 +34,10 @@ var userDeleteCmd = &cobra.Command{
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
+		if err := alpaconClient.LoadCurrentUser(); err != nil {
+			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+		}
+
 		if alpaconClient.Privileges == "general" {
 			utils.CliErrorWithExit("You do not have the permission to delete users.")
 		}

--- a/cmd/iam/user_delete.go
+++ b/cmd/iam/user_delete.go
@@ -35,7 +35,7 @@ var userDeleteCmd = &cobra.Command{
 		}
 
 		if err := alpaconClient.LoadCurrentUser(); err != nil {
-			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+			utils.CliErrorWithExit("Failed to load current user: %s", err)
 		}
 
 		if alpaconClient.Privileges == "general" {
@@ -44,7 +44,7 @@ var userDeleteCmd = &cobra.Command{
 
 		err = iam.DeleteUser(alpaconClient, userName)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to delete the user: %s.", err)
+			utils.CliErrorWithExit("Failed to delete the user: %s", err)
 		}
 
 		utils.CliSuccess("User deleted: %s", userName)

--- a/cmd/iam/user_invite.go
+++ b/cmd/iam/user_invite.go
@@ -37,6 +37,10 @@ This command requires staff or superuser privileges.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
+		if err := alpaconClient.LoadCurrentUser(); err != nil {
+			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+		}
+
 		if alpaconClient.Privileges == "general" {
 			utils.CliErrorWithExit("Insufficient permissions to invite users. This action requires staff or superuser privileges. Please contact your administrator to request elevated permissions.")
 		}

--- a/cmd/iam/user_invite.go
+++ b/cmd/iam/user_invite.go
@@ -38,11 +38,11 @@ This command requires staff or superuser privileges.`,
 		}
 
 		if err := alpaconClient.LoadCurrentUser(); err != nil {
-			utils.CliErrorWithExit("Failed to load current user: %s.", err)
+			utils.CliErrorWithExit("Failed to load current user: %s", err)
 		}
 
 		if alpaconClient.Privileges == "general" {
-			utils.CliErrorWithExit("Insufficient permissions to invite users. This action requires staff or superuser privileges. Please contact your administrator to request elevated permissions.")
+			utils.CliErrorWithExit("Insufficient permissions to invite users. This action requires staff or superuser privileges. Please contact your administrator to request elevated permissions")
 		}
 
 		var email string

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -166,8 +166,11 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 			}
 
 		}
-		_, err = client.NewAlpaconAPIClient()
+		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+		if err := ac.LoadCurrentUser(); err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -171,7 +171,7 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 		if err := ac.LoadCurrentUser(); err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+			utils.CliErrorWithExit("Login succeeded but failed to verify user profile: %s. Please try logging in again.", err)
 		}
 
 		utils.CliSuccess("Login succeeded!")

--- a/cmd/webhook/webhook_create.go
+++ b/cmd/webhook/webhook_create.go
@@ -83,7 +83,7 @@ Owner defaults to the currently logged-in user.`,
 
 		if owner == "" {
 			if err := alpaconClient.LoadCurrentUser(); err != nil {
-				utils.CliErrorWithExit("Failed to load current user: %s.", err)
+				utils.CliErrorWithExit("Failed to load current user: %s", err)
 			}
 			if alpaconClient.Username != "" {
 				owner = alpaconClient.Username

--- a/cmd/webhook/webhook_create.go
+++ b/cmd/webhook/webhook_create.go
@@ -82,6 +82,9 @@ Owner defaults to the currently logged-in user.`,
 		}
 
 		if owner == "" {
+			if err := alpaconClient.LoadCurrentUser(); err != nil {
+				utils.CliErrorWithExit("Failed to load current user: %s.", err)
+			}
 			if alpaconClient.Username != "" {
 				owner = alpaconClient.Username
 			} else {


### PR DESCRIPTION
## Summary

- **Remove preflight auth calls from `NewAlpaconAPIClient`**: The constructor no longer makes two blocking HTTP round-trips (`/api/auth/is-authenticated/` + `/api/iam/users/-`) on every CLI invocation (~1.57 s overhead eliminated)
- **Add `LoadCurrentUser` with `sync.Once` caching**: Privilege and username data are fetched at most once per process lifetime, lazily, only in commands that actually need them
- **Extract `checkAuthStatus` helper**: Deduplicates 401/403 error handling that was repeated across `sendRequest`, `SendMultipartRequest`, and `SendGetRequestForDownload`
- **Fix `SendMultipartRequest` to accept HTTP 200 and 201**: The server returns 200 for single-file upload and 201 for bulk upload; previously only 201 was accepted, silently treating 200 as an error
- **Fix `SendGetRequestForDownload`**: Close response body before returning auth errors to prevent resource leaks
- **Code quality**: Improve declaration order (`LoadCurrentUser` before unexported helpers), separate exported/unexported struct fields with a blank line

## Performance

Measured on a live workspace (10 samples each):

| Step | Before | After |
|------|--------|-------|
| `checkAuth` preflight | ~818 ms | removed |
| `checkPrivileges` preflight | ~756 ms | removed |
| Total preflight overhead | ~1,574 ms | 0 ms |
| `alpacon server list` wall time | ~2,552 ms | ~978 ms |
| **Reduction** | | **~62%** |

## Test plan

- [ ] `go test -race ./client/...` — all 13 tests pass
- [ ] `go test -race ./...` — full suite passes
- [ ] `alpacon login` completes and reports logged-in user
- [ ] Commands gated on staff/superuser privilege (`user create`, `group create`, `group delete`) correctly reject general users
- [ ] `alpacon server list` (or any non-privilege-gated command) no longer waits for a privilege preflight call