### PR TITLE
chore(ci): bump docker/login-action from v3 to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump `docker/login-action` from v3 to v4 in `.github/workflows/release.yaml`.
- v4 switches the action's default runtime to Node 24 (requires Actions Runner v2.327.1+, already provided by `ubuntu-latest`).
- Action inputs (`username`, `password`) are unchanged, so no workflow adjustments are needed.

## Context
Audited every action used across `.github/`. After this bump, all JavaScript actions are aligned on Node 24:

| Action | Version | Runtime |
| --- | --- | --- |
| actions/checkout | v6 | node24 |
| actions/setup-go | v6 | node24 |
| actions/upload-artifact | v6 | node24 |
| actions/download-artifact | v7 | node24 |
| docker/login-action | v4 | node24 |
| goreleaser/goreleaser-action | v7 | node24 |
| golangci/golangci-lint-action | v9 | node24 |
| danielmundi/upload-packagecloud | v1 | composite (bash) |

## Test plan
- [ ] Confirm the next tag push triggers `release.yaml` and the `Log in to Docker Hub` step succeeds with v4.
- [ ] Verify the subsequent `goreleaser` step still pushes the Docker image using the v4 login session.