### PR TITLE
feat(exec): propagate remote exit code and surface error_phase

### DIFF
--- a/api/event/event.go
+++ b/api/event/event.go
@@ -102,7 +102,8 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 
 	if result.Status == "stuck" || result.Status == "error" {
 		if result.ErrorPhase != nil && *result.ErrorPhase != "" {
-			return "", fmt.Errorf("command failed: %s (status=%s)", *result.ErrorPhase, result.Status)
+			return "", fmt.Errorf("command failed: [%s] %s (status=%s)",
+				*result.ErrorPhase, DescribePhase(*result.ErrorPhase), result.Status)
 		}
 		return "", fmt.Errorf("command failed with status: %s", result.Status)
 	}

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -2,7 +2,6 @@ package event
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"path"
 	"time"
@@ -129,18 +128,23 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 	return result.Result, nil
 }
 
+// PollCommandExecution polls with default timeout/tick; tests use pollCommandExecution directly.
 func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails, error) {
+	return pollCommandExecution(ac, cmdId, 5*time.Minute, 1*time.Second)
+}
+
+func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration) (EventDetails, error) {
 	var response EventDetails
 
-	timer := time.NewTimer(5 * time.Minute)
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-timer.C:
-			return response, errors.New("command execution timed out")
+			return response, &ClientTimeoutError{}
 		case <-ticker.C:
 			responseBody, err := ac.SendGetRequest(utils.BuildURL(getEventURL, cmdId, nil))
 			if err != nil {
@@ -152,7 +156,7 @@ func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails,
 
 			switch response.Status {
 			case "queued", "scheduled", "delivered", "verifying", "running", "acked":
-				timer.Reset(5 * time.Minute)
+				timer.Reset(timeout)
 				continue
 			default:
 				return response, nil

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -105,7 +105,19 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 	}
 
 	if result.Success != nil && !*result.Success {
-		return result.Result, &RemoteCommandError{Output: result.Result}
+		exitCode := 1
+		if result.ExitCode != nil {
+			exitCode = *result.ExitCode
+		}
+		errorPhase := ""
+		if result.ErrorPhase != nil {
+			errorPhase = *result.ErrorPhase
+		}
+		return result.Result, &RemoteCommandError{
+			Output:     result.Result,
+			ExitCode:   exitCode,
+			ErrorPhase: errorPhase,
+		}
 	}
 
 	return result.Result, nil

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -101,6 +101,9 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 	}
 
 	if result.Status == "stuck" || result.Status == "error" {
+		if result.ErrorPhase != nil && *result.ErrorPhase != "" {
+			return "", fmt.Errorf("command failed: %s (status=%s)", *result.ErrorPhase, result.Status)
+		}
 		return "", fmt.Errorf("command failed with status: %s", result.Status)
 	}
 

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -108,6 +108,8 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 	}
 
 	if result.Success != nil && !*result.Success {
+		// Trust the server contract: alpamon sets success=(exitCode==0), so a
+		// non-nil exit_code is propagated as-is.
 		exitCode := 1
 		if result.ExitCode != nil {
 			exitCode = *result.ExitCode

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -430,17 +430,21 @@ func strPtr(s string) *string { return &s }
 func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
+			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(api.ListResponse[map[string]any]{
 				Count:   1,
 				Results: []map[string]any{{"id": "srv-1", "name": "server-x"}},
 			})
-		case r.Method == http.MethodPost:
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/api/events/commands/"):
+			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "cmd-1"}})
-		default:
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/events/commands/"):
+			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(details)
+		default:
+			http.NotFound(w, r)
 		}
 	}))
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -315,4 +315,102 @@ func TestRunCommand_SuccessFalseReturnsRemoteCommandError(t *testing.T) {
 	require.True(t, errors.As(err, &remoteErr), "err must be *RemoteCommandError")
 	assert.Equal(t, "command output here", result)
 	assert.Equal(t, "command output here", remoteErr.Output)
+	assert.Equal(t, 1, remoteErr.ExitCode, "legacy response without exit_code must fall back to 1")
+	assert.Empty(t, remoteErr.ErrorPhase, "no phase when server omits error_phase")
+}
+
+func TestRunCommand_PropagatesExitCode(t *testing.T) {
+	tests := []struct {
+		name           string
+		respSuccess    *bool
+		respExitCode   *int
+		respErrorPhase *string
+		respResult     string
+		wantExitCode   int
+		wantErrorPhase string
+		wantOutput     string
+	}{
+		{
+			name:         "exit_1",
+			respSuccess:  boolPtr(false),
+			respExitCode: intPtr(1),
+			respResult:   "boom",
+			wantExitCode: 1,
+			wantOutput:   "boom",
+		},
+		{
+			name:         "exit_23_rsync_partial",
+			respSuccess:  boolPtr(false),
+			respExitCode: intPtr(23),
+			respResult:   "rsync: partial transfer",
+			wantExitCode: 23,
+			wantOutput:   "rsync: partial transfer",
+		},
+		{
+			name:           "exit_124_with_phase",
+			respSuccess:    boolPtr(false),
+			respExitCode:   intPtr(124),
+			respErrorPhase: strPtr("remote_command_exceeded_timeout"),
+			respResult:     "timed out",
+			wantExitCode:   124,
+			wantErrorPhase: "remote_command_exceeded_timeout",
+			wantOutput:     "timed out",
+		},
+		{
+			name:         "legacy_null_exit_code_falls_back_to_1",
+			respSuccess:  boolPtr(false),
+			respExitCode: nil,
+			respResult:   "old alpamon",
+			wantExitCode: 1,
+			wantOutput:   "old alpamon",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newRunCommandServerWithDetails(t, EventDetails{
+				ID:         "cmd-1",
+				Status:     "completed",
+				Success:    tt.respSuccess,
+				ExitCode:   tt.respExitCode,
+				ErrorPhase: tt.respErrorPhase,
+				Result:     tt.respResult,
+			})
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			result, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
+			require.Error(t, err)
+
+			var remoteErr *RemoteCommandError
+			require.True(t, errors.As(err, &remoteErr), "err must be *RemoteCommandError")
+			assert.Equal(t, tt.wantOutput, result)
+			assert.Equal(t, tt.wantOutput, remoteErr.Output)
+			assert.Equal(t, tt.wantExitCode, remoteErr.ExitCode)
+			assert.Equal(t, tt.wantErrorPhase, remoteErr.ErrorPhase)
+		})
+	}
+}
+
+// helpers placed near other test helpers in this file
+func boolPtr(b bool) *bool       { return &b }
+func intPtr(i int) *int          { return &i }
+func strPtr(s string) *string    { return &s }
+
+func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
+			_ = json.NewEncoder(w).Encode(api.ListResponse[map[string]any]{
+				Count:   1,
+				Results: []map[string]any{{"id": "srv-1", "name": "server-x"}},
+			})
+		case r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "cmd-1"}})
+		default:
+			_ = json.NewEncoder(w).Encode(details)
+		}
+	}))
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -392,6 +392,64 @@ func TestRunCommand_PropagatesExitCode(t *testing.T) {
 	}
 }
 
+func TestRunCommand_StuckWithErrorPhase(t *testing.T) {
+	tests := []struct {
+		name           string
+		respStatus     string
+		respErrorPhase *string
+		wantSubstrings []string
+	}{
+		{
+			name:           "stuck_agent_timeout",
+			respStatus:     "stuck",
+			respErrorPhase: strPtr("agent_timeout"),
+			wantSubstrings: []string{"agent_timeout", "status=stuck"},
+		},
+		{
+			name:           "stuck_agent_disconnected",
+			respStatus:     "stuck",
+			respErrorPhase: strPtr("agent_disconnected"),
+			wantSubstrings: []string{"agent_disconnected", "status=stuck"},
+		},
+		{
+			name:           "stuck_no_phase_keeps_legacy_message",
+			respStatus:     "stuck",
+			respErrorPhase: nil,
+			wantSubstrings: []string{"command failed with status: stuck"},
+		},
+		{
+			name:           "error_with_phase",
+			respStatus:     "error",
+			respErrorPhase: strPtr("agent_disconnected"),
+			wantSubstrings: []string{"agent_disconnected", "status=error"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newRunCommandServerWithDetails(t, EventDetails{
+				ID:         "cmd-1",
+				Status:     tt.respStatus,
+				ErrorPhase: tt.respErrorPhase,
+			})
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			result, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
+			require.Error(t, err)
+			assert.Empty(t, result)
+
+			var remoteErr *RemoteCommandError
+			assert.False(t, errors.As(err, &remoteErr),
+				"stuck/error must remain infra error, not RemoteCommandError")
+
+			for _, sub := range tt.wantSubstrings {
+				assert.Contains(t, err.Error(), sub)
+			}
+		})
+	}
+}
+
 // helpers placed near other test helpers in this file
 func boolPtr(b bool) *bool       { return &b }
 func intPtr(i int) *int          { return &i }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -259,20 +259,7 @@ func TestRunCommand_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
 func TestRunCommand_InfraStatusReturnsError(t *testing.T) {
 	for _, status := range []string{"stuck", "error"} {
 		t.Run(status, func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				switch {
-				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
-					_ = json.NewEncoder(w).Encode(api.ListResponse[map[string]any]{
-						Count:   1,
-						Results: []map[string]any{{"id": "srv-1", "name": "server-x"}},
-					})
-				case r.Method == http.MethodPost:
-					_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "cmd-1"}})
-				default:
-					_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: status})
-				}
-			}))
+			ts := newRunCommandServerWithDetails(t, EventDetails{ID: "cmd-1", Status: status})
 			defer ts.Close()
 
 			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
@@ -285,26 +272,12 @@ func TestRunCommand_InfraStatusReturnsError(t *testing.T) {
 }
 
 func TestRunCommand_SuccessFalseReturnsRemoteCommandError(t *testing.T) {
-	falseVal := false
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
-			_ = json.NewEncoder(w).Encode(api.ListResponse[map[string]any]{
-				Count:   1,
-				Results: []map[string]any{{"id": "srv-1", "name": "server-x"}},
-			})
-		case r.Method == http.MethodPost:
-			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "cmd-1"}})
-		default:
-			_ = json.NewEncoder(w).Encode(EventDetails{
-				ID:      "cmd-1",
-				Status:  "completed",
-				Success: &falseVal,
-				Result:  "command output here",
-			})
-		}
-	}))
+	ts := newRunCommandServerWithDetails(t, EventDetails{
+		ID:      "cmd-1",
+		Status:  "completed",
+		Success: boolPtr(false),
+		Result:  "command output here",
+	})
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
@@ -450,10 +423,9 @@ func TestRunCommand_StuckWithErrorPhase(t *testing.T) {
 	}
 }
 
-// helpers placed near other test helpers in this file
-func boolPtr(b bool) *bool       { return &b }
-func intPtr(i int) *int          { return &i }
-func strPtr(s string) *string    { return &s }
+func boolPtr(b bool) *bool    { return &b }
+func intPtr(i int) *int       { return &i }
+func strPtr(s string) *string { return &s }
 
 func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
 	t.Helper()

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/api/types"
@@ -426,6 +427,36 @@ func TestRunCommand_StuckWithErrorPhase(t *testing.T) {
 func boolPtr(b bool) *bool    { return &b }
 func intPtr(i int) *int       { return &i }
 func strPtr(s string) *string { return &s }
+
+func TestPollCommandExecution_ClientTimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always fail GETs so SendGetRequest returns an error and the poll
+		// loop never resets its timer.
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := pollCommandExecution(ac, "cmd-1", 50*time.Millisecond, 10*time.Millisecond)
+	require.Error(t, err)
+
+	var clientTimeout *ClientTimeoutError
+	require.True(t, errors.As(err, &clientTimeout),
+		"timer expiry must surface a *ClientTimeoutError, got %T: %v", err, err)
+}
+
+func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(EventDetails{ID: "cmd-1", Status: "completed"})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	resp, err := pollCommandExecution(ac, "cmd-1", 50*time.Millisecond, 5*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", resp.Status)
+}
 
 func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
 	t.Helper()

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -8,7 +8,8 @@ import (
 )
 
 // RemoteCommandError is returned when the remote command completed but exited
-// with a non-zero status. ExitCode falls back to 1 if the server omits it.
+// with a non-zero status. Callers populate ExitCode from the server response;
+// RunCommand falls back to 1 when the server omits exit_code.
 type RemoteCommandError struct {
 	Output     string
 	ExitCode   int

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -7,6 +7,13 @@ import (
 	"github.com/alpacax/alpacon-cli/api/types"
 )
 
+// phaseDescriptions humanizes server-classified error_phase identifiers.
+var phaseDescriptions = map[string]string{
+	"agent_disconnected":              "agent never acknowledged the command (likely disconnected)",
+	"agent_timeout":                   "agent acknowledged the command but did not return a result in time",
+	"remote_command_exceeded_timeout": "remote command exceeded its execution timeout",
+}
+
 // RemoteCommandError is returned when the remote command completed but exited
 // with a non-zero status. Callers populate ExitCode from the server response;
 // RunCommand falls back to 1 when the server omits exit_code.
@@ -75,4 +82,13 @@ func (e *RemoteCommandError) Error() string {
 		return fmt.Sprintf("remote command failed (%s, exit %d)", e.ErrorPhase, e.ExitCode)
 	}
 	return fmt.Sprintf("remote command exited with code %d", e.ExitCode)
+}
+
+// DescribePhase returns the human-readable description for an error_phase,
+// or the raw identifier when the phase is unknown.
+func DescribePhase(phase string) string {
+	if desc, ok := phaseDescriptions[phase]; ok {
+		return desc
+	}
+	return phase
 }

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -8,10 +8,12 @@ import (
 )
 
 // phaseDescriptions humanizes server-classified error_phase identifiers.
+// "client_timeout" is CLI-side only; the server does not emit it.
 var phaseDescriptions = map[string]string{
 	"agent_disconnected":              "agent never acknowledged the command (likely disconnected)",
 	"agent_timeout":                   "agent acknowledged the command but did not return a result in time",
 	"remote_command_exceeded_timeout": "remote command exceeded its execution timeout",
+	"client_timeout":                  "CLI gave up waiting for the server to report a result",
 }
 
 // RemoteCommandError is returned when the remote command completed but exited
@@ -22,6 +24,10 @@ type RemoteCommandError struct {
 	ExitCode   int
 	ErrorPhase string
 }
+
+// ClientTimeoutError is returned when the CLI gave up polling for the command
+// result before the server reported a terminal status.
+type ClientTimeoutError struct{}
 
 type EventAttributes struct {
 	Server      string `json:"server"`
@@ -82,6 +88,10 @@ func (e *RemoteCommandError) Error() string {
 		return fmt.Sprintf("remote command failed (%s, exit %d)", e.ErrorPhase, e.ExitCode)
 	}
 	return fmt.Sprintf("remote command exited with code %d", e.ExitCode)
+}
+
+func (*ClientTimeoutError) Error() string {
+	return "CLI timed out waiting for command result"
 }
 
 // DescribePhase returns the human-readable description for an error_phase,

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -8,22 +8,11 @@ import (
 )
 
 // RemoteCommandError is returned when the remote command completed but exited
-// with a non-zero status. Output holds the captured stdout/stderr.
-// ExitCode is the remote process exit code (>=1; falls back to 1 when the
-// server did not include exit_code in the response). ErrorPhase is the
-// server-classified phase (e.g. "remote_command_exceeded_timeout") and is
-// empty when no phase applies.
+// with a non-zero status. ExitCode falls back to 1 if the server omits it.
 type RemoteCommandError struct {
 	Output     string
 	ExitCode   int
 	ErrorPhase string
-}
-
-func (e *RemoteCommandError) Error() string {
-	if e.ErrorPhase != "" {
-		return fmt.Sprintf("remote command failed (%s, exit %d)", e.ErrorPhase, e.ExitCode)
-	}
-	return fmt.Sprintf("remote command exited with code %d", e.ExitCode)
 }
 
 type EventAttributes struct {
@@ -78,4 +67,11 @@ type CommandResponse struct {
 	Server      types.ServerSummary `json:"server"`
 	RequestedBy types.UserSummary   `json:"requested_by"`
 	RunAfter    []any               `json:"run_after"`
+}
+
+func (e *RemoteCommandError) Error() string {
+	if e.ErrorPhase != "" {
+		return fmt.Sprintf("remote command failed (%s, exit %d)", e.ErrorPhase, e.ExitCode)
+	}
+	return fmt.Sprintf("remote command exited with code %d", e.ExitCode)
 }

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/api/types"
@@ -8,12 +9,21 @@ import (
 
 // RemoteCommandError is returned when the remote command completed but exited
 // with a non-zero status. Output holds the captured stdout/stderr.
+// ExitCode is the remote process exit code (>=1; falls back to 1 when the
+// server did not include exit_code in the response). ErrorPhase is the
+// server-classified phase (e.g. "remote_command_exceeded_timeout") and is
+// empty when no phase applies.
 type RemoteCommandError struct {
-	Output string
+	Output     string
+	ExitCode   int
+	ErrorPhase string
 }
 
 func (e *RemoteCommandError) Error() string {
-	return "remote command exited with non-zero status"
+	if e.ErrorPhase != "" {
+		return fmt.Sprintf("remote command failed (%s, exit %d)", e.ErrorPhase, e.ExitCode)
+	}
+	return fmt.Sprintf("remote command exited with code %d", e.ExitCode)
 }
 
 type EventAttributes struct {
@@ -31,6 +41,8 @@ type EventDetails struct {
 	Shell         string              `json:"shell"`
 	Line          string              `json:"line"`
 	Success       *bool               `json:"success"`
+	ExitCode      *int                `json:"exit_code"`
+	ErrorPhase    *string             `json:"error_phase"`
 	Result        string              `json:"result"`
 	Status        string              `json:"status"`
 	Cancellable   bool                `json:"cancellable"`

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -52,6 +52,8 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 }
 
 // HandleCommandResult prints result on success, or exits appropriately on error.
+// On RemoteCommandError, prints captured output to stdout, surfaces error_phase
+// (if present) to stderr, and exits with the remote process's actual exit code.
 func HandleCommandResult(result string, err error) {
 	if err != nil {
 		var remoteErr *event.RemoteCommandError
@@ -59,7 +61,10 @@ func HandleCommandResult(result string, err error) {
 			if remoteErr.Output != "" {
 				fmt.Println(remoteErr.Output)
 			}
-			os.Exit(1)
+			if remoteErr.ErrorPhase != "" {
+				utils.CliWarning("remote command failed: %s", remoteErr.ErrorPhase)
+			}
+			os.Exit(remoteErr.ExitCode)
 		}
 		utils.CliErrorWithExit("%s", err)
 		return

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -18,9 +18,8 @@ import (
 // to omit it.
 func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (string, error) {
 	result, err := event.RunCommand(ac, serverName, command, username, groupname, env, workSessionID)
-	var remoteErr *event.RemoteCommandError
-	if errors.As(err, &remoteErr) {
-		return result, remoteErr
+	if phased, ok := asPhasedError(err); ok {
+		return result, phased
 	}
 	if err != nil {
 		err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
@@ -40,9 +39,9 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 				return err
 			},
 		})
-		// RetryOperation may return a RemoteCommandError; re-check after HandleCommonErrors.
-		if errors.As(err, &remoteErr) {
-			return result, remoteErr
+		// RetryOperation may surface a phased error; re-check after HandleCommonErrors.
+		if phased, ok := asPhasedError(err); ok {
+			return result, phased
 		}
 		if err != nil {
 			return "", fmt.Errorf("failed to execute command on '%s' server: %w", serverName, err)
@@ -65,10 +64,37 @@ func HandleCommandResult(result string, err error) {
 			}
 			os.Exit(exitCode)
 		}
+		var clientTimeout *event.ClientTimeoutError
+		if errors.As(err, &clientTimeout) {
+			fmt.Fprint(os.Stderr, clientTimeoutLine())
+			os.Exit(1)
+		}
 		utils.CliErrorWithExit("%s", err)
 		return
 	}
 	fmt.Println(result)
+}
+
+// asPhasedError unwraps err to a RemoteCommandError or ClientTimeoutError.
+func asPhasedError(err error) (error, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var remoteErr *event.RemoteCommandError
+	if errors.As(err, &remoteErr) {
+		return remoteErr, true
+	}
+	var clientTimeout *event.ClientTimeoutError
+	if errors.As(err, &clientTimeout) {
+		return clientTimeout, true
+	}
+	return nil, false
+}
+
+// clientTimeoutLine renders the stderr line for ClientTimeoutError (with newline).
+func clientTimeoutLine() string {
+	const phase = "client_timeout"
+	return fmt.Sprintf("%s: [%s] %s\n", utils.Red("Error"), phase, event.DescribePhase(phase))
 }
 
 // remoteCommandOutcome is the testable core of HandleCommandResult's

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -56,8 +56,8 @@ func HandleCommandResult(result string, err error) {
 	if err != nil {
 		var remoteErr *event.RemoteCommandError
 		if errors.As(err, &remoteErr) {
-			if remoteErr.Output != "" {
-				fmt.Println(remoteErr.Output)
+			if result != "" {
+				fmt.Println(result)
 			}
 			if remoteErr.ErrorPhase != "" {
 				fmt.Fprintf(os.Stderr, "%s: remote command failed: %s\n", utils.Red("Error"), remoteErr.ErrorPhase)

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -60,7 +60,7 @@ func HandleCommandResult(result string, err error) {
 				fmt.Println(remoteErr.Output)
 			}
 			if remoteErr.ErrorPhase != "" {
-				utils.CliError("remote command failed: %s", remoteErr.ErrorPhase)
+				fmt.Fprintf(os.Stderr, "%s: remote command failed: %s\n", utils.Red("Error"), remoteErr.ErrorPhase)
 			}
 			os.Exit(remoteErr.ExitCode)
 		}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -56,16 +56,29 @@ func HandleCommandResult(result string, err error) {
 	if err != nil {
 		var remoteErr *event.RemoteCommandError
 		if errors.As(err, &remoteErr) {
-			if result != "" {
-				fmt.Println(result)
+			stdoutLine, stderrLine, exitCode := remoteCommandOutcome(result, remoteErr)
+			if stdoutLine != "" {
+				fmt.Println(stdoutLine)
 			}
-			if remoteErr.ErrorPhase != "" {
-				fmt.Fprintf(os.Stderr, "%s: remote command failed: %s\n", utils.Red("Error"), remoteErr.ErrorPhase)
+			if stderrLine != "" {
+				fmt.Fprint(os.Stderr, stderrLine)
 			}
-			os.Exit(remoteErr.ExitCode)
+			os.Exit(exitCode)
 		}
 		utils.CliErrorWithExit("%s", err)
 		return
 	}
 	fmt.Println(result)
+}
+
+// remoteCommandOutcome is the testable core of HandleCommandResult's
+// RemoteCommandError branch. stderrLine already includes its trailing newline.
+func remoteCommandOutcome(result string, remoteErr *event.RemoteCommandError) (stdoutLine, stderrLine string, exitCode int) {
+	if result != "" {
+		stdoutLine = result
+	}
+	if remoteErr.ErrorPhase != "" {
+		stderrLine = fmt.Sprintf("%s: remote command failed: %s\n", utils.Red("Error"), remoteErr.ErrorPhase)
+	}
+	return stdoutLine, stderrLine, remoteErr.ExitCode
 }

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -52,8 +52,6 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 }
 
 // HandleCommandResult prints result on success, or exits appropriately on error.
-// On RemoteCommandError, prints captured output to stdout, surfaces error_phase
-// (if present) to stderr, and exits with the remote process's actual exit code.
 func HandleCommandResult(result string, err error) {
 	if err != nil {
 		var remoteErr *event.RemoteCommandError

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -60,7 +60,7 @@ func HandleCommandResult(result string, err error) {
 				fmt.Println(remoteErr.Output)
 			}
 			if remoteErr.ErrorPhase != "" {
-				utils.CliWarning("remote command failed: %s", remoteErr.ErrorPhase)
+				utils.CliError("remote command failed: %s", remoteErr.ErrorPhase)
 			}
 			os.Exit(remoteErr.ExitCode)
 		}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -78,7 +78,10 @@ func remoteCommandOutcome(result string, remoteErr *event.RemoteCommandError) (s
 		stdoutLine = result
 	}
 	if remoteErr.ErrorPhase != "" {
-		stderrLine = fmt.Sprintf("%s: remote command failed: %s\n", utils.Red("Error"), remoteErr.ErrorPhase)
+		stderrLine = fmt.Sprintf("%s: [%s] %s\n",
+			utils.Red("Error"),
+			remoteErr.ErrorPhase,
+			event.DescribePhase(remoteErr.ErrorPhase))
 	}
 	return stdoutLine, stderrLine, remoteErr.ExitCode
 }

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -1,12 +1,47 @@
 package exec
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestClientTimeoutLine(t *testing.T) {
+	line := clientTimeoutLine()
+	assert.Contains(t, line, "[client_timeout]", "stderr should carry the phase id in brackets")
+	assert.Contains(t, line, event.DescribePhase("client_timeout"),
+		"stderr should include the human-readable description")
+	assert.True(t, len(line) > 0 && line[len(line)-1] == '\n', "line should end with newline")
+}
+
+func TestAsPhasedError(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantOk  bool
+		wantNil bool
+	}{
+		{name: "nil_returns_false", err: nil, wantOk: false, wantNil: true},
+		{name: "remote_command_error", err: &event.RemoteCommandError{ExitCode: 23}, wantOk: true},
+		{name: "client_timeout", err: &event.ClientTimeoutError{}, wantOk: true},
+		{name: "wrapped_remote_command_error", err: fmt.Errorf("wrap: %w", &event.RemoteCommandError{ExitCode: 1}), wantOk: true},
+		{name: "wrapped_client_timeout", err: fmt.Errorf("wrap: %w", &event.ClientTimeoutError{}), wantOk: true},
+		{name: "plain_error", err: errors.New("nope"), wantOk: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := asPhasedError(tt.err)
+			assert.Equal(t, tt.wantOk, ok)
+			if tt.wantNil {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
 
 func TestRemoteCommandOutcome(t *testing.T) {
 	tests := []struct {

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -1,0 +1,87 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/api/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteCommandOutcome(t *testing.T) {
+	tests := []struct {
+		name              string
+		result            string
+		remoteErr         *event.RemoteCommandError
+		wantStdoutLine    string
+		wantStderrEmpty   bool
+		wantStderrPhrase  string
+		wantExitCode      int
+	}{
+		{
+			name:   "result_and_phase_propagate_exit_124",
+			result: "command timed out",
+			remoteErr: &event.RemoteCommandError{
+				Output:     "command timed out",
+				ExitCode:   124,
+				ErrorPhase: "remote_command_exceeded_timeout",
+			},
+			wantStdoutLine:   "command timed out",
+			wantStderrPhrase: "remote_command_exceeded_timeout",
+			wantExitCode:     124,
+		},
+		{
+			name:   "non_zero_exit_without_phase_skips_stderr_line",
+			result: "rsync: some files vanished",
+			remoteErr: &event.RemoteCommandError{
+				Output:     "rsync: some files vanished",
+				ExitCode:   23,
+				ErrorPhase: "",
+			},
+			wantStdoutLine:  "rsync: some files vanished",
+			wantStderrEmpty: true,
+			wantExitCode:    23,
+		},
+		{
+			name:   "empty_result_with_phase_still_emits_stderr",
+			result: "",
+			remoteErr: &event.RemoteCommandError{
+				Output:     "",
+				ExitCode:   1,
+				ErrorPhase: "agent_timeout",
+			},
+			wantStdoutLine:   "",
+			wantStderrPhrase: "agent_timeout",
+			wantExitCode:     1,
+		},
+		{
+			name:   "legacy_fallback_exit_1_no_phase",
+			result: "boom",
+			remoteErr: &event.RemoteCommandError{
+				Output:     "boom",
+				ExitCode:   1,
+				ErrorPhase: "",
+			},
+			wantStdoutLine:  "boom",
+			wantStderrEmpty: true,
+			wantExitCode:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdoutLine, stderrLine, exitCode := remoteCommandOutcome(tt.result, tt.remoteErr)
+
+			assert.Equal(t, tt.wantStdoutLine, stdoutLine, "stdout line should match")
+			assert.Equal(t, tt.wantExitCode, exitCode, "exit code should match")
+
+			if tt.wantStderrEmpty {
+				assert.Empty(t, stderrLine, "stderr line should be empty when no phase")
+				return
+			}
+			assert.Contains(t, stderrLine, "remote command failed:", "stderr should carry the phase preamble")
+			assert.Contains(t, stderrLine, tt.wantStderrPhrase, "stderr should include the error phase")
+			assert.True(t, len(stderrLine) > 0 && stderrLine[len(stderrLine)-1] == '\n',
+				"stderr line should end with a newline")
+		})
+	}
+}

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api/event"
@@ -78,8 +79,10 @@ func TestRemoteCommandOutcome(t *testing.T) {
 				assert.Empty(t, stderrLine, "stderr line should be empty when no phase")
 				return
 			}
-			assert.Contains(t, stderrLine, "remote command failed:", "stderr should carry the phase preamble")
-			assert.Contains(t, stderrLine, tt.wantStderrPhrase, "stderr should include the error phase")
+			assert.Contains(t, stderrLine, fmt.Sprintf("[%s]", tt.wantStderrPhrase),
+				"stderr should carry the phase identifier in brackets for CI/grep")
+			assert.Contains(t, stderrLine, event.DescribePhase(tt.wantStderrPhrase),
+				"stderr should include the human-readable phase description")
 			assert.True(t, len(stderrLine) > 0 && stderrLine[len(stderrLine)-1] == '\n',
 				"stderr line should end with a newline")
 		})


### PR DESCRIPTION
## Summary

- Map the remote command exit code from `alpacon exec` and `alpacon websh COMMAND` onto the CLI process exit code.
- Surface error phases on stderr in a stable, grep-friendly format: `Error: [phase_id] human-readable description`.
- Distinguish CLI-side polling timeouts from server-classified failures via a `client_timeout` phase.
- Backward compatible with older alpamon/server combinations that omit the new fields.

closes #175

## Output format

| Scenario | exit code | stderr |
|---|---:|---|
| `bash -c 'exit 0'` | 0 | (empty) |
| `bash -c 'exit 23'` (rsync partial, no phase) | 23 | (empty) |
| `bash -c 'exit 124'` (alpamon timeout) | 124 | `Error: [remote_command_exceeded_timeout] remote command exceeded its execution timeout` |
| `agent_timeout` (stuck) | 1 | `command failed: [agent_timeout] agent acknowledged the command but did not return a result in time (status=stuck)` |
| `agent_disconnected` (stuck) | 1 | `command failed: [agent_disconnected] agent never acknowledged the command (likely disconnected) (status=stuck)` |
| CLI polling timeout | 1 | `Error: [client_timeout] CLI gave up waiting for the server to report a result` |
| Unknown phase (forward compat) | exit code propagated | `Error: [future_phase] future_phase` |

The bracketed phase id is stable for CI/scripts; the description is for humans.

## How it works

The CLI consumes two upstream contracts:

1. `alpacon-server` #2056 defines `exit_code: int|null` and `error_phase: string|null` on the command detail response, with three server-classified phases: `agent_disconnected`, `agent_timeout`, `remote_command_exceeded_timeout`.
2. `alpamon` #308 sends the real process exit code in the fin payload.

On the CLI side:

- The success path returns the remote `exit_code` as the process exit code.
- When the server marks the command stuck or errored, the error message includes the server's phase classification.
- A CLI-only `client_timeout` phase covers the polling-loop timeout — a condition the server cannot classify on its own.

## Changes

### `api/event/types.go`

- `EventDetails` carries `ExitCode *int` and `ErrorPhase *string` (pointer for nil-safety).
- `RemoteCommandError` carries `Output`, `ExitCode`, `ErrorPhase`; `Error()` reflects the phase and exit code.
- `ClientTimeoutError` represents the CLI-side polling timeout.
- `phaseDescriptions` + `DescribePhase(phase)` humanize known phases; unknown phases pass through unchanged for forward compatibility.

### `api/event/event.go`

- The `success=false` branch maps the server's `exit_code` / `error_phase` into `RemoteCommandError`. Nil `exit_code` falls back to `1`.
- The `stuck` / `error` branch formats the message as `command failed: [phase] description (status=...)` when a phase is present.
- `PollCommandExecution` is a thin wrapper over `pollCommandExecution(ac, cmdId, timeout, tick)` so tests can inject short timeouts; the timer-expiry path returns `&ClientTimeoutError{}`.

### `cmd/exec/run.go`

- `RunCommandWithRetry` routes both `RemoteCommandError` and `ClientTimeoutError` through a shared `asPhasedError` helper, bypassing the MFA/retry wrapping path.
- `HandleCommandResult`, on a phased error:
  1. Prints the remote result body to stdout (`RemoteCommandError` only).
  2. Writes a single `Error: [phase] description` line to stderr.
  3. Exits with the remote exit code (`RemoteCommandError`) or `1` (`ClientTimeoutError`).
- Both `exec` and `websh COMMAND` paths share this helper.

## Design notes

- **Trust the server contract.** Alpamon guarantees `success = (exitCode == 0)`, so `exit_code` is propagated as-is — the contradictory `success=false, exit_code=0` case cannot originate from the sender.
- **Stuck/error stays a plain error.** When the remote command failed to start at all, the CLI returns a plain `error` (not `RemoteCommandError`), preserving the retry/MFA handling path. Locked by an explicit `assert.False` in `event_test.go`.
- **Phase line on stderr, not via `CliError`.** `utils.CliError` appends a ""Report on GitHub"" notice, which is misleading for legitimate remote failures (e.g., `rsync exit 23`). The CLI writes to stderr directly with a red `Error:` prefix.
- **Bracketed phase id stays stable.** The raw identifier appears in `[brackets]` so CI scripts can grep on a stable token without parsing the natural-language description.

## Backward compatibility

| Scenario | Behavior |
|---|---|
| New alpamon + new server | `exit_code` propagated as-is, phase humanized when present |
| New alpamon + old server | `exit_code` absent → nil → falls back to `1` |
| Old alpamon | Only `success` sent → falls back to `1` |
| No `error_phase` | No stderr phase line, exit code still propagated |
| Unknown phase identifier | Bracketed id surfaces, description equals the id |

## Tests

Automated:

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`

Unit coverage:

- `TestRunCommand_PropagatesExitCode` — exit 1, 23 (rsync), 124 (+phase), nil (legacy fallback to 1).
- `TestRunCommand_StuckWithErrorPhase` — `agent_timeout`, `agent_disconnected`, no phase, `status=error` with phase.
- `TestRemoteCommandOutcome` — stderr line format, exit code routing, empty-result and no-phase cases.
- `TestPollCommandExecution_ClientTimeout` — timer expiry surfaces `*ClientTimeoutError`.
- `TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout` — happy-path regression guard.
- `TestClientTimeoutLine`, `TestAsPhasedError` — stderr line content and unwrap dispatch (including wrapped errors).

### Manual E2E

Against alpacon-server with #2056 and alpamon with #308. Raw transcript:

```console
$ ./alpacon exec -u chaejiseong test bash -c 'exit 0'; echo "→ $?"
Using work-session 260a07cc-0568-4003-a8e4-f780f8b0cf97

→ 0

$ ./alpacon exec -u chaejiseong test bash -c 'exit 23' 2>err.txt; echo "→ $?"
→ 23
$ cat err.txt
Using work-session 260a07cc-0568-4003-a8e4-f780f8b0cf97

$ ./alpacon exec -u chaejiseong test bash -c 'exit 124' 2>err.txt; echo "→ $?"
→ 124
$ cat err.txt
Using work-session 260a07cc-0568-4003-a8e4-f780f8b0cf97
Error: [remote_command_exceeded_timeout] remote command exceeded its execution timeout

$ ./alpacon websh -u chaejiseong test 'exit 124' 2>err.txt; echo "→ $?"
→ 124

$ ./alpacon exec -u chaejiseong test bash -c 'exit 124' && echo "OK" || echo "FAIL: rc=$?"
Using work-session 260a07cc-0568-4003-a8e4-f780f8b0cf97
Error: [remote_command_exceeded_timeout] remote command exceeded its execution timeout
FAIL: rc=124
```

Observations:

- exit codes 0 / 23 / 124 propagate unchanged through both `exec` and `websh COMMAND`.
- stderr only carries the phase line when the server emits an `error_phase`; partial-failure rc 23 stays silent on stderr.
- The `&&`/`||` chain receives the real rc 124 and routes to the `FAIL` branch.
- `Using work-session ...` is a separate stderr notice from `worksession.ResolveAndAnnounce`, unrelated to phase output.

Stuck-state phases (`agent_timeout`, `agent_disconnected`) require ~10 minutes of server-side stuck classification plus a specific alpamon state, so they are covered by unit tests rather than manual reproduction. `client_timeout` is covered by `TestPollCommandExecution_ClientTimeout` with an injected short timeout.

## Dependencies

- `alpacon-server` #2056 — required, merged.
- `alpamon` #308 — required, merged.