### PR TITLE
fix: HTTP client safety improvements

### DIFF
--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/client"
@@ -27,11 +29,17 @@ const (
 
 func LoginAndSaveCredentials(loginReq *LoginRequest, token string, insecure bool) error {
 	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: insecure, //nolint:gosec
 				MinVersion:         tls.VersionTLS12,
 			},
+			TLSHandshakeTimeout: 10 * time.Second,
 		},
 	}
 

--- a/api/auth0/auth0.go
+++ b/api/auth0/auth0.go
@@ -254,7 +254,7 @@ func requestAccessToken(deviceCode string, envInfo *AuthEnvResponse) (*TokenResp
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: 15 * time.Second,
 		Transport: &http.Transport{
 			DialContext: (&net.Dialer{
 				Timeout:   10 * time.Second,

--- a/api/auth0/auth0.go
+++ b/api/auth0/auth0.go
@@ -252,7 +252,7 @@ func requestAccessToken(deviceCode string, envInfo *AuthEnvResponse) (*TokenResp
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/api/auth0/auth0.go
+++ b/api/auth0/auth0.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -252,7 +253,16 @@ func requestAccessToken(deviceCode string, envInfo *AuthEnvResponse) (*TokenResp
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout: 10 * time.Second,
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -95,6 +95,10 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 		return "", err
 	}
 
+	if len(cmdResponse) == 0 {
+		return "", errors.New("server returned no command response")
+	}
+
 	result, err := PollCommandExecution(ac, cmdResponse[0].ID)
 	if err != nil {
 		return "", err

--- a/api/iam/iam.go
+++ b/api/iam/iam.go
@@ -177,6 +177,10 @@ func DeleteMember(ac *client.AlpaconClient, memberDeleteRequest MemberDeleteRequ
 		return err
 	}
 
+	if len(memberDetails) == 0 {
+		return errors.New("no membership found for the given user and group")
+	}
+
 	_, err = ac.SendDeleteRequest(utils.BuildURL(membershipURL, memberDetails[0].ID, nil))
 	if err != nil {
 		return err

--- a/client/client.go
+++ b/client/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"sort"
@@ -31,6 +32,10 @@ func NewAlpaconAPIClient() (*AlpaconClient, error) {
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
 			TLSClientConfig: &tls.Config{
 				MinVersion:         tls.VersionTLS12,
 				InsecureSkipVerify: validConfig.Insecure,

--- a/client/client.go
+++ b/client/client.go
@@ -35,6 +35,8 @@ func NewAlpaconAPIClient() (*AlpaconClient, error) {
 				MinVersion:         tls.VersionTLS12,
 				InsecureSkipVerify: validConfig.Insecure,
 			},
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
 		},
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -30,6 +30,8 @@ func NewAlpaconAPIClient() (*AlpaconClient, error) {
 		return nil, fmt.Errorf("configuration file not found or invalid: %v. Please run 'alpacon login' to configure your connection", err)
 	}
 
+	// Transport-level timeouts only — Client.Timeout would abort streaming
+	// callers like SendGetRequestForDownload mid-transfer.
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			DialContext: (&net.Dialer{

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -105,10 +106,15 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 		httpClient := &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout:   10 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
 				TLSClientConfig: &tls.Config{
 					MinVersion:         tls.VersionTLS12,
 					InsecureSkipVerify: insecure,
 				},
+				TLSHandshakeTimeout: 10 * time.Second,
 			},
 		}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/alpacax/alpacon-cli/api/auth"
 	"github.com/alpacax/alpacon-cli/api/auth0"
@@ -102,6 +103,7 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 		}
 
 		httpClient := &http.Client{
+			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					MinVersion:         tls.VersionTLS12,

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
+	"time"
 
 	"github.com/alpacax/alpacon-cli/api/auth"
 	"github.com/alpacax/alpacon-cli/api/auth0"
@@ -34,10 +36,17 @@ var logoutCmd = &cobra.Command{
 		}
 
 		httpClient := &http.Client{
+			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout:   10 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
 				TLSClientConfig: &tls.Config{
+					MinVersion:         tls.VersionTLS12,
 					InsecureSkipVerify: validConfig.Insecure,
 				},
+				TLSHandshakeTimeout: 10 * time.Second,
 			},
 		}
 		ac, err := client.NewAlpaconAPIClient()


### PR DESCRIPTION
## Summary

This PR improves CLI behavior around network hangs and unexpected empty server responses.

- Add HTTP timeout protections to login, logout, Auth0 token polling, and the main API client.
- Avoid panics when command creation or IAM membership lookup returns an empty list.
- Preserve streaming download behavior by avoiding `http.Client.Timeout` on the shared API client.

## Changes

### HTTP client timeouts

- `client/client.go`
  - Adds `DialContext`, `TLSHandshakeTimeout`, and `ResponseHeaderTimeout` on the main API client transport.
  - Keeps `http.Client.Timeout` unset so streaming downloads through `SendGetRequestForDownload` are not aborted mid-transfer.

- `cmd/login.go`
  - Adds a 30 second client timeout for login/auth environment requests.
  - Adds dial and TLS handshake timeouts.

- `cmd/logout.go`
  - Adds a 30 second client timeout for logout/auth environment requests.
  - Adds dial and TLS handshake timeouts.
  - Sets TLS minimum version to TLS 1.2.

- `api/auth/auth.go`
  - Adds a 30 second client timeout for username/password and token login verification.
  - Adds dial and TLS handshake timeouts.

- `api/auth0/auth0.go`
  - Adds timeout protections to device-code access token polling requests.

### Empty response guards

- `api/event/event.go`
  - Returns an explicit error when command creation returns an empty command response list instead of indexing `cmdResponse[0]`.

- `api/iam/iam.go`
  - Returns an explicit error when deleting a membership and the lookup returns no matching membership instead of indexing `memberDetails[0]`.

## Verification

```sh
go test ./...
```

Result: pass.

## Review Notes

The branch currently has follow-up items from review:

- The main API client still does not bound `io.ReadAll(resp.Body)` for regular JSON API calls. `sendRequest` and `SendMultipartRequest` should likely use request-context timeouts while keeping streaming download calls unlimited.
- `api/auth0/requestAccessToken` creates a new transport on each polling iteration. Reusing a client/transport or cloning `http.DefaultTransport` would avoid repeated transport allocation and preserve default proxy behavior.
- Regression tests should be added for the empty command response and empty IAM membership response guards.
