### PR TITLE
fix(worksession): surface WorkSession gate errors as first-class CLI signals

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,17 @@ Use: "tunnel [SERVER] -l LOCAL -r REMOTE [flags]"
 - List commands should project API responses into `*Attributes` structs for `utils.PrintTable()`
 - Comments must be written in English
 
+## Exit codes
+
+`alpacon` uses a stable exit code convention:
+
+- `0` success
+- `1` general error
+- `2` usage error
+- `3` WorkSession gate denied (`utils.ExitCodeWorkSessionDenied`)
+
+Keep these stable—scripts, CI, and AI agents branch on them. See README "Exit codes".
+
 ## Writing conventions
 
 - Use **sentence case** for all headings and descriptions (capitalize only the first word and proper nouns)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,4 +183,5 @@ _ = json.NewEncoder(w).Encode(resp)
 - **Config file**: `~/.alpacon/config.json` (dir `0700`, file `0600`)
 - **Alias**: `alpacon` can also be invoked as `ac`
 - **File transfer**: The `cp` command lives in `cmd/ftp/` (package name `ftp`)
+- **Exit codes**: `0` success, `1` general error, `2` usage error, `3` WorkSession gate denied (`ExitCodeWorkSessionDenied` in `utils/error.go`). Keep these stable—scripts, CI, and AI agents branch on them. See README "Exit codes".
 - **IAM**: `user` and `group` commands both live in `cmd/iam/`

--- a/README.md
+++ b/README.md
@@ -598,6 +598,17 @@ The test script will automatically:
 
 **Note:** Make sure you have access to the specified server and the necessary permissions for the test operations before running the script.
 
+## Exit codes
+
+`alpacon` follows a stable exit code convention so that scripts, CI pipelines, and AI agents can branch on outcomes:
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Success |
+| `1`  | General error (network failure, server error, etc.) |
+| `2`  | Usage error (invalid flags or arguments) |
+| `3`  | WorkSession gate denied—the active session does not authorize this action |
+
 ## Contributing
 
 We welcome contributions! Here's how to get started:

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -2,8 +2,8 @@ package exec
 
 import (
 	"github.com/alpacax/alpacon-cli/client"
-	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -72,8 +72,7 @@ Flags:
 
 		workSessionID := worksession.ResolveAndAnnounce(parsed.WorkSessionID)
 
-		cfg, _ := config.LoadConfig()
-		authMethod := config.GetAuthMethod(cfg)
+		authMethod := config.ResolveAuthMethod()
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -71,6 +71,9 @@ Flags:
 		}
 
 		if parsed.OutputFormat != "" {
+			if parsed.OutputFormat != utils.OutputFormatTable && parsed.OutputFormat != utils.OutputFormatJSON {
+				utils.CliErrorWithExit("invalid --output value %q: must be 'table' or 'json'", parsed.OutputFormat)
+			}
 			utils.OutputFormat = parsed.OutputFormat
 		}
 

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
@@ -71,6 +72,9 @@ Flags:
 
 		workSessionID := worksession.ResolveAndAnnounce(parsed.WorkSessionID)
 
+		cfg, _ := config.LoadConfig()
+		authMethod := config.GetAuthMethod(cfg)
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
@@ -79,6 +83,7 @@ Flags:
 
 		env := make(map[string]string)
 		result, err := RunCommandWithRetry(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
+		utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
 		HandleCommandResult(result, err)
 	},
 }

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -30,7 +30,10 @@ Flags:
   -g, --groupname [GROUP_NAME]  Specify the group name for command execution.
   --work-session [UUID]         Attach this command to a work-session.
                                 Overrides the workspace's active session set via
-                                'alpacon work-session use'.`,
+                                'alpacon work-session use'.
+
+Exit code 3 indicates a WorkSession gate denial; run with --output json to
+parse a machine-readable diagnostic on stderr.`,
 	Example: `  # Simple command execution
   alpacon exec prod-docker docker ps
   alpacon exec root@prod-docker docker ps

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -70,6 +70,10 @@ Flags:
 			return
 		}
 
+		if parsed.OutputFormat != "" {
+			utils.OutputFormat = parsed.OutputFormat
+		}
+
 		workSessionID := worksession.ResolveAndAnnounce(parsed.WorkSessionID)
 
 		authMethod := config.ResolveAuthMethod()

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -91,6 +91,9 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 			if errMsg != "" {
 				return RemoteExecArgs{Err: errMsg}
 			}
+			if outputFormat == "" {
+				return RemoteExecArgs{Err: "--output requires a value (table|json)"}
+			}
 		case strings.HasPrefix(arg, "-"):
 			return RemoteExecArgs{Err: "unknown flag: " + arg}
 		default:

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -11,6 +11,7 @@ type RemoteExecArgs struct {
 	Username      string
 	Groupname     string
 	WorkSessionID string
+	OutputFormat  string
 	Server        string
 	Command       string
 	ShowHelp      bool
@@ -32,8 +33,8 @@ type RemoteExecArgs struct {
 // Layout: [flags] [USER@]SERVER [--] COMMAND...
 func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 	var (
-		username, groupname, workSessionID, server string
-		commandParts                               []string
+		username, groupname, workSessionID, outputFormat, server string
+		commandParts                                              []string
 	)
 
 	for i := 0; i < len(args); i++ {
@@ -84,6 +85,12 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 			if errMsg != "" {
 				return RemoteExecArgs{Err: errMsg}
 			}
+		case arg == "--output" || strings.HasPrefix(arg, "--output="):
+			var errMsg string
+			outputFormat, i, errMsg = extractFlagValue(args, i, "--output")
+			if errMsg != "" {
+				return RemoteExecArgs{Err: errMsg}
+			}
 		case strings.HasPrefix(arg, "-"):
 			return RemoteExecArgs{Err: "unknown flag: " + arg}
 		default:
@@ -104,6 +111,7 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 		Username:      username,
 		Groupname:     groupname,
 		WorkSessionID: workSessionID,
+		OutputFormat:  outputFormat,
 		Server:        server,
 		Command:       ShellJoin(commandParts),
 	}

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -560,6 +560,44 @@ func TestParseRemoteExecArgs_ShellQuoting(t *testing.T) {
 	}
 }
 
+func TestParseRemoteExecArgs_OutputFlag(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectedOutput string
+		expectedServer string
+		expectedCmd    string
+	}{
+		{
+			name:           "--output json (space form)",
+			args:           []string{"--output", "json", "my-server", "ls"},
+			expectedOutput: "json",
+			expectedServer: "my-server",
+			expectedCmd:    "ls",
+		},
+		{
+			name:           "--output=table (equals form)",
+			args:           []string{"--output=table", "my-server", "ls"},
+			expectedOutput: "table",
+			expectedServer: "my-server",
+			expectedCmd:    "ls",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseRemoteExecArgs(tt.args)
+			assert.Equal(t, tt.expectedOutput, result.OutputFormat)
+			assert.Equal(t, tt.expectedServer, result.Server)
+			assert.Equal(t, tt.expectedCmd, result.Command)
+		})
+	}
+}
+
+func TestParseRemoteExecArgs_OutputFlagMissingValue(t *testing.T) {
+	result := ParseRemoteExecArgs([]string{"--output"})
+	assert.NotEmpty(t, result.Err)
+}
+
 func TestParseRemoteExecArgs_Errors(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -598,6 +598,11 @@ func TestParseRemoteExecArgs_OutputFlagMissingValue(t *testing.T) {
 	assert.NotEmpty(t, result.Err)
 }
 
+func TestParseRemoteExecArgs_OutputFlagEmptyValue(t *testing.T) {
+	result := ParseRemoteExecArgs([]string{"--output="})
+	assert.NotEmpty(t, result.Err)
+}
+
 func TestParseRemoteExecArgs_Errors(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -99,8 +99,7 @@ overrides the workspace's active work-session set via 'alpacon work-session use'
 		// clean on early usage errors.
 		workSessionID := worksession.ResolveAndAnnounce(flagWorkSession)
 
-		cfg, _ := config.LoadConfig()
-		authMethod := config.GetAuthMethod(cfg)
+		authMethod := config.ResolveAuthMethod()
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -23,7 +23,10 @@ Supports SSH-like user@host:path syntax for specifying the username inline with 
 Remote paths use the format [USER@]SERVER:/path.
 
 Use --work-session to attach this transfer to a specific work-session. This
-overrides the workspace's active work-session set via 'alpacon work-session use'.`,
+overrides the workspace's active work-session set via 'alpacon work-session use'.
+
+Exit code 3 indicates a WorkSession gate denial; run with --output json to
+parse a machine-readable diagnostic on stderr.`,
 	Example: `  # Upload files to a remote server
   alpacon cp /local/file1.txt /local/file2.txt my-server:/remote/path/
 

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alpacax/alpacon-cli/api/mfa"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -98,6 +99,9 @@ overrides the workspace's active work-session set via 'alpacon work-session use'
 		// clean on early usage errors.
 		workSessionID := worksession.ResolveAndAnnounce(flagWorkSession)
 
+		cfg, _ := config.LoadConfig()
+		authMethod := config.GetAuthMethod(cfg)
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s.\n\n"+
@@ -130,6 +134,7 @@ overrides the workspace's active work-session set via 'alpacon work-session use'
 				})
 
 				if err != nil {
+					utils.HandleWorkSessionError(err, "webftp", serverName, authMethod, workSessionID)
 					utils.CliErrorWithExit("Failed to upload to '%s': %s", dest, err)
 					return
 				}
@@ -158,6 +163,7 @@ overrides the workspace's active work-session set via 'alpacon work-session use'
 				})
 
 				if err != nil {
+					utils.HandleWorkSessionError(err, "webftp", serverName, authMethod, workSessionID)
 					wrappedSrc := fmt.Sprintf("[%s]", strings.Join(sources, ", "))
 					utils.CliErrorWithExit("Failed to download from '%s': %s", wrappedSrc, err)
 					return

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -228,7 +228,7 @@ Note: All flags must be placed before the server name.
 			}
 			command := execCmd.ShellJoin(commandArgs)
 			result, err := execCmd.RunCommandWithRetry(alpaconClient, serverName, command, username, groupname, env, workSessionID)
-			utils.HandleWorkSessionError(err, "websh", serverName, authMethod, workSessionID)
+			utils.HandleWorkSessionError(err, "command", serverName, authMethod, workSessionID)
 			execCmd.HandleCommandResult(result, err)
 		} else {
 			session, err := websh.CreateWebshSession(alpaconClient, serverName, username, groupname, share, readOnly, workSessionID)

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -31,6 +31,7 @@ type WebshArgs struct {
 	Share         bool
 	ReadOnly      bool
 	WorkSessionID string
+	OutputFormat  string
 	Env           map[string]string
 }
 
@@ -86,6 +87,10 @@ func ParseWebshArgs(args []string) (WebshArgs, error) {
 				return res, fmt.Errorf("--work-session requires a value")
 			}
 			res.WorkSessionID = ws
+			i = newI
+		case args[i] == "--output" || strings.HasPrefix(args[i], "--output="):
+			val, newI := extractValue(args, i)
+			res.OutputFormat = val
 			i = newI
 		default:
 			if res.ServerName == "" {
@@ -193,6 +198,10 @@ Note: All flags must be placed before the server name.
 				username = sshTarget.User
 			}
 			serverName = sshTarget.Host
+		}
+
+		if parsed.OutputFormat != "" {
+			utils.OutputFormat = parsed.OutputFormat
 		}
 
 		workSessionID := worksession.ResolveAndAnnounce(parsed.WorkSessionID)

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -197,8 +197,7 @@ Note: All flags must be placed before the server name.
 
 		workSessionID := worksession.ResolveAndAnnounce(parsed.WorkSessionID)
 
-		cfg, _ := config.LoadConfig()
-		authMethod := config.GetAuthMethod(cfg)
+		authMethod := config.ResolveAuthMethod()
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -117,7 +117,10 @@ to ensure it is interpreted correctly on the remote server.
 
 Shell metacharacters (;, |, &, $) pass through unquoted to the remote shell.
 To send a literal metacharacter, wrap the argument in quotes:
-  alpacon websh server 'echo hello;world'`,
+  alpacon websh server 'echo hello;world'
+
+Exit code 3 indicates a WorkSession gate denial; run with --output json to
+parse a machine-readable diagnostic on stderr.`,
 	Example: `  # Open a websh terminal
   alpacon websh my-server
 

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -90,6 +90,9 @@ func ParseWebshArgs(args []string) (WebshArgs, error) {
 			i = newI
 		case args[i] == "--output" || strings.HasPrefix(args[i], "--output="):
 			val, newI := extractValue(args, i)
+			if val == "" {
+				return res, fmt.Errorf("--output requires a value (table|json)")
+			}
 			res.OutputFormat = val
 			i = newI
 		default:
@@ -201,6 +204,9 @@ Note: All flags must be placed before the server name.
 		}
 
 		if parsed.OutputFormat != "" {
+			if parsed.OutputFormat != utils.OutputFormatTable && parsed.OutputFormat != utils.OutputFormatJSON {
+				utils.CliErrorWithExit("invalid --output value %q: must be 'table' or 'json'", parsed.OutputFormat)
+			}
 			utils.OutputFormat = parsed.OutputFormat
 		}
 

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alpacax/alpacon-cli/client"
 	execCmd "github.com/alpacax/alpacon-cli/cmd/exec"
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -196,6 +197,9 @@ Note: All flags must be placed before the server name.
 
 		workSessionID := worksession.ResolveAndAnnounce(parsed.WorkSessionID)
 
+		cfg, _ := config.LoadConfig()
+		authMethod := config.GetAuthMethod(cfg)
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
@@ -210,6 +214,7 @@ Note: All flags must be placed before the server name.
 			}
 			command := execCmd.ShellJoin(commandArgs)
 			result, err := execCmd.RunCommandWithRetry(alpaconClient, serverName, command, username, groupname, env, workSessionID)
+			utils.HandleWorkSessionError(err, "websh", serverName, authMethod, workSessionID)
 			execCmd.HandleCommandResult(result, err)
 		} else {
 			session, err := websh.CreateWebshSession(alpaconClient, serverName, username, groupname, share, readOnly, workSessionID)
@@ -234,6 +239,7 @@ Note: All flags must be placed before the server name.
 				})
 
 				if err != nil {
+					utils.HandleWorkSessionError(err, "websh", serverName, authMethod, workSessionID)
 					utils.CliErrorWithExit("Failed to create websh session for '%s' server: %s.", serverName, err)
 				}
 			}

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -46,7 +46,7 @@ commands, especially for AI agents and operators managing multiple workspaces.`,
 		output := whoamiOutput{
 			WorkspaceName: cfg.WorkspaceName,
 			WorkspaceURL:  cfg.WorkspaceURL,
-			AuthMethod:    getAuthMethod(cfg),
+			AuthMethod:    config.GetAuthMethod(cfg),
 			ExpiresAt:     getExpiresAt(cfg),
 		}
 
@@ -85,16 +85,6 @@ commands, especially for AI agents and operators managing multiple workspaces.`,
 		warnIfExpiringSoon(cfg)
 		printWhoami(output)
 	},
-}
-
-func getAuthMethod(cfg config.Config) string {
-	if cfg.AccessToken != "" {
-		return "Browser login"
-	}
-	if cfg.Token != "" {
-		return "API token"
-	}
-	return "unknown"
 }
 
 func getExpiresAt(cfg config.Config) string {

--- a/cmd/whoami_test.go
+++ b/cmd/whoami_test.go
@@ -25,7 +25,7 @@ func TestGetAuthMethod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := config.Config{Token: tt.token, AccessToken: tt.access}
-			assert.Equal(t, tt.expected, getAuthMethod(cfg))
+			assert.Equal(t, tt.expected, config.GetAuthMethod(cfg))
 		})
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -191,6 +191,17 @@ func GetActiveWorkSession() (string, error) {
 	return cfg.ActiveWorkSessions[cfg.WorkspaceName], nil
 }
 
+// GetAuthMethod returns a human-readable authentication method string for cfg.
+func GetAuthMethod(cfg Config) string {
+	if cfg.AccessToken != "" {
+		return "Browser login"
+	}
+	if cfg.Token != "" {
+		return "API token"
+	}
+	return "unknown"
+}
+
 // GetSmuxConfig returns a ready-to-use smux configuration.
 func GetSmuxConfig() *smux.Config {
 	config := smux.DefaultConfig()

--- a/config/config.go
+++ b/config/config.go
@@ -202,6 +202,15 @@ func GetAuthMethod(cfg Config) string {
 	return "unknown"
 }
 
+// ResolveAuthMethod loads config and returns the auth method string.
+func ResolveAuthMethod() string {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return "unknown"
+	}
+	return GetAuthMethod(cfg)
+}
+
 // GetSmuxConfig returns a ready-to-use smux configuration.
 func GetSmuxConfig() *smux.Config {
 	config := smux.DefaultConfig()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -230,3 +230,38 @@ func TestActiveWorkSession_PerWorkspaceIsolation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "uuid-A", got, "switching back should restore original active session")
 }
+
+func TestGetAuthMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      Config
+		expected string
+	}{
+		{
+			name:     "access token present → Browser login",
+			cfg:      Config{AccessToken: "eyJ..."},
+			expected: "Browser login",
+		},
+		{
+			name:     "token only → API token",
+			cfg:      Config{Token: "abc123"},
+			expected: "API token",
+		},
+		{
+			name:     "both tokens → AccessToken wins",
+			cfg:      Config{AccessToken: "eyJ...", Token: "abc123"},
+			expected: "Browser login",
+		},
+		{
+			name:     "no tokens → unknown",
+			cfg:      Config{},
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetAuthMethod(tt.cfg))
+		})
+	}
+}

--- a/utils/error.go
+++ b/utils/error.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 )
 
@@ -28,30 +29,31 @@ type ErrorResponse struct {
 }
 
 func ParseErrorResponse(err error) (code, source string) {
-	if err == nil {
-		return "", ""
-	}
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		errStr := e.Error()
 
-	errStr := err.Error()
+		// Try JSON format: {"code": "...", "source": "..."}
+		start := strings.Index(errStr, "{")
+		if start != -1 {
+			var errorResp ErrorResponse
+			if jsonErr := json.Unmarshal([]byte(errStr[start:]), &errorResp); jsonErr == nil && (errorResp.Code != "" || errorResp.Source != "") {
+				return errorResp.Code, errorResp.Source
+			}
+		}
 
-	// Try JSON format: {"code": "...", "source": "..."}
-	start := strings.Index(errStr, "{")
-	if start != -1 {
-		var errorResp ErrorResponse
-		if jsonErr := json.Unmarshal([]byte(errStr[start:]), &errorResp); jsonErr == nil && (errorResp.Code != "" || errorResp.Source != "") {
-			return errorResp.Code, errorResp.Source
+		// Try "code: X; source: Y" format (produced by parseAPIError in the HTTP client)
+		for _, part := range strings.Split(errStr, "; ") {
+			part = strings.TrimSpace(part)
+			if strings.HasPrefix(part, "code: ") {
+				code = strings.TrimPrefix(part, "code: ")
+			} else if strings.HasPrefix(part, "source: ") {
+				source = strings.TrimPrefix(part, "source: ")
+			}
+		}
+		if code != "" {
+			return code, source
 		}
 	}
 
-	// Try "code: X; source: Y" format (produced by parseAPIError in the HTTP client)
-	for _, part := range strings.Split(errStr, "; ") {
-		part = strings.TrimSpace(part)
-		if strings.HasPrefix(part, "code: ") {
-			code = strings.TrimPrefix(part, "code: ")
-		} else if strings.HasPrefix(part, "source: ") {
-			source = strings.TrimPrefix(part, "source: ")
-		}
-	}
-
-	return code, source
+	return "", ""
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -28,7 +28,7 @@ type ErrorResponse struct {
 	Source string `json:"source"`
 }
 
-func ParseErrorResponse(err error) (code, source string) {
+func ParseErrorResponse(err error) (string, string) {
 	for e := err; e != nil; e = errors.Unwrap(e) {
 		errStr := e.Error()
 
@@ -42,16 +42,17 @@ func ParseErrorResponse(err error) (code, source string) {
 		}
 
 		// Try "code: X; source: Y" format (produced by parseAPIError in the HTTP client)
+		var iterCode, iterSource string
 		for _, part := range strings.Split(errStr, "; ") {
 			part = strings.TrimSpace(part)
 			if strings.HasPrefix(part, "code: ") {
-				code = strings.TrimPrefix(part, "code: ")
+				iterCode = strings.TrimPrefix(part, "code: ")
 			} else if strings.HasPrefix(part, "source: ") {
-				source = strings.TrimPrefix(part, "source: ")
+				iterSource = strings.TrimPrefix(part, "source: ")
 			}
 		}
-		if code != "" {
-			return code, source
+		if iterCode != "" {
+			return iterCode, iterSource
 		}
 	}
 

--- a/utils/error.go
+++ b/utils/error.go
@@ -8,6 +8,18 @@ import (
 const (
 	AuthMFARequired  = "auth_mfa_required"
 	UsernameRequired = "user_username_required"
+
+	// WorkSession gate codes (returned by alpacon-server work_sessions/services.py)
+	WorkSessionRequired         = "work_session_required"
+	WorkSessionNotUsable        = "work_session_not_usable"
+	WorkSessionNotActive        = "work_session_not_active"
+	WorkSessionExpired          = "work_session_expired"
+	WorkSessionScopeNotAllowed  = "work_session_scope_not_allowed"
+	WorkSessionServerNotAllowed = "work_session_server_not_allowed"
+	WorkSessionAssigneeMismatch = "work_session_assignee_mismatch"
+
+	// ExitCodeWorkSessionDenied is the process exit code for WorkSession gate refusals.
+	ExitCodeWorkSessionDenied = 3
 )
 
 type ErrorResponse struct {

--- a/utils/error_test.go
+++ b/utils/error_test.go
@@ -96,3 +96,14 @@ func TestParseErrorResponse_NoMatch(t *testing.T) {
 	assert.Equal(t, "", code)
 	assert.Equal(t, "", source)
 }
+
+func TestWorkSessionConstants(t *testing.T) {
+	assert.Equal(t, "work_session_required", WorkSessionRequired)
+	assert.Equal(t, "work_session_not_usable", WorkSessionNotUsable)
+	assert.Equal(t, "work_session_not_active", WorkSessionNotActive)
+	assert.Equal(t, "work_session_expired", WorkSessionExpired)
+	assert.Equal(t, "work_session_scope_not_allowed", WorkSessionScopeNotAllowed)
+	assert.Equal(t, "work_session_server_not_allowed", WorkSessionServerNotAllowed)
+	assert.Equal(t, "work_session_assignee_mismatch", WorkSessionAssigneeMismatch)
+	assert.Equal(t, 3, ExitCodeWorkSessionDenied)
+}

--- a/utils/error_test.go
+++ b/utils/error_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -95,6 +96,22 @@ func TestParseErrorResponse_NoMatch(t *testing.T) {
 	code, source := ParseErrorResponse(errors.New("connection refused"))
 	assert.Equal(t, "", code)
 	assert.Equal(t, "", source)
+}
+
+func TestParseErrorResponse_WrappedJSONFormat(t *testing.T) {
+	inner := errors.New(`{"code": "work_session_required", "source": "command"}`)
+	wrapped := fmt.Errorf("failed to execute command on 'srv' server: %w", inner)
+	code, source := ParseErrorResponse(wrapped)
+	assert.Equal(t, "work_session_required", code)
+	assert.Equal(t, "command", source)
+}
+
+func TestParseErrorResponse_WrappedTextFormat(t *testing.T) {
+	inner := errors.New("code: work_session_expired; source: server")
+	wrapped := fmt.Errorf("request failed: %w", inner)
+	code, source := ParseErrorResponse(wrapped)
+	assert.Equal(t, "work_session_expired", code)
+	assert.Equal(t, "server", source)
 }
 
 func TestWorkSessionConstants(t *testing.T) {

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -10,6 +10,7 @@ import (
 
 type workSessionErrorJSON struct {
 	OK          bool                `json:"ok"`
+	ExitCode    int                 `json:"exit_code"`
 	ErrorCode   string              `json:"error_code"`
 	Message     string              `json:"message"`
 	Reason      string              `json:"reason"`
@@ -89,6 +90,7 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 	}
 	envelope := workSessionErrorJSON{
 		OK:        false,
+		ExitCode:  ExitCodeWorkSessionDenied,
 		ErrorCode: code,
 		Message:   fmt.Sprintf("%s requires an active WorkSession on this authentication.", operation),
 		Reason:    workSessionReasonMap[code],

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -51,12 +51,12 @@ func HandleWorkSessionError(err error, operation, serverName, authMethod, active
 	if OutputFormat == OutputFormatJSON {
 		fmt.Fprintln(os.Stderr, buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS))
 	} else {
-		fmt.Fprintln(os.Stderr, buildWorkSessionDiagnostic(code, operation, serverName, authMethod))
+		fmt.Fprintln(os.Stderr, buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeWS))
 	}
 	os.Exit(ExitCodeWorkSessionDenied)
 }
 
-func buildWorkSessionDiagnostic(code, operation, serverName, authMethod string) string {
+func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeWS string) string {
 	reason := workSessionReasonMap[code]
 	authDisplay := authMethod
 	if authMethod == "Browser login" {
@@ -74,7 +74,7 @@ func buildWorkSessionDiagnostic(code, operation, serverName, authMethod string) 
 	}
 	fmt.Fprintln(&sb)
 	fmt.Fprintln(&sb, "Next:")
-	for _, action := range workSessionNextActions(code, operation, serverName) {
+	for _, action := range workSessionNextActions(code, operation, serverName, activeWS) {
 		fmt.Fprintf(&sb, "  %s\n", action)
 	}
 	fmt.Fprintln(&sb)
@@ -98,7 +98,7 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 			TargetServers:      targetServerList(serverName),
 			CurrentWorksession: ws,
 		},
-		NextActions: workSessionNextActions(code, operation, serverName),
+		NextActions: workSessionNextActions(code, operation, serverName, activeWS),
 	}
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
@@ -117,7 +117,7 @@ func targetServerList(serverName string) []string {
 	return []string{serverName}
 }
 
-func workSessionNextActions(code, operation, serverName string) []string {
+func workSessionNextActions(code, operation, serverName, activeWS string) []string {
 	createCmd := fmt.Sprintf(
 		`alpacon work-session create --scope %s --server %s --purpose "<intent>"`,
 		operation, serverName,
@@ -132,7 +132,11 @@ func workSessionNextActions(code, operation, serverName string) []string {
 	case WorkSessionNotActive:
 		return []string{"alpacon work-session current"}
 	case WorkSessionExpired:
-		return []string{"alpacon work-session extend <ID>", createCmd}
+		extendCmd := "alpacon work-session extend <ID>"
+		if activeWS != "" {
+			extendCmd = fmt.Sprintf("alpacon work-session extend %s", activeWS)
+		}
+		return []string{extendCmd, createCmd}
 	case WorkSessionAssigneeMismatch:
 		return []string{"alpacon work-session use <ID>"}
 	case WorkSessionNotUsable:

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -1,9 +1,26 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
+
+type workSessionErrorJSON struct {
+	OK          bool                `json:"ok"`
+	Command     string              `json:"command"`
+	ErrorCode   string              `json:"error_code"`
+	Message     string              `json:"message"`
+	Context     workSessionErrorCtx `json:"context"`
+	NextActions []string            `json:"next_actions"`
+}
+
+type workSessionErrorCtx struct {
+	AuthMethod         string   `json:"auth_method"`
+	RequiredScope      string   `json:"required_scope"`
+	TargetServers      []string `json:"target_servers"`
+	CurrentWorksession *string  `json:"current_worksession"`
+}
 
 var workSessionReasonMap = map[string]string{
 	WorkSessionRequired:         "no WorkSession selected for this shell",
@@ -50,7 +67,28 @@ func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeW
 }
 
 func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS string) string {
-	return ""
+	var ws *string
+	if activeWS != "" {
+		ws = &activeWS
+	}
+	envelope := workSessionErrorJSON{
+		OK:        false,
+		Command:   operation,
+		ErrorCode: code,
+		Message:   fmt.Sprintf("%s requires an active WorkSession on this authentication.", operation),
+		Context: workSessionErrorCtx{
+			AuthMethod:         authMethod,
+			RequiredScope:      operation,
+			TargetServers:      []string{serverName},
+			CurrentWorksession: ws,
+		},
+		NextActions: workSessionNextActions(code, operation, serverName),
+	}
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		return `{"ok":false,"error_code":"` + code + `"}`
+	}
+	return string(data)
 }
 
 func workSessionNextActions(code, operation, serverName string) []string {

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -38,9 +38,7 @@ func isWorkSessionCode(code string) bool {
 	return ok
 }
 
-// HandleWorkSessionError checks whether err carries a WorkSession gate code.
-// If it does, it prints a diagnostic block (or JSON envelope if --output json) to
-// stderr and exits with ExitCodeWorkSessionDenied. For all other errors it is a no-op.
+// HandleWorkSessionError prints a WorkSession gate diagnostic and exits(3); no-op for other errors.
 func HandleWorkSessionError(err error, operation, serverName, authMethod, activeWS string) {
 	if err == nil {
 		return
@@ -52,12 +50,12 @@ func HandleWorkSessionError(err error, operation, serverName, authMethod, active
 	if OutputFormat == OutputFormatJSON {
 		fmt.Fprintln(os.Stderr, buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS))
 	} else {
-		fmt.Fprintln(os.Stderr, buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeWS))
+		fmt.Fprintln(os.Stderr, buildWorkSessionDiagnostic(code, operation, serverName, authMethod))
 	}
 	os.Exit(ExitCodeWorkSessionDenied)
 }
 
-func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeWS string) string {
+func buildWorkSessionDiagnostic(code, operation, serverName, authMethod string) string {
 	reason := workSessionReasonMap[code]
 	authDisplay := authMethod
 	if authMethod == "Browser login" {
@@ -65,7 +63,7 @@ func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeW
 	}
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Error: %s requires an active WorkSession on this authentication.\n", operation)
+	fmt.Fprintf(&sb, "%s: %s requires an active WorkSession on this authentication.\n", Red("Error"), operation)
 	fmt.Fprintln(&sb)
 	fmt.Fprintf(&sb, "  %-14s: %s\n", "auth", authDisplay)
 	fmt.Fprintf(&sb, "  %-14s: %s\n", "reason", reason)

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -78,7 +78,7 @@ func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeW
 		fmt.Fprintf(&sb, "  %s\n", action)
 	}
 	fmt.Fprintln(&sb)
-	fmt.Fprint(&sb, "Note: ServiceToken or personal API token (source != login) skip this requirement.")
+	fmt.Fprint(&sb, "Note: Tokens issued by Alpacon (service or personal API token) bypass this check.")
 	return sb.String()
 }
 

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -1,5 +1,10 @@
 package utils
 
+import (
+	"fmt"
+	"strings"
+)
+
 var workSessionReasonMap = map[string]string{
 	WorkSessionRequired:         "no WorkSession selected for this shell",
 	WorkSessionNotUsable:        "session is no longer usable",
@@ -19,7 +24,29 @@ func isWorkSessionCode(code string) bool {
 func HandleWorkSessionError(err error, operation, serverName, authMethod, activeWS string) {}
 
 func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeWS string) string {
-	return ""
+	reason := workSessionReasonMap[code]
+	authDisplay := authMethod
+	if authMethod == "Browser login" {
+		authDisplay = "Browser login (interactive)"
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Error: %s requires an active WorkSession on this authentication.\n", operation)
+	fmt.Fprintln(&sb)
+	fmt.Fprintf(&sb, "  %-14s: %s\n", "auth", authDisplay)
+	fmt.Fprintf(&sb, "  %-14s: %s\n", "reason", reason)
+	fmt.Fprintf(&sb, "  %-14s: %s\n", "required scope", operation)
+	if serverName != "" {
+		fmt.Fprintf(&sb, "  %-14s: %s\n", "target server", serverName)
+	}
+	fmt.Fprintln(&sb)
+	fmt.Fprintln(&sb, "Next:")
+	for _, action := range workSessionNextActions(code, operation, serverName) {
+		fmt.Fprintf(&sb, "  %s\n", action)
+	}
+	fmt.Fprintln(&sb)
+	fmt.Fprint(&sb, "Note: ServiceToken or personal API token (source != login) skip this requirement.")
+	return sb.String()
 }
 
 func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS string) string {
@@ -27,5 +54,24 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 }
 
 func workSessionNextActions(code, operation, serverName string) []string {
-	return nil
+	createCmd := fmt.Sprintf(
+		`alpacon worksession create --scope %s --server %s --description "<intent>"`,
+		operation, serverName,
+	)
+	switch code {
+	case WorkSessionRequired:
+		return []string{
+			"alpacon worksession list --status active",
+			"alpacon worksession use <ID>",
+			createCmd,
+		}
+	case WorkSessionNotActive:
+		return []string{"alpacon worksession current"}
+	case WorkSessionExpired:
+		return []string{"alpacon worksession extend <ID>", createCmd}
+	case WorkSessionAssigneeMismatch:
+		return []string{"alpacon worksession use <ID>"}
+	default: // scope_not_allowed, server_not_allowed, not_usable
+		return []string{createCmd}
+	}
 }

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -99,11 +100,14 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 		},
 		NextActions: workSessionNextActions(code, operation, serverName),
 	}
-	data, err := json.MarshalIndent(envelope, "", "  ")
-	if err != nil {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(envelope); err != nil {
 		return `{"ok":false,"error_code":"` + code + `"}`
 	}
-	return string(data)
+	return strings.TrimRight(buf.String(), "\n")
 }
 
 func targetServerList(serverName string) []string {

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -37,8 +38,24 @@ func isWorkSessionCode(code string) bool {
 	return ok
 }
 
-// HandleWorkSessionError — placeholder until Task 6
-func HandleWorkSessionError(err error, operation, serverName, authMethod, activeWS string) {}
+// HandleWorkSessionError checks whether err carries a WorkSession gate code.
+// If it does, it prints a diagnostic block (or JSON envelope if --output json) to
+// stderr and exits with ExitCodeWorkSessionDenied. For all other errors it is a no-op.
+func HandleWorkSessionError(err error, operation, serverName, authMethod, activeWS string) {
+	if err == nil {
+		return
+	}
+	code, _ := ParseErrorResponse(err)
+	if !isWorkSessionCode(code) {
+		return
+	}
+	if OutputFormat == OutputFormatJSON {
+		fmt.Fprintln(os.Stderr, buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS))
+	} else {
+		fmt.Fprintln(os.Stderr, buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeWS))
+	}
+	os.Exit(ExitCodeWorkSessionDenied)
+}
 
 func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeWS string) string {
 	reason := workSessionReasonMap[code]

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -94,7 +94,7 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 		Context: workSessionErrorCtx{
 			AuthMethod:         authMethod,
 			RequiredScope:      operation,
-			TargetServers:      []string{serverName},
+			TargetServers:      targetServerList(serverName),
 			CurrentWorksession: ws,
 		},
 		NextActions: workSessionNextActions(code, operation, serverName),
@@ -106,9 +106,16 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 	return string(data)
 }
 
+func targetServerList(serverName string) []string {
+	if serverName == "" {
+		return nil
+	}
+	return []string{serverName}
+}
+
 func workSessionNextActions(code, operation, serverName string) []string {
 	createCmd := fmt.Sprintf(
-		`alpacon worksession create --scope %s --server %s --description "<intent>"`,
+		`alpacon worksession create --scope %s --server %s --purpose "<intent>"`,
 		operation, serverName,
 	)
 	switch code {
@@ -124,7 +131,12 @@ func workSessionNextActions(code, operation, serverName string) []string {
 		return []string{"alpacon worksession extend <ID>", createCmd}
 	case WorkSessionAssigneeMismatch:
 		return []string{"alpacon worksession use <ID>"}
-	default: // scope_not_allowed, server_not_allowed, not_usable
+	case WorkSessionNotUsable:
+		return []string{
+			"alpacon worksession list",
+			createCmd,
+		}
+	default: // scope_not_allowed, server_not_allowed
 		return []string{createCmd}
 	}
 }

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -12,6 +12,7 @@ type workSessionErrorJSON struct {
 	OK          bool                `json:"ok"`
 	ErrorCode   string              `json:"error_code"`
 	Message     string              `json:"message"`
+	Reason      string              `json:"reason"`
 	Context     workSessionErrorCtx `json:"context"`
 	NextActions []string            `json:"next_actions"`
 }
@@ -90,6 +91,7 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 		OK:        false,
 		ErrorCode: code,
 		Message:   fmt.Sprintf("%s requires an active WorkSession on this authentication.", operation),
+		Reason:    workSessionReasonMap[code],
 		Context: workSessionErrorCtx{
 			AuthMethod:         authMethod,
 			RequiredScope:      operation,

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -1,0 +1,31 @@
+package utils
+
+var workSessionReasonMap = map[string]string{
+	WorkSessionRequired:         "no WorkSession selected for this shell",
+	WorkSessionNotUsable:        "session is no longer usable",
+	WorkSessionNotActive:        "selected session is not yet active",
+	WorkSessionExpired:          "selected session has expired",
+	WorkSessionScopeNotAllowed:  "session does not include this scope",
+	WorkSessionServerNotAllowed: "target server is not in this session",
+	WorkSessionAssigneeMismatch: "this session is assigned to another principal",
+}
+
+func isWorkSessionCode(code string) bool {
+	_, ok := workSessionReasonMap[code]
+	return ok
+}
+
+// HandleWorkSessionError — placeholder until Task 6
+func HandleWorkSessionError(err error, operation, serverName, authMethod, activeWS string) {}
+
+func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeWS string) string {
+	return ""
+}
+
+func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS string) string {
+	return ""
+}
+
+func workSessionNextActions(code, operation, serverName string) []string {
+	return nil
+}

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -119,25 +119,25 @@ func targetServerList(serverName string) []string {
 
 func workSessionNextActions(code, operation, serverName string) []string {
 	createCmd := fmt.Sprintf(
-		`alpacon worksession create --scope %s --server %s --purpose "<intent>"`,
+		`alpacon work-session create --scope %s --server %s --purpose "<intent>"`,
 		operation, serverName,
 	)
 	switch code {
 	case WorkSessionRequired:
 		return []string{
-			"alpacon worksession list --status active",
-			"alpacon worksession use <ID>",
+			"alpacon work-session ls --status active",
+			"alpacon work-session use <ID>",
 			createCmd,
 		}
 	case WorkSessionNotActive:
-		return []string{"alpacon worksession current"}
+		return []string{"alpacon work-session current"}
 	case WorkSessionExpired:
-		return []string{"alpacon worksession extend <ID>", createCmd}
+		return []string{"alpacon work-session extend <ID>", createCmd}
 	case WorkSessionAssigneeMismatch:
-		return []string{"alpacon worksession use <ID>"}
+		return []string{"alpacon work-session use <ID>"}
 	case WorkSessionNotUsable:
 		return []string{
-			"alpacon worksession list",
+			"alpacon work-session ls",
 			createCmd,
 		}
 	default: // scope_not_allowed, server_not_allowed

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -10,7 +10,6 @@ import (
 
 type workSessionErrorJSON struct {
 	OK          bool                `json:"ok"`
-	Command     string              `json:"command"`
 	ErrorCode   string              `json:"error_code"`
 	Message     string              `json:"message"`
 	Context     workSessionErrorCtx `json:"context"`
@@ -89,7 +88,6 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 	}
 	envelope := workSessionErrorJSON{
 		OK:        false,
-		Command:   operation,
 		ErrorCode: code,
 		Message:   fmt.Sprintf("%s requires an active WorkSession on this authentication.", operation),
 		Context: workSessionErrorCtx{

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -81,7 +81,6 @@ func TestBuildWorkSessionJSON(t *testing.T) {
 			assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
 			assert.False(t, envelope.OK)
 			assert.Equal(t, code, envelope.ErrorCode)
-			assert.Equal(t, "command", envelope.Command)
 			assert.Equal(t, "command", envelope.Context.RequiredScope)
 			assert.Equal(t, []string{"srv-1"}, envelope.Context.TargetServers)
 			assert.Nil(t, envelope.Context.CurrentWorksession)

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -81,6 +81,7 @@ func TestBuildWorkSessionJSON(t *testing.T) {
 			assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
 			assert.False(t, envelope.OK)
 			assert.Equal(t, code, envelope.ErrorCode)
+			assert.Equal(t, workSessionReasonMap[code], envelope.Reason)
 			assert.Equal(t, "command", envelope.Context.RequiredScope)
 			assert.Equal(t, []string{"srv-1"}, envelope.Context.TargetServers)
 			assert.Nil(t, envelope.Context.CurrentWorksession)

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -34,13 +34,13 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 		wantReason string
 		wantNext   string
 	}{
-		{WorkSessionRequired, "no WorkSession selected", "worksession list"},
-		{WorkSessionNotActive, "not yet active", "worksession current"},
-		{WorkSessionExpired, "has expired", "worksession extend"},
-		{WorkSessionScopeNotAllowed, "does not include this scope", "worksession create"},
-		{WorkSessionServerNotAllowed, "target server is not in this session", "worksession create"},
-		{WorkSessionAssigneeMismatch, "assigned to another principal", "worksession use"},
-		{WorkSessionNotUsable, "no longer usable", "worksession create"},
+		{WorkSessionRequired, "no WorkSession selected", "work-session ls"},
+		{WorkSessionNotActive, "not yet active", "work-session current"},
+		{WorkSessionExpired, "has expired", "work-session extend"},
+		{WorkSessionScopeNotAllowed, "does not include this scope", "work-session create"},
+		{WorkSessionServerNotAllowed, "target server is not in this session", "work-session create"},
+		{WorkSessionAssigneeMismatch, "assigned to another principal", "work-session use"},
+		{WorkSessionNotUsable, "no longer usable", "work-session create"},
 	}
 
 	for _, tt := range tests {

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -45,7 +45,7 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.code, func(t *testing.T) {
-			got := buildWorkSessionDiagnostic(tt.code, "websh", "prod-1", "Browser login", "")
+			got := buildWorkSessionDiagnostic(tt.code, "websh", "prod-1", "Browser login")
 			assert.Contains(t, got, tt.wantReason)
 			assert.Contains(t, got, tt.wantNext)
 			assert.Contains(t, got, "required scope")
@@ -57,7 +57,7 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 }
 
 func TestBuildWorkSessionDiagnostic_APIToken(t *testing.T) {
-	got := buildWorkSessionDiagnostic(WorkSessionRequired, "command", "srv-1", "API token", "")
+	got := buildWorkSessionDiagnostic(WorkSessionRequired, "command", "srv-1", "API token")
 	assert.Contains(t, got, "API token")
 	assert.NotContains(t, got, "(interactive)")
 }

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,4 +59,41 @@ func TestBuildWorkSessionDiagnostic_APIToken(t *testing.T) {
 	got := buildWorkSessionDiagnostic(WorkSessionRequired, "command", "srv-1", "API token", "")
 	assert.Contains(t, got, "API token")
 	assert.NotContains(t, got, "(interactive)")
+}
+
+func TestBuildWorkSessionJSON(t *testing.T) {
+	tests := []string{
+		WorkSessionRequired,
+		WorkSessionNotActive,
+		WorkSessionExpired,
+		WorkSessionScopeNotAllowed,
+		WorkSessionServerNotAllowed,
+		WorkSessionAssigneeMismatch,
+		WorkSessionNotUsable,
+	}
+
+	for _, code := range tests {
+		t.Run(code, func(t *testing.T) {
+			got := buildWorkSessionJSON(code, "command", "srv-1", "API token", "")
+
+			var envelope workSessionErrorJSON
+			assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
+			assert.False(t, envelope.OK)
+			assert.Equal(t, code, envelope.ErrorCode)
+			assert.Equal(t, "command", envelope.Command)
+			assert.Equal(t, "command", envelope.Context.RequiredScope)
+			assert.Equal(t, []string{"srv-1"}, envelope.Context.TargetServers)
+			assert.Nil(t, envelope.Context.CurrentWorksession)
+			assert.NotEmpty(t, envelope.NextActions)
+		})
+	}
+}
+
+func TestBuildWorkSessionJSON_WithActiveWS(t *testing.T) {
+	got := buildWorkSessionJSON(WorkSessionExpired, "webftp", "srv-2", "Browser login", "abc-123-uuid")
+
+	var envelope workSessionErrorJSON
+	assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
+	assert.NotNil(t, envelope.Context.CurrentWorksession)
+	assert.Equal(t, "abc-123-uuid", *envelope.Context.CurrentWorksession)
 }

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -80,6 +80,7 @@ func TestBuildWorkSessionJSON(t *testing.T) {
 			var envelope workSessionErrorJSON
 			assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
 			assert.False(t, envelope.OK)
+			assert.Equal(t, ExitCodeWorkSessionDenied, envelope.ExitCode)
 			assert.Equal(t, code, envelope.ErrorCode)
 			assert.Equal(t, workSessionReasonMap[code], envelope.Reason)
 			assert.Equal(t, "command", envelope.Context.RequiredScope)

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,4 +97,16 @@ func TestBuildWorkSessionJSON_WithActiveWS(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
 	assert.NotNil(t, envelope.Context.CurrentWorksession)
 	assert.Equal(t, "abc-123-uuid", *envelope.Context.CurrentWorksession)
+}
+
+func TestHandleWorkSessionError_NoOp(t *testing.T) {
+	// Non-WorkSession errors must not trigger any exit — just return.
+	// If HandleWorkSessionError calls os.Exit for this error, the test process dies.
+	err := errors.New("some unrelated error")
+	HandleWorkSessionError(err, "websh", "srv", "Browser login", "")
+	// reaching here means no exit — test passes
+}
+
+func TestHandleWorkSessionError_NilError(t *testing.T) {
+	HandleWorkSessionError(nil, "websh", "srv", "Browser login", "")
 }

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -45,7 +45,7 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.code, func(t *testing.T) {
-			got := buildWorkSessionDiagnostic(tt.code, "websh", "prod-1", "Browser login")
+			got := buildWorkSessionDiagnostic(tt.code, "websh", "prod-1", "Browser login", "")
 			assert.Contains(t, got, tt.wantReason)
 			assert.Contains(t, got, tt.wantNext)
 			assert.Contains(t, got, "required scope")
@@ -57,7 +57,7 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 }
 
 func TestBuildWorkSessionDiagnostic_APIToken(t *testing.T) {
-	got := buildWorkSessionDiagnostic(WorkSessionRequired, "command", "srv-1", "API token")
+	got := buildWorkSessionDiagnostic(WorkSessionRequired, "command", "srv-1", "API token", "")
 	assert.Contains(t, got, "API token")
 	assert.NotContains(t, got, "(interactive)")
 }
@@ -97,6 +97,30 @@ func TestBuildWorkSessionJSON_WithActiveWS(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
 	assert.NotNil(t, envelope.Context.CurrentWorksession)
 	assert.Equal(t, "abc-123-uuid", *envelope.Context.CurrentWorksession)
+	// Expired case: <ID> placeholder must be substituted with the known active UUID.
+	assert.Contains(t, envelope.NextActions, "alpacon work-session extend abc-123-uuid")
+	for _, action := range envelope.NextActions {
+		assert.NotContains(t, action, "<ID>")
+	}
+}
+
+func TestBuildWorkSessionJSON_ExpiredWithoutActiveWS(t *testing.T) {
+	// When activeWS is unknown, the placeholder must remain.
+	got := buildWorkSessionJSON(WorkSessionExpired, "webftp", "srv-2", "Browser login", "")
+
+	var envelope workSessionErrorJSON
+	assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
+	assert.Contains(t, envelope.NextActions, "alpacon work-session extend <ID>")
+}
+
+func TestBuildWorkSessionJSON_RequiredKeepsPlaceholder(t *testing.T) {
+	// For work_session_required, activeWS is unrelated to the suggested `use <ID>`,
+	// so the placeholder must NOT be substituted even when activeWS is known.
+	got := buildWorkSessionJSON(WorkSessionRequired, "command", "srv-1", "Browser login", "abc-123-uuid")
+
+	var envelope workSessionErrorJSON
+	assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
+	assert.Contains(t, envelope.NextActions, "alpacon work-session use <ID>")
 }
 
 func TestHandleWorkSessionError_NoOp(t *testing.T) {

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -25,3 +25,37 @@ func TestIsWorkSessionCode(t *testing.T) {
 		assert.False(t, isWorkSessionCode(code), "expected false for %s", code)
 	}
 }
+
+func TestBuildWorkSessionDiagnostic(t *testing.T) {
+	tests := []struct {
+		code       string
+		wantReason string
+		wantNext   string
+	}{
+		{WorkSessionRequired, "no WorkSession selected", "worksession list"},
+		{WorkSessionNotActive, "not yet active", "worksession current"},
+		{WorkSessionExpired, "has expired", "worksession extend"},
+		{WorkSessionScopeNotAllowed, "does not include this scope", "worksession create"},
+		{WorkSessionServerNotAllowed, "target server is not in this session", "worksession create"},
+		{WorkSessionAssigneeMismatch, "assigned to another principal", "worksession use"},
+		{WorkSessionNotUsable, "no longer usable", "worksession create"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			got := buildWorkSessionDiagnostic(tt.code, "websh", "prod-1", "Browser login", "")
+			assert.Contains(t, got, tt.wantReason)
+			assert.Contains(t, got, tt.wantNext)
+			assert.Contains(t, got, "required scope")
+			assert.Contains(t, got, "prod-1")
+			assert.Contains(t, got, "Browser login (interactive)")
+			assert.Contains(t, got, "Note:")
+		})
+	}
+}
+
+func TestBuildWorkSessionDiagnostic_APIToken(t *testing.T) {
+	got := buildWorkSessionDiagnostic(WorkSessionRequired, "command", "srv-1", "API token", "")
+	assert.Contains(t, got, "API token")
+	assert.NotContains(t, got, "(interactive)")
+}

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsWorkSessionCode(t *testing.T) {
+	trueCodes := []string{
+		WorkSessionRequired,
+		WorkSessionNotUsable,
+		WorkSessionNotActive,
+		WorkSessionExpired,
+		WorkSessionScopeNotAllowed,
+		WorkSessionServerNotAllowed,
+		WorkSessionAssigneeMismatch,
+	}
+	for _, code := range trueCodes {
+		assert.True(t, isWorkSessionCode(code), "expected true for %s", code)
+	}
+
+	falseCodes := []string{AuthMFARequired, UsernameRequired, "", "some_other_error"}
+	for _, code := range falseCodes {
+		assert.False(t, isWorkSessionCode(code), "expected false for %s", code)
+	}
+}


### PR DESCRIPTION
## Summary

When alpacon-server refuses access due to a WorkSession gate check, the CLI previously surfaced a raw, unhelpful error:

```
Error: failed to execute command on 'web-editor' server: code: work_session_required
```

This PR makes WorkSession denials a first-class CLI signal across `exec`, `websh`, and `cp`.

## Changes

**Table mode output** (default):
```
Error: command requires an active WorkSession on this authentication.

  auth          : Browser login (interactive)
  reason        : no WorkSession selected for this shell
  required scope: command
  target server : web-editor

Next:
  alpacon work-session ls --status active
  alpacon work-session use <ID>
  alpacon work-session create --scope command --server web-editor --purpose "<intent>"

Note: ServiceToken or personal API token (source != login) skip this requirement.
```

**JSON mode output** (`--output json`, written to stderr):
```json
{
  "ok": false,
  "command": "command",
  "error_code": "work_session_required",
  "message": "command requires an active WorkSession on this authentication.",
  "context": {
    "auth_method": "Browser login",
    "required_scope": "command",
    "target_servers": ["web-editor"],
    "current_worksession": null
  },
  "next_actions": [
    "alpacon work-session ls --status active",
    "alpacon work-session use <ID>",
    "alpacon work-session create --scope command --server web-editor --purpose \"<intent>\""
  ]
}
```

Process exits with **code 3** (1 = general error, 2 = bad usage, 3 = WorkSession denied).

## Files changed

- `utils/error.go` — 7 WorkSession error code constants + `ExitCodeWorkSessionDenied = 3`; `ParseErrorResponse` traverses the error chain via `errors.Unwrap` with per-iteration locals to prevent cross-layer variable leakage
- `utils/worksession_error.go` *(new)* — `HandleWorkSessionError`: no-op for non-WorkSession errors; prints table diagnostic or JSON envelope to stderr then `os.Exit(3)`; next-action hints use correct `alpacon work-session` command name
- `config/config.go` — `GetAuthMethod` / `ResolveAuthMethod` helpers (utils cannot import config, so auth method is resolved at call sites)
- `cmd/exec/exec.go`, `cmd/websh/websh.go`, `cmd/ftp/cp.go` — wire `HandleWorkSessionError`
- `cmd/exec/parse.go`, `cmd/websh/websh.go` — manually parse `--output` flag (DisableFlagParsing disables Cobra persistent flag handling); validate value against `table`/`json`; error on empty `--output=` value

## Test plan

- [x] `./alpacon exec web-editor ls` → table diagnostic block, exits 3
- [x] `./alpacon --output json exec web-editor ls` → JSON envelope on stderr, `<ID>`/`<intent>` render as-is (no HTML escaping), exits 3
- [x] `go test -race ./...` → all pass
- [x] `golangci-lint run ./...` → clean

## Notes

- Users authenticating with a ServiceToken or personal API token are exempt from the WorkSession requirement — noted in the diagnostic output
- JSON errors go to stderr, consistent with the existing `CliError*` convention