### PR TITLE
feat(exec): add --detach flag and exec logs subcommand

### DIFF
--- a/api/event/event.go
+++ b/api/event/event.go
@@ -63,12 +63,11 @@ func GetEventList(ac *client.AlpaconClient, pageSize int, serverName string, use
 	return eventList, nil
 }
 
-func RunCommand(ac *client.AlpaconClient, serverName, command string, username, groupname string, env map[string]string, workSessionID string) (string, error) {
+func SubmitCommand(ac *client.AlpaconClient, serverName, command string, username, groupname string, env map[string]string, workSessionID string) (CommandResponse, error) {
 	serverID, err := server.GetServerIDByName(ac, serverName)
 	if err != nil {
-		return "", err
+		return CommandResponse{}, err
 	}
-
 	commandRequest := &CommandRequest{
 		Shell:       "system",
 		Line:        command,
@@ -81,20 +80,22 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 	}
 	respBody, err := ac.SendPostRequest(getEventURL, commandRequest)
 	if err != nil {
-		return "", err
+		return CommandResponse{}, err
 	}
-
-	// TODO: CLI currently supports only single-command response.
-	//       If the response contains a list, we parse only the first command result for now.
-	//       Support for handling multiple responses should be added later.
 	var cmdResponse []CommandResponse
+	if err = json.Unmarshal(respBody, &cmdResponse); err != nil {
+		return CommandResponse{}, err
+	}
+	return cmdResponse[0], nil
+}
 
-	err = json.Unmarshal(respBody, &cmdResponse)
+func RunCommand(ac *client.AlpaconClient, serverName, command string, username, groupname string, env map[string]string, workSessionID string) (string, error) {
+	cmdResponse, err := SubmitCommand(ac, serverName, command, username, groupname, env, workSessionID)
 	if err != nil {
 		return "", err
 	}
 
-	result, err := PollCommandExecution(ac, cmdResponse[0].ID)
+	result, err := PollCommandExecution(ac, cmdResponse.ID)
 	if err != nil {
 		return "", err
 	}

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -130,6 +130,10 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 		}
 	}
 
+	if result.Success == nil && result.Status != "completed" && result.Status != "success" {
+		return result.Result, fmt.Errorf("command ended with unrecognised status: %s", result.Status)
+	}
+
 	return result.Result, nil
 }
 
@@ -145,6 +149,11 @@ func GetCommandByID(ac *client.AlpaconClient, cmdID string) (EventDetails, error
 	return response, nil
 }
 
+// PollCommandExecution polls with default timeout/tick; tests use pollCommandExecution directly.
+func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails, error) {
+	return pollCommandExecution(ac, cmdId, execTimeout(), 1*time.Second)
+}
+
 func execTimeout() time.Duration {
 	if v := os.Getenv("ALPACON_EXEC_TIMEOUT"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
@@ -153,11 +162,6 @@ func execTimeout() time.Duration {
 		utils.CliWarning("ALPACON_EXEC_TIMEOUT=%q is not a valid duration (e.g. \"30m\", \"1h\"), using default 30m", v)
 	}
 	return 30 * time.Minute
-}
-
-// PollCommandExecution polls with default timeout/tick; tests use pollCommandExecution directly.
-func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails, error) {
-	return pollCommandExecution(ac, cmdId, execTimeout(), 1*time.Second)
 }
 
 func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration) (EventDetails, error) {

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -129,6 +129,18 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 	return result.Result, nil
 }
 
+func GetCommandByID(ac *client.AlpaconClient, cmdID string) (EventDetails, error) {
+	responseBody, err := ac.SendGetRequest(utils.BuildURL(getEventURL, cmdID, nil))
+	if err != nil {
+		return EventDetails{}, err
+	}
+	var response EventDetails
+	if err = json.Unmarshal(responseBody, &response); err != nil {
+		return EventDetails{}, err
+	}
+	return response, nil
+}
+
 // PollCommandExecution polls with default timeout/tick; tests use pollCommandExecution directly.
 func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails, error) {
 	return pollCommandExecution(ac, cmdId, 5*time.Minute, 1*time.Second)

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -182,8 +182,7 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 			}
 
 			if IsRunningStatus(response.Status) {
-				// Drain the channel before Reset to avoid the race where the timer
-				// fires between Stop and Reset, causing a spurious ClientTimeoutError.
+				// Drain timer.C before Reset to prevent a spurious ClientTimeoutError if the timer fires between Stop and Reset.
 				if !timer.Stop() {
 					select {
 					case <-timer.C:

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -3,6 +3,7 @@ package event
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"time"
 
@@ -141,9 +142,18 @@ func GetCommandByID(ac *client.AlpaconClient, cmdID string) (EventDetails, error
 	return response, nil
 }
 
+func execTimeout() time.Duration {
+	if v := os.Getenv("ALPACON_EXEC_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return 30 * time.Minute
+}
+
 // PollCommandExecution polls with default timeout/tick; tests use pollCommandExecution directly.
 func PollCommandExecution(ac *client.AlpaconClient, cmdId string) (EventDetails, error) {
-	return pollCommandExecution(ac, cmdId, 5*time.Minute, 1*time.Second)
+	return pollCommandExecution(ac, cmdId, execTimeout(), 1*time.Second)
 }
 
 func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration) (EventDetails, error) {

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -87,6 +87,9 @@ func SubmitCommand(ac *client.AlpaconClient, serverName, command string, usernam
 	if err = json.Unmarshal(respBody, &cmdResponse); err != nil {
 		return CommandResponse{}, err
 	}
+	if len(cmdResponse) == 0 {
+		return CommandResponse{}, fmt.Errorf("server returned empty command list")
+	}
 	return cmdResponse[0], nil
 }
 
@@ -101,7 +104,7 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 		return "", err
 	}
 
-	if result.Status == "stuck" || result.Status == "error" {
+	if result.Status == "stuck" || result.Status == "error" || result.Status == "cancelled" {
 		if result.ErrorPhase != nil && *result.ErrorPhase != "" {
 			return "", fmt.Errorf("command failed: [%s] %s (status=%s)",
 				*result.ErrorPhase, DescribePhase(*result.ErrorPhase), result.Status)
@@ -147,6 +150,7 @@ func execTimeout() time.Duration {
 		if d, err := time.ParseDuration(v); err == nil {
 			return d
 		}
+		utils.CliWarning("ALPACON_EXEC_TIMEOUT=%q is not a valid duration (e.g. \"30m\", \"1h\"), using default 30m", v)
 	}
 	return 30 * time.Minute
 }
@@ -177,13 +181,19 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 				return response, err
 			}
 
-			switch response.Status {
-			case "queued", "scheduled", "delivered", "verifying", "running", "acked":
+			if IsRunningStatus(response.Status) {
+				// Drain the channel before Reset to avoid the race where the timer
+				// fires between Stop and Reset, causing a spurious ClientTimeoutError.
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
 				timer.Reset(timeout)
 				continue
-			default:
-				return response, nil
 			}
+			return response, nil
 		}
 	}
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -482,6 +482,40 @@ func TestSubmitCommand_ReturnsJobID(t *testing.T) {
 	assert.Equal(t, "job-abc-123", resp.ID)
 }
 
+func TestGetCommandByID_ReturnsEventDetails(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/events/commands/") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(EventDetails{
+				ID:     "job-abc-123",
+				Status: "completed",
+				Result: "Packages updated.",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	details, err := GetCommandByID(ac, "job-abc-123")
+	require.NoError(t, err)
+	assert.Equal(t, "job-abc-123", details.ID)
+	assert.Equal(t, "completed", details.Status)
+	assert.Equal(t, "Packages updated.", details.Result)
+}
+
+func TestGetCommandByID_PropagatesError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "server error", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := GetCommandByID(ac, "job-abc-123")
+	require.Error(t, err)
+}
+
 func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -272,6 +272,17 @@ func TestRunCommand_InfraStatusReturnsError(t *testing.T) {
 	}
 }
 
+func TestRunCommand_UnrecognisedTerminalStatusReturnsError(t *testing.T) {
+	ts := newRunCommandServerWithDetails(t, EventDetails{ID: "cmd-1", Status: "denied"})
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unrecognised status")
+	assert.Contains(t, err.Error(), "denied")
+}
+
 func TestRunCommand_SuccessFalseReturnsRemoteCommandError(t *testing.T) {
 	ts := newRunCommandServerWithDetails(t, EventDetails{
 		ID:      "cmd-1",

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -150,7 +150,7 @@ func TestPollCommandExecution(t *testing.T) {
 				BaseURL:    ts.URL,
 			}
 
-			result, err := PollCommandExecution(ac, "cmd-1")
+			result, err := pollCommandExecution(ac, "cmd-1", 30*time.Second, 5*time.Millisecond)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantStatus, result.Status)
 			assert.Equal(t, tt.wantResult, result.Result)
@@ -229,6 +229,7 @@ func newRunCommandBodyCaptureServer(t *testing.T, capture *runCommandBodyCapture
 }
 
 func TestRunCommand_BodyIncludesWorkSession_WhenSet(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
 	var capture runCommandBodyCapture
 	ts := newRunCommandBodyCaptureServer(t, &capture)
 	defer ts.Close()
@@ -244,6 +245,7 @@ func TestRunCommand_BodyIncludesWorkSession_WhenSet(t *testing.T) {
 }
 
 func TestRunCommand_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
 	var capture runCommandBodyCapture
 	ts := newRunCommandBodyCaptureServer(t, &capture)
 	defer ts.Close()
@@ -258,6 +260,7 @@ func TestRunCommand_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
 }
 
 func TestRunCommand_InfraStatusReturnsError(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
 	for _, status := range []string{"stuck", "error", "cancelled"} {
 		t.Run(status, func(t *testing.T) {
 			ts := newRunCommandServerWithDetails(t, EventDetails{ID: "cmd-1", Status: status})
@@ -273,6 +276,7 @@ func TestRunCommand_InfraStatusReturnsError(t *testing.T) {
 }
 
 func TestRunCommand_UnrecognisedTerminalStatusReturnsError(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
 	ts := newRunCommandServerWithDetails(t, EventDetails{ID: "cmd-1", Status: "denied"})
 	defer ts.Close()
 
@@ -284,6 +288,7 @@ func TestRunCommand_UnrecognisedTerminalStatusReturnsError(t *testing.T) {
 }
 
 func TestRunCommand_SuccessFalseReturnsRemoteCommandError(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
 	ts := newRunCommandServerWithDetails(t, EventDetails{
 		ID:      "cmd-1",
 		Status:  "completed",
@@ -305,6 +310,7 @@ func TestRunCommand_SuccessFalseReturnsRemoteCommandError(t *testing.T) {
 }
 
 func TestRunCommand_PropagatesExitCode(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
 	tests := []struct {
 		name           string
 		respSuccess    *bool
@@ -378,6 +384,7 @@ func TestRunCommand_PropagatesExitCode(t *testing.T) {
 }
 
 func TestRunCommand_StuckWithErrorPhase(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
 	tests := []struct {
 		name           string
 		respStatus     string

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -516,6 +516,21 @@ func TestGetCommandByID_PropagatesError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestExecTimeout_Default(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
+	assert.Equal(t, 30*time.Minute, execTimeout())
+}
+
+func TestExecTimeout_EnvVar(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "1h")
+	assert.Equal(t, time.Hour, execTimeout())
+}
+
+func TestExecTimeout_InvalidEnvFallsBackToDefault(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "not-a-duration")
+	assert.Equal(t, 30*time.Minute, execTimeout())
+}
+
 func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -458,6 +458,30 @@ func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {
 	assert.Equal(t, "completed", resp.Status)
 }
 
+func TestSubmitCommand_ReturnsJobID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListResponse[map[string]any]{
+				Count:   1,
+				Results: []map[string]any{{"id": "srv-1", "name": "server-x"}},
+			})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/api/events/commands/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "job-abc-123"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	resp, err := SubmitCommand(ac, "server-x", "apt upgrade", "", "", nil, "")
+	require.NoError(t, err)
+	assert.Equal(t, "job-abc-123", resp.ID)
+}
+
 func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -258,7 +258,7 @@ func TestRunCommand_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
 }
 
 func TestRunCommand_InfraStatusReturnsError(t *testing.T) {
-	for _, status := range []string{"stuck", "error"} {
+	for _, status := range []string{"stuck", "error", "cancelled"} {
 		t.Run(status, func(t *testing.T) {
 			ts := newRunCommandServerWithDetails(t, EventDetails{ID: "cmd-1", Status: status})
 			defer ts.Close()

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -103,9 +103,7 @@ func DescribePhase(phase string) string {
 	return phase
 }
 
-// IsRunningStatus reports whether the given command status represents an
-// in-progress (non-terminal) state. Both the polling loop and exec logs use
-// this to decide whether to wait or report a result.
+// IsRunningStatus reports whether status represents an in-progress (non-terminal) command.
 func IsRunningStatus(status string) bool {
 	switch status {
 	case "queued", "scheduled", "delivered", "verifying", "running", "acked":

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -102,3 +102,15 @@ func DescribePhase(phase string) string {
 	}
 	return phase
 }
+
+// IsRunningStatus reports whether the given command status represents an
+// in-progress (non-terminal) state. Both the polling loop and exec logs use
+// this to decide whether to wait or report a result.
+func IsRunningStatus(status string) bool {
+	switch status {
+	case "queued", "scheduled", "delivered", "verifying", "running", "acked":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -6,6 +6,8 @@ import (
 	"os"
 
 	"github.com/alpacax/alpacon-cli/api/event"
+	"github.com/alpacax/alpacon-cli/api/iam"
+	"github.com/alpacax/alpacon-cli/api/mfa"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
 	"github.com/alpacax/alpacon-cli/config"
@@ -103,6 +105,25 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 
 		if parsed.Detach {
 			resp, err := event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
+			if err != nil {
+				err = utils.HandleCommonErrors(err, parsed.Server, utils.ErrorHandlerCallbacks{
+					OnMFARequired: func(srv string) error {
+						return mfa.HandleMFAError(alpaconClient, srv)
+					},
+					OnUsernameRequired: func() error {
+						_, err := iam.HandleUsernameRequired()
+						return err
+					},
+					CheckMFACompleted: func() (bool, error) {
+						return mfa.CheckMFACompletion(alpaconClient)
+					},
+					RefreshToken: alpaconClient.RefreshToken,
+					RetryOperation: func() error {
+						resp, err = event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
+						return err
+					},
+				})
+			}
 			if err != nil {
 				utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
 				utils.CliErrorWithExit("failed to submit command on '%s': %s", parsed.Server, err)

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -1,6 +1,9 @@
 package exec
 
 import (
+	"fmt"
+
+	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
 	"github.com/alpacax/alpacon-cli/config"
@@ -91,6 +94,19 @@ parse a machine-readable diagnostic on stderr.`,
 		}
 
 		env := make(map[string]string)
+
+		if parsed.Detach {
+			resp, err := event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
+			if err != nil {
+				utils.CliErrorWithExit("failed to submit command on '%s': %s", parsed.Server, err)
+				return
+			}
+			line1, line2 := detachResultLines(resp.ID)
+			fmt.Println(line1)
+			fmt.Println(line2)
+			return
+		}
+
 		result, err := RunCommandWithRetry(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
 		utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
 		HandleCommandResult(result, err)

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/client"
@@ -96,14 +97,18 @@ parse a machine-readable diagnostic on stderr.`,
 		env := make(map[string]string)
 
 		if parsed.Detach {
+			// Phase 1: detach path does not retry on MFA-required or username-required
+			// errors. These are surfaced as-is. Full retry support is deferred to a
+			// later phase alongside --follow / streaming output.
 			resp, err := event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
 			if err != nil {
+				utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
 				utils.CliErrorWithExit("failed to submit command on '%s': %s", parsed.Server, err)
 				return
 			}
 			line1, line2 := detachResultLines(resp.ID)
 			fmt.Println(line1)
-			fmt.Println(line2)
+			fmt.Fprintln(os.Stderr, line2)
 			return
 		}
 

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -130,7 +130,11 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 				return
 			}
 			if utils.OutputFormat == utils.OutputFormatJSON {
-				data, _ := json.Marshal(map[string]string{"job_id": resp.ID})
+				data, err := json.Marshal(map[string]string{"job_id": resp.ID})
+				if err != nil {
+					utils.CliErrorWithExit("failed to marshal JSON: %s", err)
+					return
+				}
 				utils.PrintJson(data)
 			} else {
 				line1, line2 := detachResultLines(resp.ID)

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -35,6 +36,9 @@ Flags:
   --work-session [UUID]         Attach this command to a work-session.
                                 Overrides the workspace's active session set via
                                 'alpacon work-session use'.
+  --detach                      Submit the command and return immediately without
+                                waiting for completion. Prints the job ID to stdout.
+                                Use 'alpacon exec logs JOB_ID' to retrieve the result.
 
 Exit code 3 indicates a WorkSession gate denial; run with --output json to
 parse a machine-readable diagnostic on stderr.
@@ -98,18 +102,20 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 		env := make(map[string]string)
 
 		if parsed.Detach {
-			// Phase 1: detach path does not retry on MFA-required or username-required
-			// errors. These are surfaced as-is. Full retry support is deferred to a
-			// later phase alongside --follow / streaming output.
 			resp, err := event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
 			if err != nil {
 				utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
 				utils.CliErrorWithExit("failed to submit command on '%s': %s", parsed.Server, err)
 				return
 			}
-			line1, line2 := detachResultLines(resp.ID)
-			fmt.Println(line1)
-			fmt.Fprintln(os.Stderr, line2)
+			if utils.OutputFormat == utils.OutputFormatJSON {
+				data, _ := json.Marshal(map[string]string{"job_id": resp.ID})
+				utils.PrintJson(data)
+			} else {
+				line1, line2 := detachResultLines(resp.ID)
+				fmt.Println(line1)
+				fmt.Fprintln(os.Stderr, line2)
+			}
 			return
 		}
 

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -1,0 +1,98 @@
+package exec
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alpacax/alpacon-cli/api/event"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var LogsCmd = &cobra.Command{
+	Use:   "logs JOB_ID",
+	Short: "Fetch the result of a detached command",
+	Long: `Fetch the result of a command submitted with --detach.
+
+If the command is still running, prints the current status and exits.
+Run the command again later to check for completion.`,
+	Example: `  alpacon exec logs a1b2c3d4-5678-abcd-ef01-234567890abc`,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		jobID := args[0]
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+			return
+		}
+
+		details, err := event.GetCommandByID(alpaconClient, jobID)
+		if err != nil {
+			utils.CliErrorWithExit("failed to fetch command result: %s", err)
+			return
+		}
+
+		stdoutLine, stderrLine, exitCode := logsCommandOutcome(details)
+		if stdoutLine != "" {
+			fmt.Println(stdoutLine)
+		}
+		if stderrLine != "" {
+			fmt.Fprint(os.Stderr, stderrLine)
+		}
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+	},
+}
+
+func init() {
+	ExecCmd.AddCommand(LogsCmd)
+}
+
+func isRunning(status string) bool {
+	switch status {
+	case "queued", "scheduled", "delivered", "verifying", "running", "acked":
+		return true
+	default:
+		return false
+	}
+}
+
+// logsCommandOutcome computes stdout line, stderr line, and exit code for
+// a command result fetched via GetCommandByID. stderrLine ends with \n when non-empty.
+func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine string, exitCode int) {
+	if isRunning(details.Status) {
+		stderrLine = fmt.Sprintf(
+			"Command is still running (status: %s).\nRun `alpacon exec logs %s` again to check later.\n",
+			details.Status, details.ID,
+		)
+		return "", stderrLine, 0
+	}
+
+	if details.Status == "stuck" || details.Status == "error" {
+		if details.ErrorPhase != nil && *details.ErrorPhase != "" {
+			stderrLine = fmt.Sprintf("%s: [%s] %s\n",
+				utils.Red("Error"), *details.ErrorPhase, event.DescribePhase(*details.ErrorPhase))
+		} else {
+			stderrLine = fmt.Sprintf("%s: command failed with status: %s\n",
+				utils.Red("Error"), details.Status)
+		}
+		return "", stderrLine, 1
+	}
+
+	if details.Success != nil && !*details.Success {
+		exitCode = 1
+		if details.ExitCode != nil {
+			exitCode = *details.ExitCode
+		}
+		if details.ErrorPhase != nil && *details.ErrorPhase != "" {
+			stderrLine = fmt.Sprintf("%s: [%s] %s\n",
+				utils.Red("Error"), *details.ErrorPhase, event.DescribePhase(*details.ErrorPhase))
+		}
+		return details.Result, stderrLine, exitCode
+	}
+
+	return details.Result, "", 0
+}

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -51,11 +51,7 @@ func init() {
 	ExecCmd.AddCommand(LogsCmd)
 }
 
-// logsCommandOutcome computes stdout line, stderr line, and exit code for
-// a command result fetched via GetCommandByID. stderrLine ends with \n when non-empty.
-// When Success is nil and status is terminal, the command is treated as successful —
-// this mirrors the contract in RunCommand: alpamon sets success=(exitCode==0), so a
-// nil success field on a terminal status means the server did not report a failure.
+// logsCommandOutcome maps GetCommandByID details to (stdout, stderr, exitCode). stderrLine always ends with \n.
 func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine string, exitCode int) {
 	if event.IsRunningStatus(details.Status) {
 		stderrLine = fmt.Sprintf(
@@ -88,5 +84,16 @@ func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine stri
 		return details.Result, stderrLine, exitCode
 	}
 
-	return details.Result, "", 0
+	if details.Success != nil {
+		return details.Result, "", 0
+	}
+
+	// Success nil on a known-success status means alpamon did not report failure (success=(exitCode==0) contract).
+	if details.Status == "completed" || details.Status == "success" {
+		return details.Result, "", 0
+	}
+
+	stderrLine = fmt.Sprintf("%s: command ended with unrecognised status: %s\n",
+		utils.Red("Error"), details.Status)
+	return details.Result, stderrLine, 1
 }

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -51,27 +51,21 @@ func init() {
 	ExecCmd.AddCommand(LogsCmd)
 }
 
-func isRunning(status string) bool {
-	switch status {
-	case "queued", "scheduled", "delivered", "verifying", "running", "acked":
-		return true
-	default:
-		return false
-	}
-}
-
 // logsCommandOutcome computes stdout line, stderr line, and exit code for
 // a command result fetched via GetCommandByID. stderrLine ends with \n when non-empty.
+// When Success is nil and status is terminal, the command is treated as successful —
+// this mirrors the contract in RunCommand: alpamon sets success=(exitCode==0), so a
+// nil success field on a terminal status means the server did not report a failure.
 func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine string, exitCode int) {
-	if isRunning(details.Status) {
+	if event.IsRunningStatus(details.Status) {
 		stderrLine = fmt.Sprintf(
-			"Command is still running (status: %s).\nRun `alpacon exec logs %s` again to check later.\n",
+			"command is still running (status: %s).\nRun `alpacon exec logs %s` again to check later.\n",
 			details.Status, details.ID,
 		)
 		return "", stderrLine, 0
 	}
 
-	if details.Status == "stuck" || details.Status == "error" {
+	if details.Status == "stuck" || details.Status == "error" || details.Status == "cancelled" {
 		if details.ErrorPhase != nil && *details.ErrorPhase != "" {
 			stderrLine = fmt.Sprintf("%s: [%s] %s\n",
 				utils.Red("Error"), *details.ErrorPhase, event.DescribePhase(*details.ErrorPhase))

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var LogsCmd = &cobra.Command{
+var logsCmd = &cobra.Command{
 	Use:   "logs JOB_ID",
 	Short: "Fetch the result of a detached command",
 	Long: `Fetch the result of a command submitted with --detach.
@@ -21,6 +21,11 @@ Run the command again later to check for completion.`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jobID := args[0]
+
+		if !utils.IsUUID(jobID) {
+			utils.CliErrorWithExit("invalid JOB_ID %q: must be a UUID (e.g. a1b2c3d4-5678-abcd-ef01-234567890abc)", jobID)
+			return
+		}
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
@@ -48,7 +53,7 @@ Run the command again later to check for completion.`,
 }
 
 func init() {
-	ExecCmd.AddCommand(LogsCmd)
+	ExecCmd.AddCommand(logsCmd)
 }
 
 // logsCommandOutcome maps GetCommandByID details to (stdout, stderr, exitCode). stderrLine always ends with \n.

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -60,7 +60,7 @@ func init() {
 	ExecCmd.AddCommand(logsCmd)
 }
 
-// logsCommandOutcome maps GetCommandByID details to (stdout, stderr, exitCode). stderrLine always ends with \n.
+// logsCommandOutcome maps GetCommandByID details to (stdout, stderr, exitCode). If non-empty, stderrLine ends with \n.
 func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine string, exitCode int) {
 	if event.IsRunningStatus(details.Status) {
 		stderrLine = fmt.Sprintf(

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,8 @@ Run the command again later to check for completion.`,
 			return
 		}
 
+		authMethod := config.ResolveAuthMethod()
+
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
@@ -35,6 +38,7 @@ Run the command again later to check for completion.`,
 
 		details, err := event.GetCommandByID(alpaconClient, jobID)
 		if err != nil {
+			utils.HandleWorkSessionError(err, "command", "", authMethod, "")
 			utils.CliErrorWithExit("failed to fetch command result: %s", err)
 			return
 		}

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -63,8 +63,8 @@ func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine stri
 
 	if details.Status == "stuck" || details.Status == "error" || details.Status == "cancelled" {
 		if details.ErrorPhase != nil && *details.ErrorPhase != "" {
-			stderrLine = fmt.Sprintf("%s: [%s] %s\n",
-				utils.Red("Error"), *details.ErrorPhase, event.DescribePhase(*details.ErrorPhase))
+			stderrLine = fmt.Sprintf("%s: [%s] %s (status=%s)\n",
+				utils.Red("Error"), *details.ErrorPhase, event.DescribePhase(*details.ErrorPhase), details.Status)
 		} else {
 			stderrLine = fmt.Sprintf("%s: command failed with status: %s\n",
 				utils.Red("Error"), details.Status)

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -1,0 +1,147 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/api/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(b bool) *bool    { return &b }
+func intPtr(i int) *int       { return &i }
+func strPtr(s string) *string { return &s }
+
+func TestIsRunning(t *testing.T) {
+	running := []string{"queued", "scheduled", "delivered", "verifying", "running", "acked"}
+	for _, s := range running {
+		assert.True(t, isRunning(s), "expected %q to be running", s)
+	}
+	terminal := []string{"completed", "success", "stuck", "error", "cancelled"}
+	for _, s := range terminal {
+		assert.False(t, isRunning(s), "expected %q to be terminal", s)
+	}
+}
+
+func TestLogsCommandOutcome(t *testing.T) {
+	tests := []struct {
+		name               string
+		details            event.EventDetails
+		wantStdoutLine     string
+		wantStderrContains []string
+		wantStderrEmpty    bool
+		wantExitCode       int
+	}{
+		{
+			name:            "completed with result",
+			details:         event.EventDetails{ID: "job-1", Status: "completed", Result: "Packages updated."},
+			wantStdoutLine:  "Packages updated.",
+			wantStderrEmpty: true,
+			wantExitCode:    0,
+		},
+		{
+			name:            "completed empty result",
+			details:         event.EventDetails{ID: "job-1", Status: "completed", Result: ""},
+			wantStdoutLine:  "",
+			wantStderrEmpty: true,
+			wantExitCode:    0,
+		},
+		{
+			name:               "still running",
+			details:            event.EventDetails{ID: "job-1", Status: "running"},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"still running", "status: running", "job-1"},
+			wantExitCode:       0,
+		},
+		{
+			name:               "queued",
+			details:            event.EventDetails{ID: "job-2", Status: "queued"},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"still running", "status: queued", "job-2"},
+			wantExitCode:       0,
+		},
+		{
+			name:               "stuck without phase",
+			details:            event.EventDetails{ID: "job-1", Status: "stuck"},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"stuck"},
+			wantExitCode:       1,
+		},
+		{
+			name:               "stuck with agent_timeout phase",
+			details:            event.EventDetails{ID: "job-1", Status: "stuck", ErrorPhase: strPtr("agent_timeout")},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"agent_timeout"},
+			wantExitCode:       1,
+		},
+		{
+			name: "error with agent_disconnected phase",
+			details: event.EventDetails{
+				ID:         "job-1",
+				Status:     "error",
+				ErrorPhase: strPtr("agent_disconnected"),
+			},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"agent_disconnected"},
+			wantExitCode:       1,
+		},
+		{
+			name: "remote failure exit 23",
+			details: event.EventDetails{
+				ID:       "job-1",
+				Status:   "completed",
+				Success:  boolPtr(false),
+				ExitCode: intPtr(23),
+				Result:   "partial transfer",
+			},
+			wantStdoutLine:  "partial transfer",
+			wantStderrEmpty: true,
+			wantExitCode:    23,
+		},
+		{
+			name: "remote failure with phase",
+			details: event.EventDetails{
+				ID:         "job-1",
+				Status:     "completed",
+				Success:    boolPtr(false),
+				ExitCode:   intPtr(124),
+				ErrorPhase: strPtr("remote_command_exceeded_timeout"),
+				Result:     "timed out",
+			},
+			wantStdoutLine:     "timed out",
+			wantStderrContains: []string{"remote_command_exceeded_timeout"},
+			wantExitCode:       124,
+		},
+		{
+			name: "remote failure null exit code falls back to 1",
+			details: event.EventDetails{
+				ID:      "job-1",
+				Status:  "completed",
+				Success: boolPtr(false),
+				Result:  "old alpamon output",
+			},
+			wantStdoutLine:  "old alpamon output",
+			wantStderrEmpty: true,
+			wantExitCode:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdoutLine, stderrLine, exitCode := logsCommandOutcome(tt.details)
+
+			assert.Equal(t, tt.wantStdoutLine, stdoutLine, "stdout line")
+			assert.Equal(t, tt.wantExitCode, exitCode, "exit code")
+
+			if tt.wantStderrEmpty {
+				assert.Empty(t, stderrLine, "stderr should be empty")
+			} else {
+				for _, sub := range tt.wantStderrContains {
+					assert.Contains(t, stderrLine, sub, "stderr should contain %q", sub)
+				}
+				if len(stderrLine) > 0 {
+					assert.Equal(t, '\n', rune(stderrLine[len(stderrLine)-1]), "stderr should end with newline")
+				}
+			}
+		})
+	}
+}

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -137,6 +137,20 @@ func TestLogsCommandOutcome(t *testing.T) {
 			wantStderrEmpty: true,
 			wantExitCode:    1,
 		},
+		{
+			name:            "success status with nil Success",
+			details:         event.EventDetails{ID: "job-1", Status: "success", Result: "ok"},
+			wantStdoutLine:  "ok",
+			wantStderrEmpty: true,
+			wantExitCode:    0,
+		},
+		{
+			name:               "unrecognised terminal status with nil Success exits 1",
+			details:            event.EventDetails{ID: "job-1", Status: "denied"},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"unrecognised status", "denied"},
+			wantExitCode:       1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -11,14 +11,14 @@ func boolPtr(b bool) *bool    { return &b }
 func intPtr(i int) *int       { return &i }
 func strPtr(s string) *string { return &s }
 
-func TestIsRunning(t *testing.T) {
+func TestIsRunningStatus(t *testing.T) {
 	running := []string{"queued", "scheduled", "delivered", "verifying", "running", "acked"}
 	for _, s := range running {
-		assert.True(t, isRunning(s), "expected %q to be running", s)
+		assert.True(t, event.IsRunningStatus(s), "expected %q to be running", s)
 	}
 	terminal := []string{"completed", "success", "stuck", "error", "cancelled"}
 	for _, s := range terminal {
-		assert.False(t, isRunning(s), "expected %q to be terminal", s)
+		assert.False(t, event.IsRunningStatus(s), "expected %q to be terminal", s)
 	}
 }
 
@@ -71,6 +71,20 @@ func TestLogsCommandOutcome(t *testing.T) {
 			details:            event.EventDetails{ID: "job-1", Status: "stuck", ErrorPhase: strPtr("agent_timeout")},
 			wantStdoutLine:     "",
 			wantStderrContains: []string{"agent_timeout"},
+			wantExitCode:       1,
+		},
+		{
+			name:               "cancelled",
+			details:            event.EventDetails{ID: "job-1", Status: "cancelled"},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"cancelled"},
+			wantExitCode:       1,
+		},
+		{
+			name:               "cancelled with phase",
+			details:            event.EventDetails{ID: "job-1", Status: "cancelled", ErrorPhase: strPtr("agent_disconnected")},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"agent_disconnected"},
 			wantExitCode:       1,
 		},
 		{

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -70,7 +70,7 @@ func TestLogsCommandOutcome(t *testing.T) {
 			name:               "stuck with agent_timeout phase",
 			details:            event.EventDetails{ID: "job-1", Status: "stuck", ErrorPhase: strPtr("agent_timeout")},
 			wantStdoutLine:     "",
-			wantStderrContains: []string{"agent_timeout"},
+			wantStderrContains: []string{"agent_timeout", "status=stuck"},
 			wantExitCode:       1,
 		},
 		{
@@ -84,7 +84,7 @@ func TestLogsCommandOutcome(t *testing.T) {
 			name:               "cancelled with phase",
 			details:            event.EventDetails{ID: "job-1", Status: "cancelled", ErrorPhase: strPtr("agent_disconnected")},
 			wantStdoutLine:     "",
-			wantStderrContains: []string{"agent_disconnected"},
+			wantStderrContains: []string{"agent_disconnected", "status=cancelled"},
 			wantExitCode:       1,
 		},
 		{
@@ -95,7 +95,7 @@ func TestLogsCommandOutcome(t *testing.T) {
 				ErrorPhase: strPtr("agent_disconnected"),
 			},
 			wantStdoutLine:     "",
-			wantStderrContains: []string{"agent_disconnected"},
+			wantStderrContains: []string{"agent_disconnected", "status=error"},
 			wantExitCode:       1,
 		},
 		{

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -14,6 +14,7 @@ type RemoteExecArgs struct {
 	OutputFormat  string
 	Server        string
 	Command       string
+	Detach        bool
 	ShowHelp      bool
 	Err           string
 }
@@ -35,6 +36,7 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 	var (
 		username, groupname, workSessionID, outputFormat, server string
 		commandParts                                              []string
+		detach                                                    bool
 	)
 
 	for i := 0; i < len(args); i++ {
@@ -94,6 +96,8 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 			if outputFormat == "" {
 				return RemoteExecArgs{Err: "--output requires a value (table|json)"}
 			}
+		case arg == "--detach":
+			detach = true
 		case strings.HasPrefix(arg, "-"):
 			return RemoteExecArgs{Err: "unknown flag: " + arg}
 		default:
@@ -117,6 +121,7 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 		OutputFormat:  outputFormat,
 		Server:        server,
 		Command:       ShellJoin(commandParts),
+		Detach:        detach,
 	}
 }
 

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -96,8 +96,10 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 			if outputFormat == "" {
 				return RemoteExecArgs{Err: "--output requires a value (table|json)"}
 			}
-		case arg == "--detach" || strings.HasPrefix(arg, "--detach="):
+		case arg == "--detach":
 			detach = true
+		case strings.HasPrefix(arg, "--detach="):
+			return RemoteExecArgs{Err: "--detach does not accept a value; use --detach alone"}
 		case strings.HasPrefix(arg, "-"):
 			return RemoteExecArgs{Err: "unknown flag: " + arg}
 		default:

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -96,7 +96,7 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 			if outputFormat == "" {
 				return RemoteExecArgs{Err: "--output requires a value (table|json)"}
 			}
-		case arg == "--detach":
+		case arg == "--detach" || strings.HasPrefix(arg, "--detach="):
 			detach = true
 		case strings.HasPrefix(arg, "-"):
 			return RemoteExecArgs{Err: "unknown flag: " + arg}

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -639,6 +639,13 @@ func TestParseRemoteExecArgs_DetachFlag(t *testing.T) {
 			wantServer:  "server",
 			wantCommand: "--detach",
 		},
+		{
+			name:        "--detach=true equals-form",
+			args:        []string{"--detach=true", "server", "apt", "upgrade"},
+			wantDetach:  true,
+			wantServer:  "server",
+			wantCommand: "apt upgrade",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -603,6 +603,54 @@ func TestParseRemoteExecArgs_OutputFlagEmptyValue(t *testing.T) {
 	assert.NotEmpty(t, result.Err)
 }
 
+func TestParseRemoteExecArgs_DetachFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantDetach  bool
+		wantServer  string
+		wantCommand string
+	}{
+		{
+			name:        "--detach before server",
+			args:        []string{"--detach", "server", "apt", "upgrade"},
+			wantDetach:  true,
+			wantServer:  "server",
+			wantCommand: "apt upgrade",
+		},
+		{
+			name:        "--detach combined with -u",
+			args:        []string{"--detach", "-u", "root", "server", "apt", "upgrade"},
+			wantDetach:  true,
+			wantServer:  "server",
+			wantCommand: "apt upgrade",
+		},
+		{
+			name:        "no --detach flag",
+			args:        []string{"server", "ls"},
+			wantDetach:  false,
+			wantServer:  "server",
+			wantCommand: "ls",
+		},
+		{
+			name:        "--detach after server is treated as command arg",
+			args:        []string{"server", "--detach"},
+			wantDetach:  false,
+			wantServer:  "server",
+			wantCommand: "--detach",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseRemoteExecArgs(tt.args)
+			assert.Equal(t, tt.wantDetach, result.Detach, "Detach")
+			assert.Equal(t, tt.wantServer, result.Server, "Server")
+			assert.Equal(t, tt.wantCommand, result.Command, "Command")
+		})
+	}
+}
+
 func TestParseRemoteExecArgs_Errors(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -639,13 +639,6 @@ func TestParseRemoteExecArgs_DetachFlag(t *testing.T) {
 			wantServer:  "server",
 			wantCommand: "--detach",
 		},
-		{
-			name:        "--detach=true equals-form",
-			args:        []string{"--detach=true", "server", "apt", "upgrade"},
-			wantDetach:  true,
-			wantServer:  "server",
-			wantCommand: "apt upgrade",
-		},
 	}
 
 	for _, tt := range tests {
@@ -698,6 +691,11 @@ func TestParseRemoteExecArgs_Errors(t *testing.T) {
 			name:        "--groupname as last arg with no value",
 			args:        []string{"--groupname"},
 			expectedErr: "flag needs an argument: --groupname",
+		},
+		{
+			name:        "--detach=VALUE equals-form is rejected",
+			args:        []string{"--detach=true", "server", "apt", "upgrade"},
+			expectedErr: "--detach does not accept a value; use --detach alone",
 		},
 	}
 

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -97,7 +97,6 @@ func clientTimeoutLine() string {
 	return fmt.Sprintf("%s: [%s] %s\n", utils.Red("Error"), phase, event.DescribePhase(phase))
 }
 
-// detachResultLines returns the stdout line (job ID) and the stderr hint printed after a detached job is submitted.
 func detachResultLines(jobID string) (string, string) {
 	return fmt.Sprintf("Job submitted: %s", jobID),
 		fmt.Sprintf("Run `alpacon exec logs %s` to check the result.", jobID)

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -97,6 +97,12 @@ func clientTimeoutLine() string {
 	return fmt.Sprintf("%s: [%s] %s\n", utils.Red("Error"), phase, event.DescribePhase(phase))
 }
 
+// detachResultLines returns the two stdout lines printed after a detached job is submitted.
+func detachResultLines(jobID string) (string, string) {
+	return fmt.Sprintf("Job submitted: %s", jobID),
+		fmt.Sprintf("Run `alpacon exec logs %s` to check the result.", jobID)
+}
+
 // remoteCommandOutcome is the testable core of HandleCommandResult's
 // RemoteCommandError branch. stderrLine already includes its trailing newline.
 func remoteCommandOutcome(result string, remoteErr *event.RemoteCommandError) (stdoutLine, stderrLine string, exitCode int) {

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -97,7 +97,7 @@ func clientTimeoutLine() string {
 	return fmt.Sprintf("%s: [%s] %s\n", utils.Red("Error"), phase, event.DescribePhase(phase))
 }
 
-// detachResultLines returns the two stdout lines printed after a detached job is submitted.
+// detachResultLines returns the stdout line (job ID) and the stderr hint printed after a detached job is submitted.
 func detachResultLines(jobID string) (string, string) {
 	return fmt.Sprintf("Job submitted: %s", jobID),
 		fmt.Sprintf("Run `alpacon exec logs %s` to check the result.", jobID)

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -123,3 +123,9 @@ func TestRemoteCommandOutcome(t *testing.T) {
 		})
 	}
 }
+
+func TestDetachResultLines(t *testing.T) {
+	line1, line2 := detachResultLines("a1b2c3d4-1234-5678-abcd-000000000000")
+	assert.Equal(t, "Job submitted: a1b2c3d4-1234-5678-abcd-000000000000", line1)
+	assert.Equal(t, "Run `alpacon exec logs a1b2c3d4-1234-5678-abcd-000000000000` to check the result.", line2)
+}


### PR DESCRIPTION
## Overview

Adds `--detach` flag and `exec logs` subcommand to `alpacon exec`.
Commands can now be submitted asynchronously and their results retrieved later by job ID.

## Usage

**Submit a command (returns immediately)**
```
alpacon exec --detach web-editor -- apt-get update
# stdout: Job submitted: <UUID>
# stderr: Run `alpacon exec logs <UUID>` to check the result.
```

**Retrieve the result**
```
alpacon exec logs <UUID>
```

- **Completed**: command output printed to stdout; exits with the remote exit code
- **Still running**: prints "command is still running (status: ...)" to stderr; exits 0
- **Failed** (stuck/error/cancelled): prints error message to stderr; exits 1

**JSON output**
```
alpacon exec --output json --detach web-editor echo hello
# {"job_id": "<UUID>"}
```

> **Note**: `--detach` and other flags must appear before the server name, consistent with `exec [flags] SERVER COMMAND` usage.

## Key changes

### New
- `--detach` flag: submit a command and return the job ID immediately
- `exec logs <JOB_ID>`: single-fetch subcommand to check status or retrieve result
- `event.GetCommandByID()`: fetch a single command by ID
- `event.SubmitCommand()`: extracted from `RunCommand()` for reuse

### Improvements
- `IsRunningStatus()` exported: single source of truth for in-progress status classification, shared by polling and `exec logs`
- Default exec timeout raised to 30 minutes; `ALPACON_EXEC_TIMEOUT` env var allows override
- `cancelled` status now handled (was previously missing)
- Unknown terminal statuses treated as exit 1 consistently in both `RunCommand` and `logsCommandOutcome`
- Fixed timer-reset race: drain `timer.C` before `Reset` to prevent spurious `ClientTimeoutError`
- WorkSession exit code preserved in the detach path

## Tests

- `TestIsRunningStatus`: verifies status classification for all known values
- `TestLogsCommandOutcome`: 13 cases covering completed, running, stuck, cancelled, error, exit code propagation, unknown status
- `TestRunCommand_UnrecognisedTerminalStatusReturnsError`: ensures unknown terminal statuses return an error
- `TestParseRemoteExecArgs`: validates `--detach` and `--detach=VALUE` flag parsing

## Smoke test (manual, against `web-editor`)

```
# 1. Submit detached command
$ ./alpacon exec --detach web-editor echo "hello detach"
Using work-session affcfa45-fd1b-4135-908d-7947c9d3c4d8
Job submitted: d1000d7c-fd44-4206-9143-579e6dab63df
Run `alpacon exec logs d1000d7c-fd44-4206-9143-579e6dab63df` to check the result.

# 2. Retrieve result (completed)
$ ./alpacon exec logs d1000d7c-fd44-4206-9143-579e6dab63df
hello detach

# 3. Submit a long-running command and check while running
$ ./alpacon exec --detach web-editor -- sleep 30
Job submitted: cf50c60e-2b50-4ccc-b66b-796ff51b3c08
$ ./alpacon exec logs cf50c60e-2b50-4ccc-b66b-796ff51b3c08
command is still running (status: running).
Run `alpacon exec logs cf50c60e-2b50-4ccc-b66b-796ff51b3c08` again to check later.

# 4. Failing command (false) — empty output, exit code 1
$ ./alpacon exec --detach web-editor -- false
Job submitted: 3cfce49f-ca9d-4255-ae2c-811d993503c2
$ ./alpacon exec logs 3cfce49f-ca9d-4255-ae2c-811d993503c2; echo $?
1

# 5. JSON output
$ ./alpacon exec --output json --detach web-editor echo "hello json" 2>/dev/null
{
  "job_id": "d0bbd7a8-40e2-47d6-82ca-df97a58bde63"
}
```

Closes #187