### PR TITLE
feat(worksession): improve `create` UX with scope validation and --use

### DIFF
--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -458,6 +458,35 @@ func TestPollCommandExecution_TerminalStatusReturnsBeforeTimeout(t *testing.T) {
 	assert.Equal(t, "completed", resp.Status)
 }
 
+func TestRunCommand_401WithDetailSurfacesServerReason(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListResponse[map[string]any]{
+				Count:   1,
+				Results: []map[string]any{{"id": "srv-1", "name": "server-x"}},
+			})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/api/events/commands/"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"detail": "user 'root' on server-x: denied by policy (no matching sudo/role rule)"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := RunCommand(ac, "server-x", "id", "root", "", nil, "ses-abc")
+	require.Error(t, err)
+
+	// Error is wrapped through multiple layers; assert substrings, not exact match.
+	assert.Contains(t, err.Error(), "denied by policy")
+	assert.NotContains(t, err.Error(), "authentication failed")
+	assert.Contains(t, err.Error(), "alpacon login")
+}
+
 func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client/client.go
+++ b/client/client.go
@@ -89,14 +89,36 @@ func getUserPrivileges(isStaff, isSuperuser bool) string {
 	return "general"
 }
 
-func checkAuthStatus(statusCode int) error {
+// checkAuthStatus prefers the server-provided detail so policy denials are
+// not masked as stale-token failures.
+func checkAuthStatus(statusCode int, body []byte) error {
 	switch statusCode {
 	case http.StatusUnauthorized:
+		if msg := extractServerDetail(body); msg != "" {
+			return fmt.Errorf("%s (run 'alpacon login' if your session has expired)", msg)
+		}
 		return errors.New("authentication failed: please run 'alpacon login' again")
 	case http.StatusForbidden:
+		if msg := extractServerDetail(body); msg != "" {
+			return errors.New(msg)
+		}
 		return errors.New("permission denied: you do not have the required privileges for this action")
 	}
 	return nil
+}
+
+func extractServerDetail(body []byte) string {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return ""
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	if detail, ok := parsed["detail"].(string); ok {
+		return strings.TrimSpace(detail)
+	}
+	return ""
 }
 
 func (ac *AlpaconClient) SetWebsocketHeader() http.Header {
@@ -139,17 +161,7 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := checkAuthStatus(resp.StatusCode); err != nil {
-		return nil, err
-	}
-
-	contentType := resp.Header.Get("Content-Type")
-	// Check for non-empty and non-JSON content types. Empty content type allowed for responses without content (e.g., from PATCH requests).
-	if contentType != "" && !strings.Contains(contentType, "application/json") {
-		return nil, fmt.Errorf("unexpected response from server (HTTP %d, Content-Type: %s)", resp.StatusCode, contentType)
-	}
-
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := readAndValidateResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -163,6 +175,25 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 	}
 
 	return respBody, nil
+}
+
+// readAndValidateResponse reads the body, surfaces 401/403 with server detail,
+// and rejects non-JSON content types.
+func readAndValidateResponse(resp *http.Response) ([]byte, error) {
+	body, readErr := io.ReadAll(resp.Body)
+	if err := checkAuthStatus(resp.StatusCode, body); err != nil {
+		return nil, err
+	}
+	if readErr != nil {
+		return nil, readErr
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	// Empty content type is allowed for responses without content (e.g. PATCH).
+	if contentType != "" && !strings.Contains(contentType, "application/json") {
+		return nil, fmt.Errorf("unexpected response from server (HTTP %d, Content-Type: %s)", resp.StatusCode, contentType)
+	}
+	return body, nil
 }
 
 // Get Request to Alpacon Server
@@ -222,17 +253,7 @@ func (ac *AlpaconClient) SendMultipartRequest(url string, multiPartWriter *multi
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := checkAuthStatus(resp.StatusCode); err != nil {
-		return nil, err
-	}
-
-	contentType := resp.Header.Get("Content-Type")
-	// Check for non-empty and non-JSON content types. Empty content type allowed for responses without content (e.g., from PATCH requests).
-	if contentType != "" && !strings.Contains(contentType, "application/json") {
-		return nil, fmt.Errorf("unexpected response from server (HTTP %d, Content-Type: %s)", resp.StatusCode, contentType)
-	}
-
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := readAndValidateResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -268,9 +289,10 @@ func (ac *AlpaconClient) SendGetRequestForDownload(url string) (*http.Response, 
 		return nil, err
 	}
 
-	if err := checkAuthStatus(resp.StatusCode); err != nil {
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		return nil, err
+		return nil, checkAuthStatus(resp.StatusCode, body)
 	}
 
 	return resp, nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -19,7 +19,7 @@ func newTestClient(baseURL string) *AlpaconClient {
 	}
 }
 
-func TestSendRequest_401ReturnsAuthError(t *testing.T) {
+func TestSendRequest_401SurfacesServerDetail(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -29,14 +29,37 @@ func TestSendRequest_401ReturnsAuthError(t *testing.T) {
 
 	ac := newTestClient(ts.URL)
 	_, err := ac.SendGetRequest("/api/test/")
+	assert.ErrorContains(t, err, "invalid token")
+	assert.ErrorContains(t, err, "alpacon login")
+}
+
+func TestSendRequest_401WithoutBodyFallsBackToLoginHint(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
 	assert.ErrorContains(t, err, "authentication failed")
 }
 
-func TestSendRequest_403ReturnsForbiddenError(t *testing.T) {
+func TestSendRequest_403SurfacesServerDetail(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"detail": "forbidden"}`))
+		_, _ = w.Write([]byte(`{"detail": "missing scope: sudo"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	assert.ErrorContains(t, err, "missing scope: sudo")
+}
+
+func TestSendRequest_403WithoutBodyFallsBackToGenericMessage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
 	}))
 	defer ts.Close()
 
@@ -101,7 +124,7 @@ func TestLoadCurrentUser_GeneralPrivileges(t *testing.T) {
 	assert.Equal(t, "general", ac.Privileges)
 }
 
-func TestLoadCurrentUser_401ReturnsAuthError(t *testing.T) {
+func TestLoadCurrentUser_401SurfacesServerDetail(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -111,7 +134,8 @@ func TestLoadCurrentUser_401ReturnsAuthError(t *testing.T) {
 
 	ac := newTestClient(ts.URL)
 	err := ac.LoadCurrentUser()
-	assert.ErrorContains(t, err, "authentication failed")
+	assert.ErrorContains(t, err, "invalid token")
+	assert.ErrorContains(t, err, "alpacon login")
 	assert.Empty(t, ac.Username)
 	assert.Empty(t, ac.Privileges)
 }
@@ -212,7 +236,7 @@ func TestLoadCurrentUser_ErrorIsCachedOnFailure(t *testing.T) {
 	err1 := ac.LoadCurrentUser()
 	err2 := ac.LoadCurrentUser() // second call must return cached error without hitting server
 
-	assert.ErrorContains(t, err1, "authentication failed")
-	assert.ErrorContains(t, err2, "authentication failed")
+	assert.ErrorContains(t, err1, "invalid token")
+	assert.ErrorContains(t, err2, "invalid token")
 	assert.Equal(t, 1, callCount, "LoadCurrentUser must hit the server exactly once even on failure")
 }

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
+
+var validScopePresets = []string{"command", "editor", "sudo", "tunnel", "webftp", "websh"}
 
 var (
 	purpose       string
@@ -78,6 +81,9 @@ var workSessionCreateCmd = &cobra.Command{
 		}
 		if len(scopeList) == 0 {
 			utils.CliErrorWithExit("--scope must contain at least one valid scope.")
+		}
+		if err := validateScopeEnum(scopeList); err != nil {
+			utils.CliErrorWithExit("Invalid --scope: %s", err)
 		}
 		if err := validateAgentScopes(requesterType, scopeList); err != nil {
 			utils.CliErrorWithExit("Invalid --scope: %s", err)
@@ -157,6 +163,29 @@ func parseExpiryFlag(expiresIn, expiresAt string) (string, error) {
 	return expiresAt, nil
 }
 
+// validateScopeEnum rejects scopes not in validScopePresets and lists the
+// allowed values in the error message. The caller is expected to prefix the
+// error with the relevant flag name (e.g. "Invalid --scope: ...").
+func validateScopeEnum(scopes []string) error {
+	allowed := make(map[string]struct{}, len(validScopePresets))
+	for _, s := range validScopePresets {
+		allowed[s] = struct{}{}
+	}
+	var unknown []string
+	for _, s := range scopes {
+		if _, ok := allowed[s]; !ok {
+			unknown = append(unknown, s)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("%s. valid: %s",
+		strings.Join(unknown, ", "),
+		strings.Join(validScopePresets, ", "))
+}
+
 // validateAgentScopes returns an error when requester_type is "agent" and
 // scopes contains "websh", which the server disallows.
 func validateAgentScopes(requesterType string, scopes []string) error {
@@ -215,7 +244,7 @@ func pollForApproval(ac *client.AlpaconClient, id string) error {
 
 func init() {
 	workSessionCreateCmd.Flags().StringVar(&purpose, "purpose", "", "Session purpose")
-	workSessionCreateCmd.Flags().StringSliceVar(&createScopes, "scope", nil, "Scopes to request (repeatable; comma-separated values also accepted)")
+	workSessionCreateCmd.Flags().StringSliceVar(&createScopes, "scope", nil, "Scopes to request. Valid: command, editor, sudo, tunnel, webftp, websh (repeatable; comma-separated values also accepted)")
 	workSessionCreateCmd.Flags().StringSliceVar(&createServers, "server", nil, "Target server names (repeatable; comma-separated values also accepted)")
 	workSessionCreateCmd.Flags().StringVar(&expiresIn, "expires-in", "", "Session duration (e.g. 1h, 2h, 4h)")
 	workSessionCreateCmd.Flags().StringVar(&expiresAt, "expires-at", "", "Absolute expiry time (RFC3339)")

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alpacax/alpacon-cli/api/server"
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -18,20 +19,29 @@ import (
 var validScopePresets = []string{"command", "editor", "sudo", "tunnel", "webftp", "websh"}
 
 var (
-	purpose       string
-	createScopes  []string
-	createServers []string
-	expiresIn     string
-	expiresAt     string
-	requesterType string
-	waitApproval  bool
+	purpose        string
+	createScopes   []string
+	createServers  []string
+	expiresIn      string
+	expiresAt      string
+	requesterType  string
+	waitApproval   bool
+	useAfterCreate bool
 )
 
 var workSessionCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new work session",
+	Long: `Create a new work session.
+
+Pass --use to set the new session as the workspace's active session, so subsequent
+exec/websh/cp/tunnel commands attach to it without --work-session. When approval is
+required, combine --use with --wait — the session is attached once it reaches the
+active state.`,
 	Example: `  alpacon work-session create --purpose "nginx fix" --scope command,websh --server web-01 --expires-in 2h
-  alpacon work-session create --purpose "deploy" --scope command --server web-01,db-01 --expires-at 2026-05-09T10:00:00Z --wait`,
+  alpacon work-session create --purpose "deploy" --scope command --server web-01,db-01 --expires-at 2026-05-09T10:00:00Z --wait
+  alpacon work-session create --purpose "hotfix" --scope command --server web-01 --expires-in 1h --use
+  alpacon work-session create --purpose "deploy" --scope command --server web-01 --expires-in 2h --wait --use`,
 	Run: func(cmd *cobra.Command, args []string) {
 		purpose = strings.TrimSpace(purpose)
 		if purpose == "" {
@@ -71,6 +81,18 @@ var workSessionCreateCmd = &cobra.Command{
 
 		if requesterType != "user" && requesterType != "agent" {
 			utils.CliErrorWithExit("Invalid --requester-type %q: must be \"user\" or \"agent\".", requesterType)
+		}
+
+		// Pre-validate --use to avoid creating an orphan server-side session that we
+		// can't attach to the workspace.
+		if useAfterCreate {
+			if requesterType == "agent" {
+				utils.CliErrorWithExit("--use cannot be combined with --requester-type=agent (agent sessions are not workspace-attachable).")
+			}
+			cfg, err := config.LoadConfig()
+			if err != nil || cfg.WorkspaceName == "" {
+				utils.CliErrorWithExit("--use requires an active workspace. Run 'alpacon login' first.")
+			}
 		}
 
 		var scopeList []string
@@ -127,13 +149,64 @@ var workSessionCreateCmd = &cobra.Command{
 
 		utils.CliSuccess("Work session created: %s (status: %s)", session.ID, session.Status)
 
-		if waitApproval {
-			if err := pollForApproval(ac, session.ID); err != nil {
-				utils.CliErrorWithExit("%s", err)
+		// Phase 1: post-create decision. Cases without an explicit return delegate to
+		// the --wait branch below (or exit immediately when --wait is not set).
+		switch decideUseAction(session.Status, useAfterCreate) {
+		case useDecisionUseNow:
+			attachActiveOrExit(ac, session.ID, "Work session created (%s) but failed to set as active: %s. Run 'work-session use %s' to retry.", "")
+			return
+		case useDecisionSkipScheduled:
+			if !waitApproval {
+				utils.CliInfo("Session is scheduled to activate. Run 'work-session use %s' once active.", session.ID)
+				return
 			}
-			utils.CliSuccess("Work session %s approved.", session.ID)
+		case useDecisionErrorNeedsWait:
+			if !waitApproval {
+				utils.CliErrorWithExit("--use requires the session to be active. Pass --wait to wait for approval, or run 'work-session use %s' after approval.", session.ID)
+			}
 		}
+
+		if !waitApproval {
+			return
+		}
+
+		// Phase 2: poll. With --use we wait for active; otherwise approved is enough.
+		if err := pollForApproval(ac, session.ID, useAfterCreate); err != nil {
+			utils.CliErrorWithExit("%s", err)
+		}
+
+		if !useAfterCreate {
+			utils.CliSuccess("Work session %s approved.", session.ID)
+			return
+		}
+
+		// Phase 3: --wait --use. pollForApproval(untilActive=true) guarantees status reached active.
+		attachActiveOrExit(ac, session.ID, "Work session %s approved but failed to set as active: %s. Run 'work-session use %s' to retry.", fmt.Sprintf("Work session %s approved. ", session.ID))
 	},
+}
+
+type useDecision int
+
+const (
+	useDecisionNoop useDecision = iota
+	useDecisionUseNow
+	useDecisionErrorNeedsWait
+	useDecisionSkipScheduled
+)
+
+// attachActiveOrExit calls RunUse and prints either a success line (with description if present)
+// or exits with the supplied error format (which receives session ID, error, session ID in order).
+// successPrefix is prepended to the success line so callers can distinguish phases.
+func attachActiveOrExit(ac *client.AlpaconClient, id, errFmt, successPrefix string) {
+	desc, err := RunUse(ac, id)
+	if err != nil {
+		utils.CliErrorWithExit(errFmt, id, err, id)
+	}
+	suffix := ""
+	if desc != "" {
+		suffix = fmt.Sprintf(" (%s)", desc)
+	}
+	utils.CliSuccess("%sActive work-session set to %s%s.", successPrefix, id, suffix)
 }
 
 // parseExpiryFlag validates the --expires-in / --expires-at mutual exclusion
@@ -186,6 +259,20 @@ func validateScopeEnum(scopes []string) error {
 		strings.Join(validScopePresets, ", "))
 }
 
+func decideUseAction(status string, useEnabled bool) useDecision {
+	if !useEnabled {
+		return useDecisionNoop
+	}
+	switch status {
+	case activeWorkSessionStatus:
+		return useDecisionUseNow
+	case approvedWorkSessionStatus:
+		return useDecisionSkipScheduled
+	default:
+		return useDecisionErrorNeedsWait
+	}
+}
+
 // validateAgentScopes returns an error when requester_type is "agent" and
 // scopes contains "websh", which the server disallows.
 func validateAgentScopes(requesterType string, scopes []string) error {
@@ -211,9 +298,10 @@ func splitCSV(s string) []string {
 	return result
 }
 
-// pollForApproval polls every 10 seconds until the session is approved/active,
-// a terminal status is reached (rejected/expired/revoked/completed), or attempts are exhausted.
-func pollForApproval(ac *client.AlpaconClient, id string) error {
+// pollForApproval polls every 10 seconds until the session reaches a terminal state.
+// untilActive=false returns on approved or active; untilActive=true returns only on
+// active (continues polling on approved until the server auto-activates).
+func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) error {
 	const maxAttempts = 30
 	const interval = 10 * time.Second
 
@@ -223,15 +311,19 @@ func pollForApproval(ac *client.AlpaconClient, id string) error {
 			return fmt.Errorf("polling failed: %w", err)
 		}
 		switch s.Status {
-		case "approved", "active":
+		case activeWorkSessionStatus:
 			return nil
-		case "rejected":
+		case approvedWorkSessionStatus:
+			if !untilActive {
+				return nil
+			}
+		case rejectedWorkSessionStatus:
 			return errors.New("work session was rejected")
-		case "expired":
+		case expiredWorkSessionStatus:
 			return errors.New("work session expired while waiting for approval")
-		case "revoked":
+		case revokedWorkSessionStatus:
 			return errors.New("work session was revoked")
-		case "completed":
+		case completedWorkSessionStatus:
 			return errors.New("work session was completed unexpectedly")
 		}
 		utils.CliInfo("Waiting for approval... (attempt %d/%d)", attempt, maxAttempts)
@@ -249,6 +341,7 @@ func init() {
 	workSessionCreateCmd.Flags().StringVar(&expiresIn, "expires-in", "", "Session duration (e.g. 1h, 2h, 4h)")
 	workSessionCreateCmd.Flags().StringVar(&expiresAt, "expires-at", "", "Absolute expiry time (RFC3339)")
 	workSessionCreateCmd.Flags().StringVar(&requesterType, "requester-type", "user", "Requester type: user or agent")
-	workSessionCreateCmd.Flags().BoolVar(&waitApproval, "wait", false, "Poll until the session is approved, then exit")
+	workSessionCreateCmd.Flags().BoolVar(&waitApproval, "wait", false, "Poll until the session is approved, then exit (does not set as active; combine with --use to attach automatically)")
+	workSessionCreateCmd.Flags().BoolVar(&useAfterCreate, "use", false, "Set the created session as the workspace's active session (requires status to reach 'active'; combine with --wait when approval is needed)")
 	workSessionCreateCmd.MarkFlagsMutuallyExclusive("expires-in", "expires-at")
 }

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -153,16 +153,16 @@ active state.`,
 		// the --wait branch below (or exit immediately when --wait is not set).
 		switch decideUseAction(session.Status, useAfterCreate) {
 		case useDecisionUseNow:
-			attachActiveOrExit(ac, session.ID, "Work session created (%s) but failed to set as active: %s. Run 'work-session use %s' to retry.", "")
+			attachActiveOrExit(ac, session.ID, "Work session created (%s) but failed to set as active: %s. Run 'alpacon work-session use %s' to retry.", "")
 			return
 		case useDecisionSkipScheduled:
 			if !waitApproval {
-				utils.CliInfo("Session is scheduled to activate. Run 'work-session use %s' once active.", session.ID)
+				utils.CliInfo("Session is scheduled to activate. Run 'alpacon work-session use %s' once active.", session.ID)
 				return
 			}
 		case useDecisionErrorNeedsWait:
 			if !waitApproval {
-				utils.CliErrorWithExit("--use requires the session to be active. Pass --wait to wait for approval, or run 'work-session use %s' after approval.", session.ID)
+				utils.CliErrorWithExit("--use requires the session to be active. Pass --wait to wait for approval, or run 'alpacon work-session use %s' after approval.", session.ID)
 			}
 		}
 
@@ -181,7 +181,7 @@ active state.`,
 		}
 
 		// Phase 3: --wait --use. pollForApproval(untilActive=true) guarantees status reached active.
-		attachActiveOrExit(ac, session.ID, "Work session %s approved but failed to set as active: %s. Run 'work-session use %s' to retry.", fmt.Sprintf("Work session %s approved. ", session.ID))
+		attachActiveOrExit(ac, session.ID, "Work session %s approved but failed to set as active: %s. Run 'alpacon work-session use %s' to retry.", fmt.Sprintf("Work session %s approved. ", session.ID))
 	},
 }
 

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -16,6 +16,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	pollMaxAttempts   = 30
+	pollInterval      = 10 * time.Second
+	waitMsgApproval   = "Waiting for approval..."
+	waitMsgActivation = "Waiting for activation..."
+)
+
 var validScopePresets = []string{"command", "editor", "sudo", "tunnel", "webftp", "websh"}
 
 var (
@@ -302,10 +309,7 @@ func splitCSV(s string) []string {
 // untilActive=false returns on approved or active; untilActive=true returns only on
 // active (continues polling on approved until the server auto-activates).
 func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) error {
-	const maxAttempts = 30
-	const interval = 10 * time.Second
-
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
+	for attempt := 1; attempt <= pollMaxAttempts; attempt++ {
 		s, err := wsapi.GetWorkSession(ac, id)
 		if err != nil {
 			return fmt.Errorf("polling failed: %w", err)
@@ -326,16 +330,16 @@ func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) erro
 		case completedWorkSessionStatus:
 			return errors.New("work session was completed unexpectedly")
 		}
-		waitMsg := "Waiting for approval..."
+		waitMsg := waitMsgApproval
 		if s.Status == approvedWorkSessionStatus {
-			waitMsg = "Waiting for activation..."
+			waitMsg = waitMsgActivation
 		}
-		utils.CliInfo("%s (attempt %d/%d)", waitMsg, attempt, maxAttempts)
-		if attempt < maxAttempts {
-			time.Sleep(interval)
+		utils.CliInfo("%s (attempt %d/%d)", waitMsg, attempt, pollMaxAttempts)
+		if attempt < pollMaxAttempts {
+			time.Sleep(pollInterval)
 		}
 	}
-	return fmt.Errorf("timed out waiting for approval after %d attempts", maxAttempts)
+	return fmt.Errorf("timed out waiting for approval after %d attempts", pollMaxAttempts)
 }
 
 func init() {

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -36,7 +36,7 @@ var workSessionCreateCmd = &cobra.Command{
 
 Pass --use to set the new session as the workspace's active session, so subsequent
 exec/websh/cp/tunnel commands attach to it without --work-session. When approval is
-required, combine --use with --wait — the session is attached once it reaches the
+required, combine --use with --wait. The session is attached once it reaches the
 active state.`,
 	Example: `  alpacon work-session create --purpose "nginx fix" --scope command,websh --server web-01 --expires-in 2h
   alpacon work-session create --purpose "deploy" --scope command --server web-01,db-01 --expires-at 2026-05-09T10:00:00Z --wait
@@ -326,7 +326,11 @@ func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) erro
 		case completedWorkSessionStatus:
 			return errors.New("work session was completed unexpectedly")
 		}
-		utils.CliInfo("Waiting for approval... (attempt %d/%d)", attempt, maxAttempts)
+		waitMsg := "Waiting for approval..."
+		if s.Status == approvedWorkSessionStatus {
+			waitMsg = "Waiting for activation..."
+		}
+		utils.CliInfo("%s (attempt %d/%d)", waitMsg, attempt, maxAttempts)
 		if attempt < maxAttempts {
 			time.Sleep(interval)
 		}

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -72,6 +72,62 @@ func TestValidateAgentScopes_UserWithWebsh(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidateScopeEnum(t *testing.T) {
+	tests := []struct {
+		name        string
+		scopes      []string
+		wantErr     bool
+		wantSubstrs []string
+	}{
+		{
+			name:    "empty input passes (handled by other validation)",
+			scopes:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "single valid scope",
+			scopes:  []string{"command"},
+			wantErr: false,
+		},
+		{
+			name:    "multiple valid scopes",
+			scopes:  []string{"command", "websh", "sudo"},
+			wantErr: false,
+		},
+		{
+			name:        "single unknown scope",
+			scopes:      []string{"foo"},
+			wantErr:     true,
+			wantSubstrs: []string{"foo", "valid:", "command", "editor", "sudo", "tunnel", "webftp", "websh"},
+		},
+		{
+			name:        "mixed valid and unknown scopes, alphabetically sorted in message",
+			scopes:      []string{"command", "zzz", "aaa"},
+			wantErr:     true,
+			wantSubstrs: []string{"aaa, zzz", "valid:"},
+		},
+		{
+			name:        "case-sensitive: capitalized is rejected",
+			scopes:      []string{"Command"},
+			wantErr:     true,
+			wantSubstrs: []string{"Command", "valid:"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateScopeEnum(tt.scopes)
+			if tt.wantErr {
+				assert.Error(t, err)
+				for _, s := range tt.wantSubstrs {
+					assert.Contains(t, err.Error(), s)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestSplitCSV(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -128,6 +128,31 @@ func TestValidateScopeEnum(t *testing.T) {
 	}
 }
 
+func TestDecideUseAction(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		useEnabled bool
+		want       useDecision
+	}{
+		{name: "use disabled with pending status", status: "pending", useEnabled: false, want: useDecisionNoop},
+		{name: "use disabled with active status", status: "active", useEnabled: false, want: useDecisionNoop},
+		{name: "use enabled with active status (superuser or post-poll)", status: "active", useEnabled: true, want: useDecisionUseNow},
+		{name: "use enabled with pending status (needs --wait)", status: "pending", useEnabled: true, want: useDecisionErrorNeedsWait},
+		{name: "use enabled with approved status (scheduled starts_at)", status: "approved", useEnabled: true, want: useDecisionSkipScheduled},
+		{name: "use enabled with rejected status (terminal)", status: "rejected", useEnabled: true, want: useDecisionErrorNeedsWait},
+		{name: "use enabled with expired status (terminal)", status: "expired", useEnabled: true, want: useDecisionErrorNeedsWait},
+		{name: "use enabled with revoked status (terminal)", status: "revoked", useEnabled: true, want: useDecisionErrorNeedsWait},
+		{name: "use enabled with completed status (terminal)", status: "completed", useEnabled: true, want: useDecisionErrorNeedsWait},
+		{name: "use enabled with empty status (defensive)", status: "", useEnabled: true, want: useDecisionErrorNeedsWait},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, decideUseAction(tt.status, tt.useEnabled))
+		})
+	}
+}
+
 func TestSplitCSV(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/cmd/worksession/worksession_use.go
+++ b/cmd/worksession/worksession_use.go
@@ -10,7 +10,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const activeWorkSessionStatus = "active"
+const (
+	activeWorkSessionStatus    = "active"
+	approvedWorkSessionStatus  = "approved"
+	rejectedWorkSessionStatus  = "rejected"
+	expiredWorkSessionStatus   = "expired"
+	revokedWorkSessionStatus   = "revoked"
+	completedWorkSessionStatus = "completed"
+)
 
 var unsetActiveWorkSession bool
 


### PR DESCRIPTION
## Summary

Improves `alpacon work-session create` for scriptable and AI-agent workflows. Refs alpacax/alpacon-cli#188 (findings #1 and #2).

- **Finding #1 — Discoverable `--scope` values:** the flag's help text now lists the valid presets (`command, editor, sudo, tunnel, webftp, websh`), and the client rejects unknown scopes before the API call with the same enum in the error message.
- **Finding #2 — `--use` attaches the created session:** new `--use` flag sets the new session as the workspace's active session, so subsequent `exec`/`websh`/`cp`/`tunnel` commands attach automatically without `--work-session`. Combine `--use` with `--wait` for sessions that need approval — `pollForApproval` then waits specifically for `active` (not just `approved`) to eliminate the approved→active race. Pre-validation rejects `--use` without an active workspace or with `--requester-type=agent` to avoid orphan sessions.
- **Side fix:** the HTTP client now surfaces server-provided `detail` on 401/403 responses instead of a bare status code, which makes login/permission failures debuggable.

Not in scope: finding #4 (`sudo` scope discoverability and non-interactive `exec` sudo behavior) — to be handled separately.

## Test plan

- [x] `go test -race ./...` passes locally
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `create` without `--use` behaves as before (regression-safe)
- [x] Manual: `create --use` on a session that comes back `active` (superuser, no `starts_at`) attaches immediately
- [x] Manual: `create --use` on a session that comes back non-active without `--wait` exits 1 with a clear remediation message
- [x] Manual: `create --wait --use` polls until `active`, then attaches
- [x] Manual: `create --use` without an active workspace exits 1 before hitting the API (no orphan session)
- [x] Manual: `create --use --requester-type=agent` is rejected up front
- [x] Manual: `create --scope foo` is rejected client-side with the valid-scopes list in the error