### PR TITLE
feat(worksession): declare sudo bypass policies via CLI for agent flows

### DIFF
--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -65,9 +65,15 @@ type SudoPolicyInline struct {
 }
 
 // WorkSessionUpdateRequest carries the FULL desired sudo policy set (PUT-style):
-// the server deletes any existing policy absent from the list. SudoPolicies is
-// sent even when empty so an explicit empty set clears all policies; callers
-// that only mean to add must echo the existing policies back.
+// the server deletes any existing policy absent from the list. Callers that
+// only mean to add must echo the existing policies back.
+//
+// Note on Go JSON encoding: a nil slice marshals to JSON `null` (treated by
+// the server as "field not provided" → no change). To explicitly clear all
+// policies, pass an explicitly empty slice (`[]SudoPolicyInline{}`), which
+// marshals to `[]`. The current CLI never sends nil here because the update
+// command guards `len(newPolicies) == 0` upstream and always builds the
+// desired slice via `make(...)`.
 type WorkSessionUpdateRequest struct {
 	SudoPolicies []SudoPolicyInline `json:"sudo_policies"`
 }

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -20,6 +20,7 @@ type WorkSession struct {
 	CompletedAt   *time.Time            `json:"completed_at"`
 	AddedAt       time.Time             `json:"added_at"`
 	UpdatedAt     time.Time             `json:"updated_at"`
+	SudoPolicies  []SudoPolicyInline    `json:"sudo_policies"`
 }
 
 type WorkSessionAttributes struct {
@@ -35,11 +36,36 @@ type WorkSessionAttributes struct {
 }
 
 type WorkSessionCreateRequest struct {
-	Description   string   `json:"description"`
-	RequesterType string   `json:"requester_type"`
-	Scopes        []string `json:"scopes"`
-	Servers       []string `json:"servers"`
-	ExpiresAt     string   `json:"expires_at"`
+	Description   string             `json:"description"`
+	RequesterType string             `json:"requester_type"`
+	Scopes        []string           `json:"scopes"`
+	Servers       []string           `json:"servers"`
+	ExpiresAt     string             `json:"expires_at"`
+	SudoPolicies  []SudoPolicyInline `json:"sudo_policies,omitempty"`
+}
+
+// SudoPolicyInline is a sudo policy bound to a work session. It serves three
+// roles: read (when returned on a WorkSession), create (attached at session
+// create time), and modify (sent on update). Commands are the allowed patterns
+// (wildcards permitted); AllowBypassMFA lets matching sudo run without
+// interactive MFA, which is the only way a non-interactive execute-command
+// caller (e.g. an AI agent) can sudo. Users is intentionally omitted — the
+// server binds the policy to the session assignee automatically so it never
+// applies to other workspace users.
+//
+// ID is set only on read and on modify: an update PATCH sends the FULL desired
+// set, so existing policies must be echoed back with their ID (modify in place)
+// alongside new entries without an ID (additions). Omitting an existing policy
+// from the set deletes it, so callers must preserve the current entries.
+type SudoPolicyInline struct {
+	ID             string   `json:"id,omitempty"`
+	Commands       []string `json:"commands"`
+	Reason         string   `json:"reason,omitempty"`
+	AllowBypassMFA bool     `json:"allow_bypass_mfa"`
+}
+
+type WorkSessionUpdateRequest struct {
+	SudoPolicies []SudoPolicyInline `json:"sudo_policies,omitempty"`
 }
 
 type WorkSessionExtendRequest struct {
@@ -60,21 +86,21 @@ type TimelineItem struct {
 	ServerID  *string `json:"server_id"`
 
 	// shared across session-like types (websh_session, tunnel_session, ftp_session)
-	Username  string  `json:"username"`
-	Groupname string  `json:"groupname"`
-	ClosedAt  *string `json:"closed_at"`
-	ClientType string `json:"client_type"`
+	Username   string  `json:"username"`
+	Groupname  string  `json:"groupname"`
+	ClosedAt   *string `json:"closed_at"`
+	ClientType string  `json:"client_type"`
 
 	// command
-	Shell       string   `json:"shell"`
-	Line        string   `json:"line"`
-	Success     *bool    `json:"success"`
-	Denied      bool     `json:"denied"`
-	ElapsedTime float64  `json:"elapsed_time"`
+	Shell       string  `json:"shell"`
+	Line        string  `json:"line"`
+	Success     *bool   `json:"success"`
+	Denied      bool    `json:"denied"`
+	ElapsedTime float64 `json:"elapsed_time"`
 
 	// tunnel_session
-	IsTunnel   bool  `json:"is_tunnel"`
-	TargetPort *int  `json:"target_port"`
+	IsTunnel   bool `json:"is_tunnel"`
+	TargetPort *int `json:"target_port"`
 
 	// file_upload / file_download
 	Name string `json:"name"`

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -64,8 +64,12 @@ type SudoPolicyInline struct {
 	AllowBypassMFA bool     `json:"allow_bypass_mfa"`
 }
 
+// WorkSessionUpdateRequest carries the FULL desired sudo policy set (PUT-style):
+// the server deletes any existing policy absent from the list. SudoPolicies is
+// sent even when empty so an explicit empty set clears all policies; callers
+// that only mean to add must echo the existing policies back.
 type WorkSessionUpdateRequest struct {
-	SudoPolicies []SudoPolicyInline `json:"sudo_policies,omitempty"`
+	SudoPolicies []SudoPolicyInline `json:"sudo_policies"`
 }
 
 type WorkSessionExtendRequest struct {

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -48,8 +48,8 @@ type WorkSessionCreateRequest struct {
 // roles: read (when returned on a WorkSession), create (attached at session
 // create time), and modify (sent on update). Commands are the allowed patterns
 // (wildcards permitted); AllowBypassMFA lets matching sudo run without
-// interactive MFA, which is the only way a non-interactive execute-command
-// caller (e.g. an AI agent) can sudo. Users is intentionally omitted — the
+// interactive MFA, which is the only way a non-interactive caller (e.g. an AI
+// agent running 'exec') can sudo. Users is intentionally omitted — the
 // server binds the policy to the session assignee automatically so it never
 // applies to other workspace users.
 //

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -63,6 +63,22 @@ func CreateWorkSession(ac *client.AlpaconClient, req WorkSessionCreateRequest) (
 	return &session, nil
 }
 
+// UpdateWorkSession PATCHes a work session. Used to attach sudo policies to an
+// existing session (e.g. after an execute-command sudo was denied). The server
+// may queue the change for approval, in which case it takes effect only once
+// approved.
+func UpdateWorkSession(ac *client.AlpaconClient, id string, req WorkSessionUpdateRequest) (*WorkSession, error) {
+	body, err := ac.SendPatchRequest(utils.BuildURL(workSessionURL, id, nil), req)
+	if err != nil {
+		return nil, err
+	}
+	var session WorkSession
+	if err = json.Unmarshal(body, &session); err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
 func GetWorkSession(ac *client.AlpaconClient, id string) (*WorkSession, error) {
 	body, err := ac.SendGetRequest(utils.BuildURL(workSessionURL, id, nil))
 	if err != nil {

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -64,7 +64,7 @@ func CreateWorkSession(ac *client.AlpaconClient, req WorkSessionCreateRequest) (
 }
 
 // UpdateWorkSession PATCHes a work session. Used to attach sudo policies to an
-// existing session (e.g. after an execute-command sudo was denied). The server
+// existing session (e.g. after an 'exec' sudo was denied). The server
 // may queue the change for approval, in which case it takes effect only once
 // approved.
 func UpdateWorkSession(ac *client.AlpaconClient, id string, req WorkSessionUpdateRequest) (*WorkSession, error) {

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -290,7 +290,7 @@ func TestUpdateWorkSession(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
 		assert.Equal(t, "/api/work-sessions/sessions/ses-abc/", r.URL.Path)
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "active"})
 	}))

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -285,4 +285,29 @@ func TestGetWorkSessionTimeline_ExcludeRecords(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+func TestUpdateWorkSession(t *testing.T) {
+	var gotBody WorkSessionUpdateRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/api/work-sessions/sessions/ses-abc/", r.URL.Path)
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "active"})
+	}))
+	defer ts.Close()
+
+	req := WorkSessionUpdateRequest{SudoPolicies: []SudoPolicyInline{
+		{ID: "pol-1", Commands: []string{"systemctl restart nginx"}, AllowBypassMFA: true},
+		{Commands: []string{"tail -f /var/log/nginx/*.log"}, AllowBypassMFA: true},
+	}}
+	session, err := UpdateWorkSession(newTestClient(ts), "ses-abc", req)
+	assert.NoError(t, err)
+	assert.Equal(t, "ses-abc", session.ID)
+	// Full desired set is sent: existing policy echoed back with its ID
+	// plus the new addition without one.
+	assert.Len(t, gotBody.SudoPolicies, 2)
+	assert.Equal(t, "pol-1", gotBody.SudoPolicies[0].ID)
+	assert.Empty(t, gotBody.SudoPolicies[1].ID)
+}
+
 func newString(s string) *string { return &s }

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -28,8 +28,8 @@ func sudoDenialHint(output string) string {
 	}
 	return fmt.Sprintf(
 		"%s sudo was denied: this command is not covered by an MFA-bypass policy in your work session.\n"+
-			"Add it and re-run:\n"+
-			"  alpacon work-session update --sudo \"<command>\"\n",
+			"Add it and re-run (omit SESSION_ID to use the active session):\n"+
+			"  alpacon work-session update [SESSION_ID] --sudo \"<command>\"\n",
 		utils.Yellow("Hint:"),
 	)
 }

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -17,7 +17,12 @@ import (
 // output when a non-interactive sudo is denied for lack of a matching
 // MFA-bypass policy in the work session. Kept in sync with
 // alpacon-server utils/error_codes.py ErrorCode.SUDO_NO_WORKSESSION_POLICY.
-const sudoNoWorksessionPolicyCode = "sudo_no_worksession_policy"
+//
+// The form is UPPERCASE because alpacon_approval.c only passes [A-Z0-9_]
+// codes through its sanitizer into the user-facing denial message; lowercase
+// values are dropped, so this is the form that actually reaches stderr as
+// "Permission denied (SUDO_NO_WORKSESSION_POLICY)".
+const sudoNoWorksessionPolicyCode = "SUDO_NO_WORKSESSION_POLICY"
 
 // sudoDenialHint returns actionable guidance when the command output shows a
 // non-interactive sudo denial, telling the caller how to authorize the command

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/api/iam"
@@ -11,6 +12,27 @@ import (
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 )
+
+// sudoNoWorksessionPolicyCode is the server error code surfaced in command
+// output when a non-interactive sudo is denied for lack of a matching
+// MFA-bypass policy in the work session. Kept in sync with
+// alpacon-server utils/error_codes.py ErrorCode.SUDO_NO_WORKSESSION_POLICY.
+const sudoNoWorksessionPolicyCode = "sudo_no_worksession_policy"
+
+// sudoDenialHint returns actionable guidance when the command output shows a
+// non-interactive sudo denial, telling the caller how to authorize the command
+// via their work session. Returns "" when no such denial is present.
+func sudoDenialHint(output string) string {
+	if !strings.Contains(output, sudoNoWorksessionPolicyCode) {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%s sudo was denied: this command is not covered by an MFA-bypass policy in your work session.\n"+
+			"Add it and re-run:\n"+
+			"  alpacon work-session update --sudo \"<command>\"\n",
+		utils.Yellow("Hint:"),
+	)
+}
 
 // RunCommandWithRetry executes a remote command with MFA and username-required
 // error handling and retry logic. Used by both exec and websh commands.
@@ -62,6 +84,9 @@ func HandleCommandResult(result string, err error) {
 			if stderrLine != "" {
 				fmt.Fprint(os.Stderr, stderrLine)
 			}
+			if hint := sudoDenialHint(result); hint != "" {
+				fmt.Fprint(os.Stderr, hint)
+			}
 			os.Exit(exitCode)
 		}
 		var clientTimeout *event.ClientTimeoutError
@@ -73,6 +98,9 @@ func HandleCommandResult(result string, err error) {
 		return
 	}
 	fmt.Println(result)
+	if hint := sudoDenialHint(result); hint != "" {
+		fmt.Fprint(os.Stderr, hint)
+	}
 }
 
 // asPhasedError unwraps err to a RemoteCommandError or ClientTimeoutError.

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -1,0 +1,23 @@
+package exec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSudoDenialHint(t *testing.T) {
+	t.Run("returns guidance when denial code present", func(t *testing.T) {
+		out := "sudo: a password is required\nsudo_no_worksession_policy\n"
+		hint := sudoDenialHint(out)
+		assert.NotEmpty(t, hint)
+		assert.True(t, strings.Contains(hint, "work-session update --sudo"),
+			"hint should point to the work-session update command")
+	})
+
+	t.Run("empty when no denial code", func(t *testing.T) {
+		assert.Empty(t, sudoDenialHint("ok\n"))
+		assert.Empty(t, sudoDenialHint(""))
+	})
+}

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -12,7 +12,7 @@ func TestSudoDenialHint(t *testing.T) {
 		out := "sudo: a password is required\nsudo_no_worksession_policy\n"
 		hint := sudoDenialHint(out)
 		assert.NotEmpty(t, hint)
-		assert.True(t, strings.Contains(hint, "work-session update --sudo"),
+		assert.True(t, strings.Contains(hint, "work-session update"),
 			"hint should point to the work-session update command")
 	})
 

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSudoDenialHint(t *testing.T) {
 	t.Run("returns guidance when denial code present", func(t *testing.T) {
-		out := "sudo: a password is required\nsudo_no_worksession_policy\n"
+		out := "sudo: Permission denied (SUDO_NO_WORKSESSION_POLICY)\n"
 		hint := sudoDenialHint(out)
 		assert.NotEmpty(t, hint)
 		assert.True(t, strings.Contains(hint, "work-session update"),

--- a/cmd/worksession/sudo_policies_test.go
+++ b/cmd/worksession/sudo_policies_test.go
@@ -1,0 +1,26 @@
+package worksession
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildSudoPolicies(t *testing.T) {
+	t.Run("one policy per --sudo value, commands split on comma", func(t *testing.T) {
+		policies := buildSudoPolicies(
+			[]string{"systemctl restart nginx,systemctl reload nginx", "tail -f /var/log/nginx/*.log"},
+			"hotfix",
+		)
+		assert.Len(t, policies, 2)
+		assert.Equal(t, []string{"systemctl restart nginx", "systemctl reload nginx"}, policies[0].Commands)
+		assert.True(t, policies[0].AllowBypassMFA)
+		assert.Equal(t, "hotfix", policies[0].Reason)
+		assert.Equal(t, []string{"tail -f /var/log/nginx/*.log"}, policies[1].Commands)
+	})
+
+	t.Run("empty and whitespace-only values are skipped", func(t *testing.T) {
+		assert.Empty(t, buildSudoPolicies(nil, ""))
+		assert.Empty(t, buildSudoPolicies([]string{"", " , "}, ""))
+	})
+}

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -55,6 +55,7 @@ func init() {
 	WorkSessionCmd.AddCommand(workSessionActivateCmd)
 	WorkSessionCmd.AddCommand(workSessionCompleteCmd)
 	WorkSessionCmd.AddCommand(workSessionExtendCmd)
+	WorkSessionCmd.AddCommand(workSessionUpdateCmd)
 	WorkSessionCmd.AddCommand(workSessionUseCmd)
 	WorkSessionCmd.AddCommand(workSessionCurrentCmd)
 	WorkSessionCmd.AddCommand(workSessionTimelineCmd)

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -44,7 +44,7 @@ Run 'alpacon whoami' to check your WorkSession requirement and active session.`,
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session approve', 'alpacon work-session reject', 'alpacon work-session revoke', 'alpacon work-session timeline', or 'alpacon work-session recording'. Run 'alpacon work-session --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session update', 'alpacon work-session approve', 'alpacon work-session reject', 'alpacon work-session revoke', 'alpacon work-session timeline', or 'alpacon work-session recording'. Run 'alpacon work-session --help' for more information")
 	},
 }
 

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -55,7 +55,7 @@ prompt. The 'sudo' scope is added automatically, and the policies are submitted 
 approval together with the session. If a sudo command is later denied, add it to the
 session with 'alpacon work-session update <id> --sudo "<command>"'.`,
 	Example: `  alpacon work-session create --purpose "nginx fix" --scope command,websh --server web-01 --expires-in 2h
-  alpacon work-session create --purpose "deploy" --scope command --server web-01,db-01 --expires-at 2026-05-09T10:00:00Z --wait
+  alpacon work-session create --purpose "deploy" --scope command --server web-01,db-01 --expires-at 2027-01-15T10:00:00Z --wait
   alpacon work-session create --purpose "hotfix" --scope command --server web-01 --expires-in 1h --use
   alpacon work-session create --purpose "deploy" --scope command --server web-01 --expires-in 2h --wait --use
   alpacon work-session create --purpose "nginx hotfix" --server web-01 --expires-in 2h \

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -124,7 +124,7 @@ session with 'alpacon work-session update <id> --sudo "<command>"'.`,
 		// policies are MFA-bypass (the only way a non-interactive caller
 		// running 'exec' can sudo). The server binds each policy to
 		// the session assignee automatically, so they never apply to other
-		// users. ``sudo`` scope is required server-side, so add it implicitly.
+		// users. The 'sudo' scope is required server-side, so add it implicitly.
 		sudoPolicies := buildSudoPolicies(createSudo, createSudoReason)
 		if len(sudoPolicies) > 0 && !slices.Contains(scopeList, "sudo") {
 			scopeList = append(scopeList, "sudo")

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -393,7 +393,7 @@ func init() {
 	workSessionCreateCmd.Flags().StringVar(&requesterType, "requester-type", "user", "Requester type: user or agent")
 	workSessionCreateCmd.Flags().BoolVar(&waitApproval, "wait", false, "Poll until the session is approved, then exit (does not set as active; combine with --use to attach automatically)")
 	workSessionCreateCmd.Flags().BoolVar(&useAfterCreate, "use", false, "Set the created session as the workspace's active session (requires status to reach 'active'; combine with --wait when approval is needed)")
-	workSessionCreateCmd.Flags().StringArrayVar(&createSudo, "sudo", nil, "Pre-declare sudo command patterns to run without interactive MFA (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed). Required for non-interactive sudo via 'exec' (e.g. AI agents). Implies the 'sudo' scope. Patterns are submitted for approval with the session.")
+	workSessionCreateCmd.Flags().StringArrayVar(&createSudo, "sudo", nil, "Pre-declare sudo command patterns to run without interactive MFA (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed; literal commas inside a pattern are not supported — pass the flag again for each policy that needs them). Required for non-interactive sudo via 'exec' (e.g. AI agents). Implies the 'sudo' scope. Patterns are submitted for approval with the session.")
 	workSessionCreateCmd.Flags().StringVar(&createSudoReason, "sudo-reason", "", "Justification applied to the sudo policies created via --sudo")
 	workSessionCreateCmd.MarkFlagsMutuallyExclusive("expires-in", "expires-at")
 }

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -49,8 +49,8 @@ required, combine --use with --wait. The session is attached once it reaches the
 active state.
 
 If the work needs sudo, pre-declare the command patterns with --sudo. This attaches
-MFA-bypass sudo policies to the session so a non-interactive execute-command caller
-(e.g. an AI agent) can run those exact sudo commands without an interactive MFA
+MFA-bypass sudo policies to the session so a non-interactive caller (e.g. an AI agent
+running 'exec') can run those exact sudo commands without an interactive MFA
 prompt. The 'sudo' scope is added automatically, and the policies are submitted for
 approval together with the session. If a sudo command is later denied, add it to the
 session with 'alpacon work-session update <id> --sudo "<command>"'.`,
@@ -121,8 +121,8 @@ session with 'alpacon work-session update <id> --sudo "<command>"'.`,
 		}
 		// Build sudo bypass policies from --sudo. Each --sudo value is a
 		// comma-separated list of command patterns forming one policy; the
-		// policies are MFA-bypass (the only way a non-interactive
-		// execute-command caller can sudo). The server binds each policy to
+		// policies are MFA-bypass (the only way a non-interactive caller
+		// running 'exec' can sudo). The server binds each policy to
 		// the session assignee automatically, so they never apply to other
 		// users. ``sudo`` scope is required server-side, so add it implicitly.
 		sudoPolicies := buildSudoPolicies(createSudo, createSudoReason)
@@ -393,7 +393,7 @@ func init() {
 	workSessionCreateCmd.Flags().StringVar(&requesterType, "requester-type", "user", "Requester type: user or agent")
 	workSessionCreateCmd.Flags().BoolVar(&waitApproval, "wait", false, "Poll until the session is approved, then exit (does not set as active; combine with --use to attach automatically)")
 	workSessionCreateCmd.Flags().BoolVar(&useAfterCreate, "use", false, "Set the created session as the workspace's active session (requires status to reach 'active'; combine with --wait when approval is needed)")
-	workSessionCreateCmd.Flags().StringArrayVar(&createSudo, "sudo", nil, "Pre-declare sudo command patterns to run without interactive MFA (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed). Required for non-interactive execute-command sudo (e.g. AI agents). Implies the 'sudo' scope. Patterns are submitted for approval with the session.")
+	workSessionCreateCmd.Flags().StringArrayVar(&createSudo, "sudo", nil, "Pre-declare sudo command patterns to run without interactive MFA (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed). Required for non-interactive sudo via 'exec' (e.g. AI agents). Implies the 'sudo' scope. Patterns are submitted for approval with the session.")
 	workSessionCreateCmd.Flags().StringVar(&createSudoReason, "sudo-reason", "", "Justification applied to the sudo policies created via --sudo")
 	workSessionCreateCmd.MarkFlagsMutuallyExclusive("expires-in", "expires-at")
 }

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -26,14 +26,16 @@ const (
 var validScopePresets = []string{"command", "editor", "sudo", "tunnel", "webftp", "websh"}
 
 var (
-	purpose        string
-	createScopes   []string
-	createServers  []string
-	expiresIn      string
-	expiresAt      string
-	requesterType  string
-	waitApproval   bool
-	useAfterCreate bool
+	purpose          string
+	createScopes     []string
+	createServers    []string
+	expiresIn        string
+	expiresAt        string
+	requesterType    string
+	waitApproval     bool
+	useAfterCreate   bool
+	createSudo       []string
+	createSudoReason string
 )
 
 var workSessionCreateCmd = &cobra.Command{
@@ -44,11 +46,20 @@ var workSessionCreateCmd = &cobra.Command{
 Pass --use to set the new session as the workspace's active session, so subsequent
 exec/websh/cp/tunnel commands attach to it without --work-session. When approval is
 required, combine --use with --wait. The session is attached once it reaches the
-active state.`,
+active state.
+
+If the work needs sudo, pre-declare the command patterns with --sudo. This attaches
+MFA-bypass sudo policies to the session so a non-interactive execute-command caller
+(e.g. an AI agent) can run those exact sudo commands without an interactive MFA
+prompt. The 'sudo' scope is added automatically, and the policies are submitted for
+approval together with the session. If a sudo command is later denied, add it to the
+session with 'alpacon work-session update <id> --sudo "<command>"'.`,
 	Example: `  alpacon work-session create --purpose "nginx fix" --scope command,websh --server web-01 --expires-in 2h
   alpacon work-session create --purpose "deploy" --scope command --server web-01,db-01 --expires-at 2026-05-09T10:00:00Z --wait
   alpacon work-session create --purpose "hotfix" --scope command --server web-01 --expires-in 1h --use
-  alpacon work-session create --purpose "deploy" --scope command --server web-01 --expires-in 2h --wait --use`,
+  alpacon work-session create --purpose "deploy" --scope command --server web-01 --expires-in 2h --wait --use
+  alpacon work-session create --purpose "nginx hotfix" --server web-01 --expires-in 2h \
+    --sudo "systemctl restart nginx,systemctl reload nginx" --sudo "tail -f /var/log/nginx/*.log"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		purpose = strings.TrimSpace(purpose)
 		if purpose == "" {
@@ -108,6 +119,17 @@ active state.`,
 				scopeList = append(scopeList, s)
 			}
 		}
+		// Build sudo bypass policies from --sudo. Each --sudo value is a
+		// comma-separated list of command patterns forming one policy; the
+		// policies are MFA-bypass (the only way a non-interactive
+		// execute-command caller can sudo). The server binds each policy to
+		// the session assignee automatically, so they never apply to other
+		// users. ``sudo`` scope is required server-side, so add it implicitly.
+		sudoPolicies := buildSudoPolicies(createSudo, createSudoReason)
+		if len(sudoPolicies) > 0 && !slices.Contains(scopeList, "sudo") {
+			scopeList = append(scopeList, "sudo")
+		}
+
 		if len(scopeList) == 0 {
 			utils.CliErrorWithExit("--scope must contain at least one valid scope.")
 		}
@@ -147,6 +169,7 @@ active state.`,
 			Scopes:        scopeList,
 			Servers:       serverIDs,
 			ExpiresAt:     expiresAtVal,
+			SudoPolicies:  sudoPolicies,
 		}
 
 		session, err := wsapi.CreateWorkSession(ac, req)
@@ -292,6 +315,25 @@ func validateAgentScopes(requesterType string, scopes []string) error {
 	return nil
 }
 
+// buildSudoPolicies turns repeatable --sudo values into MFA-bypass policy
+// definitions. Each value is a comma-separated list of command patterns
+// (wildcards permitted) forming one policy. Empty values are skipped.
+func buildSudoPolicies(specs []string, reason string) []wsapi.SudoPolicyInline {
+	var policies []wsapi.SudoPolicyInline
+	for _, spec := range specs {
+		commands := splitCSV(spec)
+		if len(commands) == 0 {
+			continue
+		}
+		policies = append(policies, wsapi.SudoPolicyInline{
+			Commands:       commands,
+			Reason:         reason,
+			AllowBypassMFA: true,
+		})
+	}
+	return policies
+}
+
 // splitCSV splits a comma-separated string and trims whitespace.
 func splitCSV(s string) []string {
 	parts := strings.Split(s, ",")
@@ -351,5 +393,7 @@ func init() {
 	workSessionCreateCmd.Flags().StringVar(&requesterType, "requester-type", "user", "Requester type: user or agent")
 	workSessionCreateCmd.Flags().BoolVar(&waitApproval, "wait", false, "Poll until the session is approved, then exit (does not set as active; combine with --use to attach automatically)")
 	workSessionCreateCmd.Flags().BoolVar(&useAfterCreate, "use", false, "Set the created session as the workspace's active session (requires status to reach 'active'; combine with --wait when approval is needed)")
+	workSessionCreateCmd.Flags().StringArrayVar(&createSudo, "sudo", nil, "Pre-declare sudo command patterns to run without interactive MFA (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed). Required for non-interactive execute-command sudo (e.g. AI agents). Implies the 'sudo' scope. Patterns are submitted for approval with the session.")
+	workSessionCreateCmd.Flags().StringVar(&createSudoReason, "sudo-reason", "", "Justification applied to the sudo policies created via --sudo")
 	workSessionCreateCmd.MarkFlagsMutuallyExclusive("expires-in", "expires-at")
 }

--- a/cmd/worksession/worksession_recording_test.go
+++ b/cmd/worksession/worksession_recording_test.go
@@ -121,4 +121,3 @@ func TestRecordingPreview_EmptyRaw(t *testing.T) {
 func TestRecordingPreview_OnlyANSI(t *testing.T) {
 	assert.Equal(t, "", recordingPreview("\x1b[?2004h\x1b[2J\x1b[H"))
 }
-

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -31,6 +31,30 @@ func validateSessionForSudoUpdate(session *wsapi.WorkSession) error {
 	return nil
 }
 
+// attachSudoPoliciesToSession is the testable core of the update command Run:
+// load the current session, validate it can accept sudo policy changes, then
+// PATCH the full desired set (existing policies echoed back by ID + new
+// additions). The modify endpoint is PUT-style — any policy absent from the
+// request is deleted — so the echo-existing step is the regression bait this
+// helper exists to lock down.
+func attachSudoPoliciesToSession(
+	ac *client.AlpaconClient,
+	sessionID string,
+	newPolicies []wsapi.SudoPolicyInline,
+) (*wsapi.WorkSession, error) {
+	session, err := wsapi.GetWorkSession(ac, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load work session %s: %w", sessionID, err)
+	}
+	if err := validateSessionForSudoUpdate(session); err != nil {
+		return nil, err
+	}
+	desired := make([]wsapi.SudoPolicyInline, 0, len(session.SudoPolicies)+len(newPolicies))
+	desired = append(desired, session.SudoPolicies...)
+	desired = append(desired, newPolicies...)
+	return wsapi.UpdateWorkSession(ac, sessionID, wsapi.WorkSessionUpdateRequest{SudoPolicies: desired})
+}
+
 var (
 	updateSudo       []string
 	updateSudoReason string
@@ -75,30 +99,9 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		// The modify endpoint takes the FULL desired set of policies (PUT-style):
-		// any existing policy missing from the request is deleted. Read the
-		// current set and echo it back (with IDs) alongside the additions so
-		// nothing is dropped.
-		session, err := wsapi.GetWorkSession(ac, sessionID)
+		updated, err := attachSudoPoliciesToSession(ac, sessionID, newPolicies)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to load work session %s: %s.", sessionID, err)
-		}
-		// Server rejects sudo_policies on a pending session (the update
-		// serializer drops the field) or on one without the 'sudo' scope
-		// (work_session_sudo_policy_without_scope). The update endpoint has no
-		// scopes field, so we cannot add it here — fail early with guidance.
-		if err := validateSessionForSudoUpdate(session); err != nil {
-			utils.CliErrorWithExit("%s", err)
-		}
-
-		desired := make([]wsapi.SudoPolicyInline, 0, len(session.SudoPolicies)+len(newPolicies))
-		desired = append(desired, session.SudoPolicies...)
-		desired = append(desired, newPolicies...)
-
-		req := wsapi.WorkSessionUpdateRequest{SudoPolicies: desired}
-		updated, err := wsapi.UpdateWorkSession(ac, sessionID, req)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to update work session: %s.", err)
+			utils.CliErrorWithExit("%s.", err)
 		}
 
 		utils.CliSuccess("Work session %s updated (status: %s).", updated.ID, updated.Status)

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -25,8 +25,9 @@ Each --sudo value is a comma-separated pattern list (wildcards allowed) forming 
 policy. The session's existing policies are preserved; the additions may require
 approval before they take effect.
 
-If SESSION_ID is omitted, the workspace's active work session is used (set via
-'alpacon work-session use').`,
+If SESSION_ID is omitted, the effective work session is resolved from the
+ALPACON_WORK_SESSION environment variable, then the workspace's active session
+(set via 'alpacon work-session use').`,
 	Args: cobra.MaximumNArgs(1),
 	Example: `  alpacon work-session update ses-abc123 --sudo "systemctl restart nginx"
   alpacon work-session update --sudo "tail -f /var/log/nginx/*.log"`,

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -70,7 +70,7 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 		// (work_session_sudo_policy_without_scope). The update endpoint has no
 		// scopes field, so we cannot add it here — fail early with guidance.
 		if !slices.Contains(session.Scopes, "sudo") {
-			utils.CliErrorWithExit("Work session %s does not include the 'sudo' scope; sudo policies cannot be added. Create a new session with '--scope sudo' (and --sudo).", sessionID)
+			utils.CliErrorWithExit("Work session %s does not include the 'sudo' scope; sudo policies cannot be added. Create a new session with --sudo (it adds the 'sudo' scope automatically).", sessionID)
 		}
 
 		desired := make([]wsapi.SudoPolicyInline, 0, len(session.SudoPolicies)+len(newPolicies))

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -1,0 +1,85 @@
+package worksession
+
+import (
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+const pendingWorkSessionStatus = "pending"
+
+var (
+	updateSudo       []string
+	updateSudoReason string
+)
+
+var workSessionUpdateCmd = &cobra.Command{
+	Use:   "update [SESSION_ID]",
+	Short: "Update a work session (e.g. add sudo command patterns)",
+	Long: `Update an existing work session.
+
+Use --sudo to add MFA-bypass sudo command patterns to the session. This is the
+recovery path when an execute-command sudo was denied: add the command and re-run.
+Each --sudo value is a comma-separated pattern list (wildcards allowed) forming one
+policy. The session's existing policies are preserved; the additions may require
+approval before they take effect.
+
+If SESSION_ID is omitted, the workspace's active work session is used (set via
+'alpacon work-session use').`,
+	Args: cobra.MaximumNArgs(1),
+	Example: `  alpacon work-session update ses-abc123 --sudo "systemctl restart nginx"
+  alpacon work-session update --sudo "tail -f /var/log/nginx/*.log"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var sessionID string
+		if len(args) == 1 {
+			sessionID = args[0]
+		} else {
+			resolved, err := Resolve("")
+			if err != nil || resolved == "" {
+				utils.CliErrorWithExit("No SESSION_ID given and no active work session. Pass an ID or run 'alpacon work-session use <id>' first.")
+			}
+			sessionID = resolved
+		}
+
+		newPolicies := buildSudoPolicies(updateSudo, updateSudoReason)
+		if len(newPolicies) == 0 {
+			utils.CliErrorWithExit("Nothing to update. Pass --sudo with at least one command pattern.")
+		}
+
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		// The modify endpoint takes the FULL desired set of policies (PUT-style):
+		// any existing policy missing from the request is deleted. Read the
+		// current set and echo it back (with IDs) alongside the additions so
+		// nothing is dropped.
+		session, err := wsapi.GetWorkSession(ac, sessionID)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to load work session %s: %s.", sessionID, err)
+		}
+		if session.Status == pendingWorkSessionStatus {
+			utils.CliErrorWithExit("Work session %s is pending approval; sudo policies cannot be modified yet. Set them at create time with --sudo, or wait until it is approved.", sessionID)
+		}
+
+		desired := make([]wsapi.SudoPolicyInline, 0, len(session.SudoPolicies)+len(newPolicies))
+		desired = append(desired, session.SudoPolicies...)
+		desired = append(desired, newPolicies...)
+
+		req := wsapi.WorkSessionUpdateRequest{SudoPolicies: desired}
+		updated, err := wsapi.UpdateWorkSession(ac, sessionID, req)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to update work session: %s.", err)
+		}
+
+		utils.CliSuccess("Work session %s updated (status: %s).", updated.ID, updated.Status)
+		utils.CliInfo("Added sudo policies may require approval before they take effect. Re-run your command once the session reflects the change.")
+	},
+}
+
+func init() {
+	workSessionUpdateCmd.Flags().StringArrayVar(&updateSudo, "sudo", nil, "Sudo command patterns to add as MFA-bypass policies (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed)")
+	workSessionUpdateCmd.Flags().StringVar(&updateSudoReason, "sudo-reason", "", "Justification applied to the sudo policies added via --sudo")
+}

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -1,6 +1,8 @@
 package worksession
 
 import (
+	"slices"
+
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
@@ -63,6 +65,12 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 		}
 		if session.Status == pendingWorkSessionStatus {
 			utils.CliErrorWithExit("Work session %s is pending approval; sudo policies cannot be modified yet. Set them at create time with --sudo, or wait until it is approved.", sessionID)
+		}
+		// Server rejects sudo_policies on a session without the 'sudo' scope
+		// (work_session_sudo_policy_without_scope). The update endpoint has no
+		// scopes field, so we cannot add it here — fail early with guidance.
+		if !slices.Contains(session.Scopes, "sudo") {
+			utils.CliErrorWithExit("Work session %s does not include the 'sudo' scope; sudo policies cannot be added. Create a new session with '--scope sudo' (and --sudo).", sessionID)
 		}
 
 		desired := make([]wsapi.SudoPolicyInline, 0, len(session.SudoPolicies)+len(newPolicies))

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -20,7 +20,7 @@ var workSessionUpdateCmd = &cobra.Command{
 	Long: `Update an existing work session.
 
 Use --sudo to add MFA-bypass sudo command patterns to the session. This is the
-recovery path when an execute-command sudo was denied: add the command and re-run.
+recovery path when an 'exec' sudo was denied: add the command and re-run.
 Each --sudo value is a comma-separated pattern list (wildcards allowed) forming one
 policy. The session's existing policies are preserved; the additions may require
 approval before they take effect.

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -1,6 +1,7 @@
 package worksession
 
 import (
+	"fmt"
 	"slices"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
@@ -10,6 +11,25 @@ import (
 )
 
 const pendingWorkSessionStatus = "pending"
+
+// validateSessionForSudoUpdate checks the preconditions for adding sudo
+// policies to an existing work session. It is extracted from the command Run
+// so the guard logic can be unit-tested without driving the cobra/HTTP stack.
+func validateSessionForSudoUpdate(session *wsapi.WorkSession) error {
+	if session.Status == pendingWorkSessionStatus {
+		return fmt.Errorf(
+			"work session %s is pending approval; sudo policies cannot be modified yet. Set them at create time with --sudo, or wait until it is approved",
+			session.ID,
+		)
+	}
+	if !slices.Contains(session.Scopes, "sudo") {
+		return fmt.Errorf(
+			"work session %s does not include the 'sudo' scope; sudo policies cannot be added. Create a new session with --sudo (it adds the 'sudo' scope automatically)",
+			session.ID,
+		)
+	}
+	return nil
+}
 
 var (
 	updateSudo       []string
@@ -40,7 +60,7 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 		} else {
 			resolved, err := Resolve("")
 			if err != nil || resolved == "" {
-				utils.CliErrorWithExit("No SESSION_ID given and no active work session. Pass an ID or run 'alpacon work-session use <id>' first.")
+				utils.CliErrorWithExit("No SESSION_ID given and no active work session. Pass an ID, set ALPACON_WORK_SESSION, or run 'alpacon work-session use <id>' first.")
 			}
 			sessionID = resolved
 		}
@@ -63,14 +83,12 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 		if err != nil {
 			utils.CliErrorWithExit("Failed to load work session %s: %s.", sessionID, err)
 		}
-		if session.Status == pendingWorkSessionStatus {
-			utils.CliErrorWithExit("Work session %s is pending approval; sudo policies cannot be modified yet. Set them at create time with --sudo, or wait until it is approved.", sessionID)
-		}
-		// Server rejects sudo_policies on a session without the 'sudo' scope
+		// Server rejects sudo_policies on a pending session (the update
+		// serializer drops the field) or on one without the 'sudo' scope
 		// (work_session_sudo_policy_without_scope). The update endpoint has no
 		// scopes field, so we cannot add it here — fail early with guidance.
-		if !slices.Contains(session.Scopes, "sudo") {
-			utils.CliErrorWithExit("Work session %s does not include the 'sudo' scope; sudo policies cannot be added. Create a new session with --sudo (it adds the 'sudo' scope automatically).", sessionID)
+		if err := validateSessionForSudoUpdate(session); err != nil {
+			utils.CliErrorWithExit("%s", err)
 		}
 
 		desired := make([]wsapi.SudoPolicyInline, 0, len(session.SudoPolicies)+len(newPolicies))

--- a/cmd/worksession/worksession_update_test.go
+++ b/cmd/worksession/worksession_update_test.go
@@ -1,10 +1,14 @@
 package worksession
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/client"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,4 +54,75 @@ func TestValidateSessionForSudoUpdate(t *testing.T) {
 			Scopes: []string{"sudo"},
 		}))
 	})
+}
+
+// TestAttachSudoPoliciesToSession_PreservesExistingPolicies locks down the
+// "don't drop existing policies" invariant of the modify endpoint: a future
+// refactor that forgets to echo the current set back would silently delete it.
+func TestAttachSudoPoliciesToSession_PreservesExistingPolicies(t *testing.T) {
+	var gotPATCH wsapi.WorkSessionUpdateRequest
+	patchCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(wsapi.WorkSession{
+				ID:     "ses-1",
+				Status: "active",
+				Scopes: []string{"sudo"},
+				SudoPolicies: []wsapi.SudoPolicyInline{
+					{ID: "pol-old", Commands: []string{"systemctl restart nginx"}, AllowBypassMFA: true},
+				},
+			})
+		case http.MethodPatch:
+			patchCalled = true
+			assert.Equal(t, "/api/work-sessions/sessions/ses-1/", r.URL.Path)
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&gotPATCH))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(wsapi.WorkSession{ID: "ses-1", Status: "active"})
+		default:
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	newPolicies := []wsapi.SudoPolicyInline{
+		{Commands: []string{"systemctl reload nginx"}, AllowBypassMFA: true},
+	}
+	_, err := attachSudoPoliciesToSession(ac, "ses-1", newPolicies)
+	assert.NoError(t, err)
+	assert.True(t, patchCalled, "PATCH must be issued")
+	// Full desired set is sent: existing policy echoed back with its ID + the new addition without one.
+	assert.Len(t, gotPATCH.SudoPolicies, 2)
+	assert.Equal(t, "pol-old", gotPATCH.SudoPolicies[0].ID)
+	assert.Empty(t, gotPATCH.SudoPolicies[1].ID)
+	assert.Equal(t, []string{"systemctl reload nginx"}, gotPATCH.SudoPolicies[1].Commands)
+}
+
+// TestAttachSudoPoliciesToSession_PendingSessionAbortsBeforePATCH ensures the
+// validator runs in the wiring path: a pending session must error out without
+// issuing the PATCH so the server doesn't even see the request.
+func TestAttachSudoPoliciesToSession_PendingSessionAbortsBeforePATCH(t *testing.T) {
+	patchCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			patchCalled = true
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(wsapi.WorkSession{
+			ID:     "ses-pending",
+			Status: "pending",
+			Scopes: []string{"sudo"},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := attachSudoPoliciesToSession(ac, "ses-pending", []wsapi.SudoPolicyInline{
+		{Commands: []string{"x"}, AllowBypassMFA: true},
+	})
+	assert.Error(t, err)
+	assert.False(t, patchCalled, "PATCH must not be issued when the validator rejects")
 }

--- a/cmd/worksession/worksession_update_test.go
+++ b/cmd/worksession/worksession_update_test.go
@@ -1,0 +1,53 @@
+package worksession
+
+import (
+	"strings"
+	"testing"
+
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSessionForSudoUpdate(t *testing.T) {
+	t.Run("pending session is rejected with actionable message", func(t *testing.T) {
+		err := validateSessionForSudoUpdate(&wsapi.WorkSession{
+			ID:     "ses-pending",
+			Status: pendingWorkSessionStatus,
+			Scopes: []string{"command", "sudo"},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ses-pending")
+		assert.Contains(t, err.Error(), "pending")
+		assert.Contains(t, err.Error(), "--sudo")
+	})
+
+	t.Run("missing sudo scope is rejected with guidance", func(t *testing.T) {
+		err := validateSessionForSudoUpdate(&wsapi.WorkSession{
+			ID:     "ses-no-sudo",
+			Status: "active",
+			Scopes: []string{"command"},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ses-no-sudo")
+		assert.Contains(t, err.Error(), "'sudo' scope")
+		// Guidance must point at the create flag, not at a separate scope flag.
+		assert.True(t, strings.Contains(err.Error(), "--sudo"),
+			"guidance should reference --sudo so the user creates the right session next time")
+	})
+
+	t.Run("active session with sudo scope passes", func(t *testing.T) {
+		assert.NoError(t, validateSessionForSudoUpdate(&wsapi.WorkSession{
+			ID:     "ses-ok",
+			Status: "active",
+			Scopes: []string{"command", "sudo"},
+		}))
+	})
+
+	t.Run("approved session with sudo scope passes (pre-active is allowed)", func(t *testing.T) {
+		assert.NoError(t, validateSessionForSudoUpdate(&wsapi.WorkSession{
+			ID:     "ses-approved",
+			Status: "approved",
+			Scopes: []string{"sudo"},
+		}))
+	})
+}


### PR DESCRIPTION
## Summary
Lets a non-interactive execute-command caller (e.g. an AI agent) run sudo without interactive MFA by pre-declaring sudo command patterns on a work session.

- `work-session create --sudo "cmd,cmd"` (repeatable, `--sudo-reason`) attaches MFA-bypass policies and implies the `sudo` scope. `users` is omitted so the server binds each policy to the session assignee.
- `work-session update [SESSION_ID] --sudo` adds patterns to an existing session. It sends the **full desired policy set** (existing policies echoed back by `id` + the additions) so the PUT-style modify endpoint never drops current policies, and guards against `pending` sessions (whose serializer ignores `sudo_policies`).
- `exec` prints an actionable hint pointing at `work-session update` when command output carries the `sudo_no_worksession_policy` denial code (paired with the alpacon-server PR).

## Flow
```
alpacon work-session create --purpose "nginx fix" --server web-01 --expires-in 2h \
  --sudo "systemctl restart nginx,systemctl reload nginx" --wait
alpacon work-session use <id>
alpacon exec web-01 "sudo systemctl restart nginx"   # no MFA / no password
# denied command -> hint -> alpacon work-session update --sudo "<cmd>"
```

## Depends on
- alpacon-server: `SUDO_NO_WORKSESSION_POLICY` error code (companion PR).

## Test plan
- [x] `go build ./...`, `go vet`, gofmt clean on changed files.
- [x] `cmd/worksession`, `cmd/exec`, `api/worksession` tests pass; added unit tests for `buildSudoPolicies` and `sudoDenialHint`.
- [ ] Manual: create a session with `--sudo`, run a covered sudo via `exec` (bypasses MFA); run an uncovered one (hint shown); `work-session update --sudo` then re-run.