### PR TITLE
feat(approval): add approval command

### DIFF
--- a/api/approval/approval.go
+++ b/api/approval/approval.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	approvalURL   = "/api/approvals/"
-	myRequestsURL = "/api/approvals/-/"
+	approvalURL   = "/api/approvals/approvals/"
+	myRequestsURL = "/api/approvals/approvals/-/"
 )
 
 func ListApprovalRequests(ac *client.AlpaconClient, status, requestType string) ([]ApprovalRequestAttributes, error) {

--- a/api/approval/approval.go
+++ b/api/approval/approval.go
@@ -1,0 +1,90 @@
+package approval
+
+import (
+	"encoding/json"
+	"path"
+
+	"github.com/alpacax/alpacon-cli/api"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+const (
+	approvalURL   = "/api/approvals/"
+	myRequestsURL = "/api/approvals/-/"
+)
+
+func ListApprovalRequests(ac *client.AlpaconClient, status, requestType string) ([]ApprovalRequestAttributes, error) {
+	return fetchApprovalList(ac, approvalURL, status, requestType)
+}
+
+func ListMyApprovalRequests(ac *client.AlpaconClient, status, requestType string) ([]ApprovalRequestAttributes, error) {
+	return fetchApprovalList(ac, myRequestsURL, status, requestType)
+}
+
+func fetchApprovalList(ac *client.AlpaconClient, endpoint, status, requestType string) ([]ApprovalRequestAttributes, error) {
+	params := map[string]string{}
+	if status != "" {
+		params["status"] = status
+	}
+	if requestType != "" {
+		params["request_type"] = requestType
+	}
+
+	requests, err := api.FetchAllPages[ApprovalRequest](ac, endpoint, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []ApprovalRequestAttributes
+	for i := range requests {
+		result = append(result, projectAttributes(&requests[i]))
+	}
+	return result, nil
+}
+
+func projectAttributes(r *ApprovalRequest) ApprovalRequestAttributes {
+	requestedBy := ""
+	if r.RequestedBy != nil {
+		requestedBy = r.RequestedBy.Name
+	}
+	return ApprovalRequestAttributes{
+		ID:          r.ID,
+		Type:        r.RequestType,
+		Status:      r.Status,
+		RequestData: utils.TruncateString(r.RequestData, 50),
+		RequestedBy: requestedBy,
+		AddedAt:     r.AddedAt.Local().Format("2006-01-02 15:04"),
+	}
+}
+
+func GetApprovalRequest(ac *client.AlpaconClient, id string) (*ApprovalRequest, error) {
+	body, err := ac.SendGetRequest(utils.BuildURL(approvalURL, id, nil))
+	if err != nil {
+		return nil, err
+	}
+	var req ApprovalRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+func GetApprovalRequestRaw(ac *client.AlpaconClient, id string) ([]byte, error) {
+	return ac.SendGetRequest(utils.BuildURL(approvalURL, id, nil))
+}
+
+func ApproveRequest(ac *client.AlpaconClient, id string, opts ApproveOptions) error {
+	_, err := ac.SendPostRequest(utils.BuildURL(approvalURL, path.Join(id, "approve"), nil), opts)
+	return err
+}
+
+func RejectRequest(ac *client.AlpaconClient, id string) error {
+	_, err := ac.SendPostRequest(utils.BuildURL(approvalURL, path.Join(id, "reject"), nil), struct{}{})
+	return err
+}
+
+func CancelRequest(ac *client.AlpaconClient, id string) error {
+	_, err := ac.SendPostRequest(utils.BuildURL(approvalURL, path.Join(id, "cancel"), nil), struct{}{})
+	return err
+}

--- a/api/approval/approval_test.go
+++ b/api/approval/approval_test.go
@@ -138,3 +138,15 @@ func TestRejectRequest(t *testing.T) {
 	err := RejectRequest(newTestClient(ts), "apr-abc")
 	assert.NoError(t, err)
 }
+
+func TestCancelRequest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/cancel/"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	err := CancelRequest(newTestClient(ts), "apr-abc")
+	assert.NoError(t, err)
+}

--- a/api/approval/approval_test.go
+++ b/api/approval/approval_test.go
@@ -1,0 +1,140 @@
+package approval
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/api"
+	"github.com/alpacax/alpacon-cli/api/types"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestClient(ts *httptest.Server) *client.AlpaconClient {
+	return &client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}
+}
+
+func TestListApprovalRequests(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	requests := []ApprovalRequest{
+		{
+			ID:          "apr-1",
+			RequestType: "work_session",
+			RequestData: "deploy access",
+			Status:      "pending",
+			RequestedBy: &types.UserSummary{ID: "u-1", Name: "alice"},
+			AddedAt:     now,
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/approvals/", r.URL.Path)
+		assert.Equal(t, "pending", r.URL.Query().Get("status"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[ApprovalRequest]{Count: 1, Results: requests})
+	}))
+	defer ts.Close()
+
+	list, err := ListApprovalRequests(newTestClient(ts), "pending", "")
+	assert.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Equal(t, "apr-1", list[0].ID)
+	assert.Equal(t, "work_session", list[0].Type)
+	assert.Equal(t, "alice", list[0].RequestedBy)
+}
+
+func TestListApprovalRequests_TypeFilter(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "sudo", r.URL.Query().Get("request_type"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[ApprovalRequest]{Count: 0, Results: nil})
+	}))
+	defer ts.Close()
+
+	_, err := ListApprovalRequests(newTestClient(ts), "", "sudo")
+	assert.NoError(t, err)
+}
+
+func TestListMyApprovalRequests(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/approvals/-/", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[ApprovalRequest]{Count: 0, Results: nil})
+	}))
+	defer ts.Close()
+
+	_, err := ListMyApprovalRequests(newTestClient(ts), "pending", "")
+	assert.NoError(t, err)
+}
+
+func TestGetApprovalRequest(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ApprovalRequest{
+			ID: "apr-abc", RequestType: "sudo", Status: "pending", AddedAt: now,
+		})
+	}))
+	defer ts.Close()
+
+	req, err := GetApprovalRequest(newTestClient(ts), "apr-abc")
+	assert.NoError(t, err)
+	assert.Equal(t, "apr-abc", req.ID)
+	assert.Equal(t, "sudo", req.RequestType)
+}
+
+func TestApproveRequest_NoAdjustments(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/approve/"))
+		var body ApproveOptions
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Nil(t, body.AdjustedScopes)
+		assert.Nil(t, body.AdjustedServers)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	err := ApproveRequest(newTestClient(ts), "apr-abc", ApproveOptions{})
+	assert.NoError(t, err)
+}
+
+func TestApproveRequest_WithAdjustments(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/approve/"))
+		var body ApproveOptions
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, []string{"command"}, body.AdjustedScopes)
+		assert.Equal(t, []string{"srv-uuid-1"}, body.AdjustedServers)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	err := ApproveRequest(newTestClient(ts), "apr-abc", ApproveOptions{
+		AdjustedScopes:  []string{"command"},
+		AdjustedServers: []string{"srv-uuid-1"},
+	})
+	assert.NoError(t, err)
+}
+
+func TestRejectRequest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "apr-abc/reject/"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	err := RejectRequest(newTestClient(ts), "apr-abc")
+	assert.NoError(t, err)
+}

--- a/api/approval/approval_test.go
+++ b/api/approval/approval_test.go
@@ -34,7 +34,7 @@ func TestListApprovalRequests(t *testing.T) {
 		},
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/approvals/", r.URL.Path)
+		assert.Equal(t, "/api/approvals/approvals/", r.URL.Path)
 		assert.Equal(t, "pending", r.URL.Query().Get("status"))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.ListResponse[ApprovalRequest]{Count: 1, Results: requests})
@@ -63,7 +63,7 @@ func TestListApprovalRequests_TypeFilter(t *testing.T) {
 
 func TestListMyApprovalRequests(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/approvals/-/", r.URL.Path)
+		assert.Equal(t, "/api/approvals/approvals/-/", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.ListResponse[ApprovalRequest]{Count: 0, Results: nil})
 	}))

--- a/api/approval/approval_test.go
+++ b/api/approval/approval_test.go
@@ -150,3 +150,42 @@ func TestCancelRequest(t *testing.T) {
 	err := CancelRequest(newTestClient(ts), "apr-abc")
 	assert.NoError(t, err)
 }
+
+func TestApproveRequest_403PropagatesError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail": "you do not have permission to perform this action"}`))
+	}))
+	defer ts.Close()
+
+	err := ApproveRequest(newTestClient(ts), "apr-abc", ApproveOptions{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "permission")
+}
+
+func TestRejectRequest_404PropagatesError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail": "not found"}`))
+	}))
+	defer ts.Close()
+
+	err := RejectRequest(newTestClient(ts), "apr-missing")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestCancelRequest_403PropagatesError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail": "you do not have permission to perform this action"}`))
+	}))
+	defer ts.Close()
+
+	err := CancelRequest(newTestClient(ts), "apr-abc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "permission")
+}

--- a/api/approval/types.go
+++ b/api/approval/types.go
@@ -1,0 +1,33 @@
+package approval
+
+import (
+	"time"
+
+	"github.com/alpacax/alpacon-cli/api/types"
+)
+
+type ApprovalRequest struct {
+	ID          string             `json:"id"`
+	RequestType string             `json:"request_type"`
+	RequestData string             `json:"request_data"`
+	Description string             `json:"description"`
+	Status      string             `json:"status"`
+	RequestedBy *types.UserSummary `json:"requested_by"`
+	ReviewedBy  *types.UserSummary `json:"reviewed_by"`
+	ReviewedAt  *time.Time         `json:"reviewed_at"`
+	AddedAt     time.Time          `json:"added_at"`
+}
+
+type ApprovalRequestAttributes struct {
+	ID          string `json:"id"           table:"ID"`
+	Type        string `json:"request_type" table:"Type"`
+	Status      string `json:"status"       table:"Status"`
+	RequestData string `json:"request_data" table:"Request"`
+	RequestedBy string `json:"requested_by" table:"Requested By"`
+	AddedAt     string `json:"added_at"     table:"Added At"`
+}
+
+type ApproveOptions struct {
+	AdjustedScopes  []string `json:"adjusted_scopes,omitempty"`
+	AdjustedServers []string `json:"adjusted_servers,omitempty"`
+}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -100,6 +100,7 @@ func GetServerIDByName(ac *client.AlpaconClient, serverName string) (string, err
 	return response.Results[0].ID, nil
 }
 
+// ResolveServerNames converts a list of server names to their UUIDs via sequential API calls (one per name).
 func ResolveServerNames(ac *client.AlpaconClient, names []string) ([]string, error) {
 	ids := make([]string, 0, len(names))
 	for _, name := range names {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -100,6 +100,22 @@ func GetServerIDByName(ac *client.AlpaconClient, serverName string) (string, err
 	return response.Results[0].ID, nil
 }
 
+func ResolveServerNames(ac *client.AlpaconClient, names []string) ([]string, error) {
+	ids := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		id, err := GetServerIDByName(ac, name)
+		if err != nil {
+			return nil, fmt.Errorf("server %q not found: %w", name, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
 func UpdateServer(ac *client.AlpaconClient, serverName string) ([]byte, error) {
 	serverID, err := GetServerIDByName(ac, serverName)
 	if err != nil {

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -7,19 +7,20 @@ import (
 )
 
 type WorkSession struct {
-	ID            string                `json:"id"`
-	Description   string                `json:"description"`
-	Status        string                `json:"status"`
-	RequesterType string                `json:"requester_type"`
-	Scopes        []string              `json:"scopes"`
-	Servers       []types.ServerSummary `json:"servers"`
-	CreatedBy     *types.UserSummary    `json:"created_by"`
-	AssignedUser  *types.UserSummary    `json:"assigned_user"`
-	ExpiresAt     time.Time             `json:"expires_at"`
-	StartedAt     *time.Time            `json:"started_at"`
-	CompletedAt   *time.Time            `json:"completed_at"`
-	AddedAt       time.Time             `json:"added_at"`
-	UpdatedAt     time.Time             `json:"updated_at"`
+	ID                string                `json:"id"`
+	Description       string                `json:"description"`
+	Status            string                `json:"status"`
+	RequesterType     string                `json:"requester_type"`
+	Scopes            []string              `json:"scopes"`
+	Servers           []types.ServerSummary `json:"servers"`
+	CreatedBy         *types.UserSummary    `json:"created_by"`
+	AssignedUser      *types.UserSummary    `json:"assigned_user"`
+	ApprovalRequestID string                `json:"approval_request_id"`
+	ExpiresAt         time.Time             `json:"expires_at"`
+	StartedAt         *time.Time            `json:"started_at"`
+	CompletedAt       *time.Time            `json:"completed_at"`
+	AddedAt           time.Time             `json:"added_at"`
+	UpdatedAt         time.Time             `json:"updated_at"`
 }
 
 type WorkSessionAttributes struct {

--- a/client/client.go
+++ b/client/client.go
@@ -166,7 +166,7 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 		return nil, err
 	}
 
-	if req.Method == http.MethodPost && (resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK) {
+	if req.Method == http.MethodPost && (resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent) {
 		return nil, parseAPIError(respBody)
 	} else if req.Method == http.MethodDelete && resp.StatusCode != http.StatusNoContent {
 		return nil, parseAPIError(respBody)

--- a/client/client.go
+++ b/client/client.go
@@ -166,11 +166,7 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 		return nil, err
 	}
 
-	if req.Method == http.MethodPost && (resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent) {
-		return nil, parseAPIError(respBody)
-	} else if req.Method == http.MethodDelete && resp.StatusCode != http.StatusNoContent {
-		return nil, parseAPIError(respBody)
-	} else if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, parseAPIError(respBody)
 	}
 
@@ -258,7 +254,7 @@ func (ac *AlpaconClient) SendMultipartRequest(url string, multiPartWriter *multi
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, parseAPIError(respBody)
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -222,6 +222,34 @@ func TestSendMultipartRequest_200IsSuccess(t *testing.T) {
 	assert.Equal(t, []byte(`{}`), body)
 }
 
+func TestSendPostRequest_204IsSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	body, err := ac.SendPostRequest("/api/test/", struct{}{})
+	assert.NoError(t, err)
+	assert.Empty(t, body)
+}
+
+func TestSendDeleteRequest_200IsSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	body, err := ac.SendDeleteRequest("/api/test/")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(`{}`), body)
+}
+
 func TestLoadCurrentUser_ErrorIsCachedOnFailure(t *testing.T) {
 	callCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/approval/approval.go
+++ b/cmd/approval/approval.go
@@ -40,5 +40,6 @@ Subcommands for requesters:
 
 func init() {
 	ApprovalCmd.AddCommand(approvalListCmd)
-	// remaining subcommands (describe, approve, reject, cancel) added in T08
+	ApprovalCmd.AddCommand(approvalApproveCmd)
+	// remaining subcommands (describe, reject, cancel) added in T08
 }

--- a/cmd/approval/approval.go
+++ b/cmd/approval/approval.go
@@ -6,12 +6,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	statusFilter string
-	typeFilter   string
-	myRequests   bool
-)
-
 var ApprovalCmd = &cobra.Command{
 	Use:     "approval",
 	Aliases: []string{"req"},

--- a/cmd/approval/approval.go
+++ b/cmd/approval/approval.go
@@ -41,5 +41,6 @@ Subcommands for requesters:
 func init() {
 	ApprovalCmd.AddCommand(approvalListCmd)
 	ApprovalCmd.AddCommand(approvalApproveCmd)
-	// remaining subcommands (describe, reject, cancel) added in T08
+	ApprovalCmd.AddCommand(approvalCancelCmd)
+	// remaining subcommands (describe, reject) added in T08
 }

--- a/cmd/approval/approval.go
+++ b/cmd/approval/approval.go
@@ -40,7 +40,8 @@ Subcommands for requesters:
 
 func init() {
 	ApprovalCmd.AddCommand(approvalListCmd)
+	ApprovalCmd.AddCommand(approvalDescribeCmd)
 	ApprovalCmd.AddCommand(approvalApproveCmd)
+	ApprovalCmd.AddCommand(approvalRejectCmd)
 	ApprovalCmd.AddCommand(approvalCancelCmd)
-	// remaining subcommands (describe, reject) added in T08
 }

--- a/cmd/approval/approval.go
+++ b/cmd/approval/approval.go
@@ -1,0 +1,44 @@
+package approval
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	statusFilter string
+	typeFilter   string
+	myRequests   bool
+)
+
+var ApprovalCmd = &cobra.Command{
+	Use:     "approval",
+	Aliases: []string{"req"},
+	Short:   "List and manage approval requests",
+	Long: `Approval requests are created when actions require administrator
+review—work session creation, sudo policy grants, IAM username
+conflicts, and service token issuance all generate requests that
+a superuser must approve or reject before the action proceeds.
+
+Subcommands for reviewers (superuser only):
+  ls        List pending approval requests
+  describe  Show details of a request
+  approve   Approve a pending request
+  reject    Reject a pending request
+
+Subcommands for requesters:
+  ls --my   List your own pending requests
+  cancel    Cancel a pending request you submitted`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+		return errors.New("a subcommand is required. Use 'alpacon approval ls', 'alpacon approval describe', 'alpacon approval approve', 'alpacon approval reject', or 'alpacon approval cancel'. Run 'alpacon approval --help' for more information")
+	},
+}
+
+func init() {
+	ApprovalCmd.AddCommand(approvalListCmd)
+	// remaining subcommands (describe, approve, reject, cancel) added in T08
+}

--- a/cmd/approval/approval_approve.go
+++ b/cmd/approval/approval_approve.go
@@ -35,13 +35,11 @@ approves the request exactly as submitted.`,
 			AdjustedScopes: utils.CompactStrings(approveScopes),
 		}
 
-		if len(approveServers) > 0 {
-			serverIDs, err := server.ResolveServerNames(ac, approveServers)
-			if err != nil {
-				utils.CliErrorWithExit("%s.", err)
-			}
-			req.AdjustedServers = serverIDs
+		serverIDs, err := server.ResolveServerNames(ac, approveServers)
+		if err != nil {
+			utils.CliErrorWithExit("%s.", err)
 		}
+		req.AdjustedServers = serverIDs
 
 		if err := approvalapi.ApproveRequest(ac, args[0], req); err != nil {
 			utils.CliErrorWithExit("Failed to approve request: %s.", err)

--- a/cmd/approval/approval_approve.go
+++ b/cmd/approval/approval_approve.go
@@ -37,7 +37,7 @@ approves the request exactly as submitted.`,
 
 		serverIDs, err := server.ResolveServerNames(ac, approveServers)
 		if err != nil {
-			utils.CliErrorWithExit("%s.", err)
+			utils.CliErrorWithExit("Failed to resolve server names: %s.", err)
 		}
 		req.AdjustedServers = serverIDs
 

--- a/cmd/approval/approval_approve.go
+++ b/cmd/approval/approval_approve.go
@@ -1,0 +1,75 @@
+package approval
+
+import (
+	"strings"
+
+	approvalapi "github.com/alpacax/alpacon-cli/api/approval"
+	"github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	approveScopes  []string
+	approveServers []string
+)
+
+var approvalApproveCmd = &cobra.Command{
+	Use:   "approve REQUEST_ID",
+	Short: "Approve a pending approval request",
+	Long: `Approve a pending approval request. Superuser only.
+
+For work_session requests, use --scope and --server to narrow
+the granted access at approval time. Omitting these flags
+approves the request exactly as submitted.`,
+	Args: cobra.ExactArgs(1),
+	Example: `  alpacon approval approve apr-abc123
+  alpacon approval approve apr-abc123 --scope command --scope websh
+  alpacon approval approve apr-abc123 --scope command,websh --server web-01`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		var filteredScopes []string
+		for _, s := range approveScopes {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				filteredScopes = append(filteredScopes, s)
+			}
+		}
+
+		req := approvalapi.ApproveOptions{
+			AdjustedScopes: filteredScopes,
+		}
+
+		if len(approveServers) > 0 {
+			serverIDs := make([]string, 0, len(approveServers))
+			for _, name := range approveServers {
+				name = strings.TrimSpace(name)
+				if name == "" {
+					continue
+				}
+				id, err := server.GetServerIDByName(ac, name)
+				if err != nil {
+					utils.CliErrorWithExit("Server %q not found: %s.", name, err)
+				}
+				serverIDs = append(serverIDs, id)
+			}
+			req.AdjustedServers = serverIDs
+		}
+
+		if err := approvalapi.ApproveRequest(ac, args[0], req); err != nil {
+			utils.CliErrorWithExit("Failed to approve request: %s.", err)
+		}
+
+		utils.CliSuccess("Approval request %s approved.", args[0])
+	},
+}
+
+func init() {
+	approvalApproveCmd.Flags().StringSliceVar(&approveScopes, "scope", nil, "Adjust granted scopes (work_session only; repeatable or comma-separated)")
+	approvalApproveCmd.Flags().StringSliceVar(&approveServers, "server", nil, "Adjust target servers by name (work_session only; repeatable or comma-separated)")
+}

--- a/cmd/approval/approval_approve.go
+++ b/cmd/approval/approval_approve.go
@@ -1,8 +1,6 @@
 package approval
 
 import (
-	"strings"
-
 	approvalapi "github.com/alpacax/alpacon-cli/api/approval"
 	"github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/client"
@@ -33,30 +31,14 @@ approves the request exactly as submitted.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		var filteredScopes []string
-		for _, s := range approveScopes {
-			s = strings.TrimSpace(s)
-			if s != "" {
-				filteredScopes = append(filteredScopes, s)
-			}
-		}
-
 		req := approvalapi.ApproveOptions{
-			AdjustedScopes: filteredScopes,
+			AdjustedScopes: utils.CompactStrings(approveScopes),
 		}
 
 		if len(approveServers) > 0 {
-			serverIDs := make([]string, 0, len(approveServers))
-			for _, name := range approveServers {
-				name = strings.TrimSpace(name)
-				if name == "" {
-					continue
-				}
-				id, err := server.GetServerIDByName(ac, name)
-				if err != nil {
-					utils.CliErrorWithExit("Server %q not found: %s.", name, err)
-				}
-				serverIDs = append(serverIDs, id)
+			serverIDs, err := server.ResolveServerNames(ac, approveServers)
+			if err != nil {
+				utils.CliErrorWithExit("%s.", err)
 			}
 			req.AdjustedServers = serverIDs
 		}

--- a/cmd/approval/approval_cancel.go
+++ b/cmd/approval/approval_cancel.go
@@ -1,0 +1,33 @@
+package approval
+
+import (
+	approvalapi "github.com/alpacax/alpacon-cli/api/approval"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var approvalCancelCmd = &cobra.Command{
+	Use:   "cancel REQUEST_ID",
+	Short: "Cancel a pending approval request you submitted",
+	Long: `Cancel a pending approval request. Non-superusers may only cancel
+requests they personally submitted. Superusers may cancel any
+pending request.
+
+Cancelling a work_session request also cancels the linked work
+session.`,
+	Args:    cobra.ExactArgs(1),
+	Example: `  alpacon approval cancel apr-abc123`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if err := approvalapi.CancelRequest(ac, args[0]); err != nil {
+			utils.CliErrorWithExit("Failed to cancel request: %s.", err)
+		}
+
+		utils.CliSuccess("Approval request %s cancelled.", args[0])
+	},
+}

--- a/cmd/approval/approval_describe.go
+++ b/cmd/approval/approval_describe.go
@@ -1,0 +1,68 @@
+package approval
+
+import (
+	approvalapi "github.com/alpacax/alpacon-cli/api/approval"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+type describeRow struct {
+	Field string `table:"Field"`
+	Value string `table:"Value"`
+}
+
+var approvalDescribeCmd = &cobra.Command{
+	Use:     "describe REQUEST_ID",
+	Aliases: []string{"desc"},
+	Short:   "Show details of an approval request",
+	Args:    cobra.ExactArgs(1),
+	Example: `  alpacon approval describe apr-abc123
+  alpacon approval desc apr-abc123`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			body, err := approvalapi.GetApprovalRequestRaw(ac, args[0])
+			if err != nil {
+				utils.CliErrorWithExit("Failed to retrieve approval request: %s.", err)
+			}
+			utils.PrintJson(body)
+			return
+		}
+
+		req, err := approvalapi.GetApprovalRequest(ac, args[0])
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve approval request: %s.", err)
+		}
+
+		requestedBy := ""
+		if req.RequestedBy != nil {
+			requestedBy = req.RequestedBy.Name
+		}
+		reviewedBy := ""
+		if req.ReviewedBy != nil {
+			reviewedBy = req.ReviewedBy.Name
+		}
+		reviewedAt := ""
+		if req.ReviewedAt != nil {
+			reviewedAt = req.ReviewedAt.Local().Format("2006-01-02 15:04")
+		}
+
+		rows := []describeRow{
+			{"ID", req.ID},
+			{"Type", req.RequestType},
+			{"Status", req.Status},
+			{"Request", req.RequestData},
+			{"Description", req.Description},
+			{"Requested by", requestedBy},
+			{"Reviewed by", reviewedBy},
+			{"Reviewed at", reviewedAt},
+			{"Added at", req.AddedAt.Local().Format("2006-01-02 15:04")},
+		}
+		utils.PrintTable(rows)
+	},
+}

--- a/cmd/approval/approval_describe.go
+++ b/cmd/approval/approval_describe.go
@@ -15,8 +15,12 @@ type describeRow struct {
 var approvalDescribeCmd = &cobra.Command{
 	Use:     "describe REQUEST_ID",
 	Aliases: []string{"desc"},
-	Short:   "Show details of an approval request",
-	Args:    cobra.ExactArgs(1),
+	Short: "Show details of an approval request",
+	Long: `Show all fields of an approval request.
+
+Use --output json to see the full raw response including nested
+work session details that are omitted from the table view.`,
+	Args: cobra.ExactArgs(1),
 	Example: `  alpacon approval describe apr-abc123
   alpacon approval desc apr-abc123`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/approval/approval_list.go
+++ b/cmd/approval/approval_list.go
@@ -1,0 +1,86 @@
+package approval
+
+import (
+	"fmt"
+
+	approvalapi "github.com/alpacax/alpacon-cli/api/approval"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var approvalListCmd = &cobra.Command{
+	Use:     "ls",
+	Aliases: []string{"list"},
+	Short:   "List approval requests",
+	Long: `List approval requests. Defaults to pending status.
+
+Superusers see all workspace requests. Non-superusers are
+restricted to their own requests (equivalent to --my).`,
+	Example: `  alpacon approval ls
+  alpacon approval ls --status approved
+  alpacon approval ls --type sudo
+  alpacon approval ls --type work_session --status pending
+  alpacon approval ls --my
+  alpacon approval ls --my --status approved`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := validateStatusFilter(statusFilter); err != nil {
+			utils.CliErrorWithExit("Invalid --status %q: must be one of pending, approved, rejected, cancelled, expired.", statusFilter)
+		}
+		if err := validateTypeFilter(typeFilter); err != nil {
+			utils.CliErrorWithExit("Invalid --type %q: must be one of sudo, work_session, username, groupname, service_token, svc_token_mod, app_username, work_session_mod, sudo_policy.", typeFilter)
+		}
+
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		var requests []approvalapi.ApprovalRequestAttributes
+		if myRequests {
+			requests, err = approvalapi.ListMyApprovalRequests(ac, statusFilter, typeFilter)
+		} else {
+			requests, err = approvalapi.ListApprovalRequests(ac, statusFilter, typeFilter)
+		}
+		if err != nil {
+			utils.CliErrorWithExit("Failed to list approval requests: %s.", err)
+		}
+
+		utils.PrintTable(requests)
+	},
+}
+
+func init() {
+	approvalListCmd.Flags().StringVar(&statusFilter, "status", "pending", "Filter by status: pending|approved|rejected|cancelled|expired")
+	approvalListCmd.Flags().StringVar(&typeFilter, "type", "", "Filter by request type: sudo|work_session|username|groupname|service_token|svc_token_mod|app_username|work_session_mod|sudo_policy")
+	approvalListCmd.Flags().BoolVar(&myRequests, "my", false, "Show only requests you submitted")
+}
+
+func validateStatusFilter(s string) error {
+	if s == "" {
+		return nil
+	}
+	valid := map[string]bool{
+		"pending": true, "approved": true, "rejected": true,
+		"cancelled": true, "expired": true,
+	}
+	if !valid[s] {
+		return fmt.Errorf("invalid status %q", s)
+	}
+	return nil
+}
+
+func validateTypeFilter(s string) error {
+	if s == "" {
+		return nil
+	}
+	valid := map[string]bool{
+		"sudo": true, "work_session": true, "username": true,
+		"groupname": true, "service_token": true, "svc_token_mod": true,
+		"app_username": true, "work_session_mod": true, "sudo_policy": true,
+	}
+	if !valid[s] {
+		return fmt.Errorf("invalid type %q", s)
+	}
+	return nil
+}

--- a/cmd/approval/approval_list.go
+++ b/cmd/approval/approval_list.go
@@ -17,6 +17,13 @@ var (
 	myRequests   bool
 )
 
+var validStatuses = []string{"pending", "approved", "rejected", "cancelled", "expired"}
+
+var validTypes = []string{
+	"sudo", "work_session", "username", "groupname", "service_token",
+	"svc_token_mod", "app_username", "work_session_mod", "sudo_policy",
+}
+
 var approvalListCmd = &cobra.Command{
 	Use:     "ls",
 	Aliases: []string{"list"},
@@ -62,13 +69,6 @@ func init() {
 	approvalListCmd.Flags().StringVar(&statusFilter, "status", "pending", "Filter by status: pending|approved|rejected|cancelled|expired")
 	approvalListCmd.Flags().StringVar(&typeFilter, "type", "", "Filter by request type: sudo|work_session|username|groupname|service_token|svc_token_mod|app_username|work_session_mod|sudo_policy")
 	approvalListCmd.Flags().BoolVar(&myRequests, "my", false, "Show only requests you submitted")
-}
-
-var validStatuses = []string{"pending", "approved", "rejected", "cancelled", "expired"}
-
-var validTypes = []string{
-	"sudo", "work_session", "username", "groupname", "service_token",
-	"svc_token_mod", "app_username", "work_session_mod", "sudo_policy",
 }
 
 func validateEnumFlag(flag, value string, valid []string) error {

--- a/cmd/approval/approval_list.go
+++ b/cmd/approval/approval_list.go
@@ -71,16 +71,12 @@ var validTypes = []string{
 	"svc_token_mod", "app_username", "work_session_mod", "sudo_policy",
 }
 
-func validateStatusFilter(s string) error {
-	if s == "" || slices.Contains(validStatuses, s) {
+func validateEnumFlag(flag, value string, valid []string) error {
+	if value == "" || slices.Contains(valid, value) {
 		return nil
 	}
-	return fmt.Errorf("invalid --status %q: must be one of %s", s, strings.Join(validStatuses, ", "))
+	return fmt.Errorf("invalid --%s %q: must be one of %s", flag, value, strings.Join(valid, ", "))
 }
 
-func validateTypeFilter(s string) error {
-	if s == "" || slices.Contains(validTypes, s) {
-		return nil
-	}
-	return fmt.Errorf("invalid --type %q: must be one of %s", s, strings.Join(validTypes, ", "))
-}
+func validateStatusFilter(s string) error { return validateEnumFlag("status", s, validStatuses) }
+func validateTypeFilter(s string) error    { return validateEnumFlag("type", s, validTypes) }

--- a/cmd/approval/approval_list.go
+++ b/cmd/approval/approval_list.go
@@ -33,10 +33,10 @@ restricted to their own requests (equivalent to --my).`,
   alpacon approval ls --my --status approved`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := validateStatusFilter(statusFilter); err != nil {
-			utils.CliErrorWithExit("%s.", err)
+			utils.CliErrorWithExit("%s", err)
 		}
 		if err := validateTypeFilter(typeFilter); err != nil {
-			utils.CliErrorWithExit("%s.", err)
+			utils.CliErrorWithExit("%s", err)
 		}
 
 		ac, err := client.NewAlpaconAPIClient()

--- a/cmd/approval/approval_list.go
+++ b/cmd/approval/approval_list.go
@@ -51,8 +51,21 @@ restricted to their own requests (equivalent to --my).`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
+		// Server enforces /api/approvals/approvals/ as superuser-only. Auto-fall back to
+		// the my-requests endpoint for non-superusers so the default `approval ls` does not
+		// return a confusing 403.
+		useMyEndpoint := myRequests
+		if !useMyEndpoint {
+			if err := ac.LoadCurrentUser(); err != nil {
+				utils.CliErrorWithExit("Failed to load current user: %s.", err)
+			}
+			if ac.Privileges != "superuser" {
+				useMyEndpoint = true
+			}
+		}
+
 		var requests []approvalapi.ApprovalRequestAttributes
-		if myRequests {
+		if useMyEndpoint {
 			requests, err = approvalapi.ListMyApprovalRequests(ac, statusFilter, typeFilter)
 		} else {
 			requests, err = approvalapi.ListApprovalRequests(ac, statusFilter, typeFilter)

--- a/cmd/approval/approval_list.go
+++ b/cmd/approval/approval_list.go
@@ -33,10 +33,10 @@ restricted to their own requests (equivalent to --my).`,
   alpacon approval ls --my --status approved`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := validateStatusFilter(statusFilter); err != nil {
-			utils.CliErrorWithExit("%s", err)
+			utils.CliErrorWithExit("%s.", err)
 		}
 		if err := validateTypeFilter(typeFilter); err != nil {
-			utils.CliErrorWithExit("%s", err)
+			utils.CliErrorWithExit("%s.", err)
 		}
 
 		ac, err := client.NewAlpaconAPIClient()

--- a/cmd/approval/approval_list.go
+++ b/cmd/approval/approval_list.go
@@ -2,6 +2,8 @@ package approval
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	approvalapi "github.com/alpacax/alpacon-cli/api/approval"
 	"github.com/alpacax/alpacon-cli/client"
@@ -25,10 +27,10 @@ restricted to their own requests (equivalent to --my).`,
   alpacon approval ls --my --status approved`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := validateStatusFilter(statusFilter); err != nil {
-			utils.CliErrorWithExit("Invalid --status %q: must be one of pending, approved, rejected, cancelled, expired.", statusFilter)
+			utils.CliErrorWithExit("%s.", err)
 		}
 		if err := validateTypeFilter(typeFilter); err != nil {
-			utils.CliErrorWithExit("Invalid --type %q: must be one of sudo, work_session, username, groupname, service_token, svc_token_mod, app_username, work_session_mod, sudo_policy.", typeFilter)
+			utils.CliErrorWithExit("%s.", err)
 		}
 
 		ac, err := client.NewAlpaconAPIClient()
@@ -56,31 +58,23 @@ func init() {
 	approvalListCmd.Flags().BoolVar(&myRequests, "my", false, "Show only requests you submitted")
 }
 
+var validStatuses = []string{"pending", "approved", "rejected", "cancelled", "expired"}
+
+var validTypes = []string{
+	"sudo", "work_session", "username", "groupname", "service_token",
+	"svc_token_mod", "app_username", "work_session_mod", "sudo_policy",
+}
+
 func validateStatusFilter(s string) error {
-	if s == "" {
+	if s == "" || slices.Contains(validStatuses, s) {
 		return nil
 	}
-	valid := map[string]bool{
-		"pending": true, "approved": true, "rejected": true,
-		"cancelled": true, "expired": true,
-	}
-	if !valid[s] {
-		return fmt.Errorf("invalid status %q", s)
-	}
-	return nil
+	return fmt.Errorf("invalid --status %q: must be one of %s", s, strings.Join(validStatuses, ", "))
 }
 
 func validateTypeFilter(s string) error {
-	if s == "" {
+	if s == "" || slices.Contains(validTypes, s) {
 		return nil
 	}
-	valid := map[string]bool{
-		"sudo": true, "work_session": true, "username": true,
-		"groupname": true, "service_token": true, "svc_token_mod": true,
-		"app_username": true, "work_session_mod": true, "sudo_policy": true,
-	}
-	if !valid[s] {
-		return fmt.Errorf("invalid type %q", s)
-	}
-	return nil
+	return fmt.Errorf("invalid --type %q: must be one of %s", s, strings.Join(validTypes, ", "))
 }

--- a/cmd/approval/approval_list.go
+++ b/cmd/approval/approval_list.go
@@ -11,6 +11,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	statusFilter string
+	typeFilter   string
+	myRequests   bool
+)
+
 var approvalListCmd = &cobra.Command{
 	Use:     "ls",
 	Aliases: []string{"list"},

--- a/cmd/approval/approval_list_test.go
+++ b/cmd/approval/approval_list_test.go
@@ -1,0 +1,60 @@
+package approval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateStatusFilter(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantErr bool
+	}{
+		{"", false},
+		{"pending", false},
+		{"approved", false},
+		{"rejected", false},
+		{"cancelled", false},
+		{"expired", false},
+		{"unknown", true},
+		{"PENDING", true},
+		{"active", true},
+	}
+	for _, tc := range cases {
+		err := validateStatusFilter(tc.input)
+		if tc.wantErr {
+			assert.Error(t, err, "input: %q", tc.input)
+		} else {
+			assert.NoError(t, err, "input: %q", tc.input)
+		}
+	}
+}
+
+func TestValidateTypeFilter(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantErr bool
+	}{
+		{"", false},
+		{"sudo", false},
+		{"work_session", false},
+		{"username", false},
+		{"groupname", false},
+		{"service_token", false},
+		{"svc_token_mod", false},
+		{"app_username", false},
+		{"work_session_mod", false},
+		{"sudo_policy", false},
+		{"bad_type", true},
+		{"WorkSession", true},
+	}
+	for _, tc := range cases {
+		err := validateTypeFilter(tc.input)
+		if tc.wantErr {
+			assert.Error(t, err, "input: %q", tc.input)
+		} else {
+			assert.NoError(t, err, "input: %q", tc.input)
+		}
+	}
+}

--- a/cmd/approval/approval_reject.go
+++ b/cmd/approval/approval_reject.go
@@ -1,0 +1,28 @@
+package approval
+
+import (
+	approvalapi "github.com/alpacax/alpacon-cli/api/approval"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var approvalRejectCmd = &cobra.Command{
+	Use:     "reject REQUEST_ID",
+	Short:   "Reject a pending approval request",
+	Long:    "Reject a pending approval request. Superuser only.",
+	Args:    cobra.ExactArgs(1),
+	Example: `  alpacon approval reject apr-abc123`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if err := approvalapi.RejectRequest(ac, args[0]); err != nil {
+			utils.CliErrorWithExit("Failed to reject request: %s.", err)
+		}
+
+		utils.CliSuccess("Approval request %s rejected.", args[0])
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/alpacax/alpacon-cli/cmd/agent"
+	"github.com/alpacax/alpacon-cli/cmd/approval"
 	"github.com/alpacax/alpacon-cli/cmd/audit"
 	"github.com/alpacax/alpacon-cli/cmd/authority"
 	"github.com/alpacax/alpacon-cli/cmd/cert"
@@ -141,6 +142,9 @@ func init() {
 
 	// work-session
 	RootCmd.AddCommand(worksession.WorkSessionCmd)
+
+	// approval
+	RootCmd.AddCommand(approval.ApprovalCmd)
 
 	// whoami
 	RootCmd.AddCommand(whoamiCmd)

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -1,8 +1,6 @@
 package worksession
 
 import (
-	"strings"
-
 	"github.com/alpacax/alpacon-cli/api/server"
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
@@ -32,29 +30,14 @@ Use --scope and --server to narrow down the granted access at approval time.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		var filteredScopes []string
-		for _, s := range approveScopes {
-			s = strings.TrimSpace(s)
-			if s != "" {
-				filteredScopes = append(filteredScopes, s)
-			}
-		}
 		req := wsapi.WorkSessionApproveRequest{
-			AdjustedScopes: filteredScopes,
+			AdjustedScopes: utils.CompactStrings(approveScopes),
 		}
 
 		if len(approveServers) > 0 {
-			serverIDs := make([]string, 0, len(approveServers))
-			for _, name := range approveServers {
-				name = strings.TrimSpace(name)
-				if name == "" {
-					continue
-				}
-				id, err := server.GetServerIDByName(ac, name)
-				if err != nil {
-					utils.CliErrorWithExit("Server %q not found: %s.", name, err)
-				}
-				serverIDs = append(serverIDs, id)
+			serverIDs, err := server.ResolveServerNames(ac, approveServers)
+			if err != nil {
+				utils.CliErrorWithExit("%s.", err)
 			}
 			req.AdjustedServers = serverIDs
 		}

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -123,22 +123,13 @@ active state.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		var serverNames []string
-		for _, s := range createServers {
-			if s = strings.TrimSpace(s); s != "" {
-				serverNames = append(serverNames, s)
-			}
-		}
+		serverNames := utils.CompactStrings(createServers)
 		if len(serverNames) == 0 {
 			utils.CliErrorWithExit("--server must contain at least one valid server name.")
 		}
-		serverIDs := make([]string, 0, len(serverNames))
-		for _, name := range serverNames {
-			id, err := server.GetServerIDByName(ac, name)
-			if err != nil {
-				utils.CliErrorWithExit("Server %q not found: %s.", name, err)
-			}
-			serverIDs = append(serverIDs, id)
+		serverIDs, err := server.ResolveServerNames(ac, serverNames)
+		if err != nil {
+			utils.CliErrorWithExit("%s.", err)
 		}
 
 		req := wsapi.WorkSessionCreateRequest{

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -145,7 +145,11 @@ active state.`,
 			utils.CliErrorWithExit("Failed to create work session: %s.", err)
 		}
 
-		utils.CliSuccess("Work session created: %s (status: %s)", session.ID, session.Status)
+		if session.ApprovalRequestID != "" {
+			utils.CliSuccess("Work session created: %s (status: %s, approval request: %s)", session.ID, session.Status, session.ApprovalRequestID)
+		} else {
+			utils.CliSuccess("Work session created: %s (status: %s)", session.ID, session.Status)
+		}
 
 		// Phase 1: post-create decision. Cases without an explicit return delegate to
 		// the --wait branch below (or exit immediately when --wait is not set).

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -23,6 +23,15 @@ const (
 	waitMsgActivation = "Waiting for activation..."
 )
 
+type useDecision int
+
+const (
+	useDecisionNoop useDecision = iota
+	useDecisionUseNow
+	useDecisionErrorNeedsWait
+	useDecisionSkipScheduled
+)
+
 var validScopePresets = []string{"command", "editor", "sudo", "tunnel", "webftp", "websh"}
 
 var (
@@ -186,15 +195,6 @@ active state.`,
 		attachActiveOrExit(ac, session.ID, "Work session %s approved but failed to set as active: %s. Run 'alpacon work-session use %s' to retry.", fmt.Sprintf("Work session %s approved. ", session.ID))
 	},
 }
-
-type useDecision int
-
-const (
-	useDecisionNoop useDecision = iota
-	useDecisionUseNow
-	useDecisionErrorNeedsWait
-	useDecisionSkipScheduled
-)
 
 // attachActiveOrExit calls RunUse and prints either a success line (with description if present)
 // or exits with the supplied error format (which receives session ID, error, session ID in order).

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -551,6 +551,16 @@ func IsInteractiveShell() bool {
 
 // SplitAndTrim splits s by sep, trims whitespace from each element, and drops empty entries.
 // Returns nil when the input is empty or yields no non-empty elements.
+func CompactStrings(ss []string) []string {
+	var out []string
+	for _, s := range ss {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 func SplitAndTrim(s, sep string) []string {
 	if s == "" {
 		return nil

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -549,8 +549,7 @@ func IsInteractiveShell() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
-// SplitAndTrim splits s by sep, trims whitespace from each element, and drops empty entries.
-// Returns nil when the input is empty or yields no non-empty elements.
+// CompactStrings trims whitespace from each element and drops empty entries.
 func CompactStrings(ss []string) []string {
 	var out []string
 	for _, s := range ss {
@@ -561,6 +560,8 @@ func CompactStrings(ss []string) []string {
 	return out
 }
 
+// SplitAndTrim splits s by sep, trims whitespace from each element, and drops empty entries.
+// Returns nil when the input is empty or yields no non-empty elements.
 func SplitAndTrim(s, sep string) []string {
 	if s == "" {
 		return nil


### PR DESCRIPTION
## Summary
Adds the `alpacon approval` command family for managing approval requests from the CLI.

Subcommands:
- `approval ls` (alias `list`) — list approval requests, with `--status`, `--type`, `--my` filters. Non-superusers running `approval ls` without `--my` are auto-scoped to their own requests (server enforces the all-requests endpoint as superuser-only).
- `approval describe ID` (alias `desc`) — show details of a single request
- `approval approve ID` — approve a request (with optional `--adjusted-scopes`, `--adjusted-servers` for work_session requests)
- `approval reject ID` — reject a request
- `approval cancel ID` — cancel a pending request you submitted

All commands honor the global `--output json|table` flag.

## Related
Depends on alpacax/alpacon-server#2147 (`approval_request_id` exposure on `WorkSessionSerializer`) for the `work-session create` UX improvement that surfaces the approval request id inline. The CLI change is backward-compatible: when the server does not return the field, the create message falls back to the original format.

**Merge order:** server PR #2147 first, then this PR.

Closes #188

## Test plan
- [ ] `approval ls` returns pending requests by default; `--status` / `--type` filters work
- [ ] `approval ls --my` returns only the current user's requests (non-superuser path uses `/api/approvals/approvals/-/`)
- [ ] `approval ls` as a non-superuser (without `--my`) auto-routes to the my-requests endpoint instead of returning 403
- [ ] `approval describe ID` table view and `--output json` raw view both work, including nested `work_session` payload in JSON
- [ ] `approval approve ID` succeeds on a pending request; rejected/cancelled responses propagate error
- [ ] `approval reject ID` succeeds on a pending request
- [ ] `approval cancel ID` succeeds for the requester; superuser may cancel others
- [ ] After alpacon-server #2147 merges, `work-session create` (non-superuser) emits `Work session created: <id> (status: pending, approval request: <approval_id>)`; superuser path is unchanged