### PR TITLE
feat(exec): stream command output via WebSocket with REST fallback

### DIFF
--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -1,0 +1,24 @@
+package event
+
+import (
+	"strconv"
+
+	"github.com/alpacax/alpacon-cli/api"
+	"github.com/alpacax/alpacon-cli/client"
+)
+
+// Chunk represents a single stdout/stderr chunk produced during command execution.
+type Chunk struct {
+	Seq     int    `json:"seq"`
+	Content string `json:"content"`
+}
+
+// GetCommandChunks fetches all chunks for cmdID whose seq is >= fromSeq.
+// Pagination is handled transparently by api.FetchAllPages.
+func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq int) ([]Chunk, error) {
+	endpoint := "/api/events/commands/" + cmdID + "/chunks/"
+	params := map[string]string{
+		"seq__gte": strconv.Itoa(fromSeq),
+	}
+	return api.FetchAllPages[Chunk](ac, endpoint, params)
+}

--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"sort"
 	"strconv"
 
 	"github.com/alpacax/alpacon-cli/api"
@@ -14,11 +15,20 @@ type Chunk struct {
 }
 
 // GetCommandChunks fetches all chunks for cmdID whose seq is >= fromSeq.
-// Pagination is handled transparently by api.FetchAllPages.
+// Pagination is handled transparently by api.FetchAllPages. Results are sorted
+// by seq ascending: the streaming consumers (warm-fire, gap-fill, drain) rely
+// on this invariant, so we request server-side ordering and also sort
+// defensively in case the server does not honor it (or paginates unordered).
 func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq int) ([]Chunk, error) {
 	endpoint := "/api/events/commands/" + cmdID + "/chunks/"
 	params := map[string]string{
 		"seq__gte": strconv.Itoa(fromSeq),
+		"ordering": "seq",
 	}
-	return api.FetchAllPages[Chunk](ac, endpoint, params)
+	chunks, err := api.FetchAllPages[Chunk](ac, endpoint, params)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(chunks, func(i, j int) bool { return chunks[i].Seq < chunks[j].Seq })
+	return chunks, nil
 }

--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -33,9 +33,8 @@ func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq int) ([]Ch
 }
 
 // GetCommandOutput reconstructs the full command output from its chunks in seq
-// order. Empty when no chunks were produced. Used by paths that don't stream
-// live (polling fallback, exec logs) where Result is empty under the chunk
-// contract.
+// order. Empty when no chunks were produced. Used by exec logs, which doesn't
+// stream live, where Result is empty under the chunk contract.
 func GetCommandOutput(ac *client.AlpaconClient, cmdID string) (string, error) {
 	chunks, err := GetCommandChunks(ac, cmdID, 0)
 	if err != nil {

--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -3,6 +3,7 @@ package event
 import (
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/client"
@@ -29,4 +30,20 @@ func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq int) ([]Ch
 	}
 	sort.Slice(chunks, func(i, j int) bool { return chunks[i].Seq < chunks[j].Seq })
 	return chunks, nil
+}
+
+// GetCommandOutput reconstructs the full command output from its chunks in seq
+// order. Empty when no chunks were produced. Used by paths that don't stream
+// live (polling fallback, exec logs) where Result is empty under the chunk
+// contract.
+func GetCommandOutput(ac *client.AlpaconClient, cmdID string) (string, error) {
+	chunks, err := GetCommandChunks(ac, cmdID, 0)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for _, c := range chunks {
+		b.WriteString(c.Content)
+	}
+	return b.String(), nil
 }

--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -33,8 +33,8 @@ func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq int) ([]Ch
 }
 
 // GetCommandOutput reconstructs the full command output from its chunks in seq
-// order. Empty when no chunks were produced. Used by exec logs, which doesn't
-// stream live, where Result is empty under the chunk contract.
+// order. Empty when no chunks were produced. Used by non-streaming paths (exec
+// logs, polling fallback) where Result is empty under the chunk contract.
 func GetCommandOutput(ac *client.AlpaconClient, cmdID string) (string, error) {
 	chunks, err := GetCommandChunks(ac, cmdID, 0)
 	if err != nil {

--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -14,11 +14,9 @@ type Chunk struct {
 	Content string `json:"content"`
 }
 
-// GetCommandChunks fetches all chunks for cmdID whose seq is >= fromSeq.
-// Pagination is handled transparently by api.FetchAllPages. Results are sorted
-// by seq ascending: the streaming consumers (warm-fire, gap-fill, drain) rely
-// on this invariant, so we request server-side ordering and also sort
-// defensively in case the server does not honor it (or paginates unordered).
+// GetCommandChunks fetches chunks for cmdID with seq >= fromSeq, sorted by seq
+// ascending. The streaming consumers rely on that order, so we sort defensively
+// in case the server does not honor the ordering param.
 func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq int) ([]Chunk, error) {
 	endpoint := "/api/events/commands/" + cmdID + "/chunks/"
 	params := map[string]string{

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -48,6 +48,32 @@ func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
 	assert.Contains(t, capturedQuery, "ordering=seq")
 }
 
+// TestGetCommandOutput_ConcatenatesChunksInSeqOrder verifies the full output is
+// reconstructed from chunks in seq order regardless of server ordering.
+func TestGetCommandOutput_ConcatenatesChunksInSeqOrder(t *testing.T) {
+	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := api.ListResponse[Chunk]{
+			Count: 3,
+			Results: []Chunk{
+				{Seq: 1, Content: "b\n"},
+				{Seq: 0, Content: "a\n"},
+				{Seq: 2, Content: "c\n"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	got, err := GetCommandOutput(ac, cmdID)
+	require.NoError(t, err)
+	assert.Equal(t, "a\nb\nc\n", got)
+}
+
 // TestGetCommandChunks_SortsBySeq verifies out-of-order server results are
 // returned sorted by seq.
 func TestGetCommandChunks_SortsBySeq(t *testing.T) {

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -45,4 +45,36 @@ func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
 		{Seq: 6, Content: "world\n"},
 	}, got)
 	assert.Contains(t, capturedQuery, "seq__gte=5")
+	assert.Contains(t, capturedQuery, "ordering=seq")
+}
+
+// TestGetCommandChunks_SortsBySeq guards the seq-ascending invariant the
+// streaming consumers rely on: even if the server returns chunks out of order,
+// GetCommandChunks must return them sorted by seq.
+func TestGetCommandChunks_SortsBySeq(t *testing.T) {
+	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := api.ListResponse[Chunk]{
+			Count: 3,
+			Results: []Chunk{
+				{Seq: 2, Content: "c\n"},
+				{Seq: 0, Content: "a\n"},
+				{Seq: 1, Content: "b\n"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	got, err := GetCommandChunks(ac, cmdID, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []Chunk{
+		{Seq: 0, Content: "a\n"},
+		{Seq: 1, Content: "b\n"},
+		{Seq: 2, Content: "c\n"},
+	}, got)
 }

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -1,0 +1,48 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/api"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
+	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
+	var capturedQuery string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasPrefix(r.URL.Path, fmt.Sprintf("/api/events/commands/%s/chunks/", cmdID)),
+			"unexpected path: %s", r.URL.Path)
+		capturedQuery = r.URL.RawQuery
+
+		resp := api.ListResponse[Chunk]{
+			Count: 2,
+			Results: []Chunk{
+				{Seq: 5, Content: "hello\n"},
+				{Seq: 6, Content: "world\n"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	got, err := GetCommandChunks(ac, cmdID, 5)
+	require.NoError(t, err)
+	assert.Equal(t, []Chunk{
+		{Seq: 5, Content: "hello\n"},
+		{Seq: 6, Content: "world\n"},
+	}, got)
+	assert.Contains(t, capturedQuery, "seq__gte=5")
+}

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -48,9 +48,8 @@ func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
 	assert.Contains(t, capturedQuery, "ordering=seq")
 }
 
-// TestGetCommandChunks_SortsBySeq guards the seq-ascending invariant the
-// streaming consumers rely on: even if the server returns chunks out of order,
-// GetCommandChunks must return them sorted by seq.
+// TestGetCommandChunks_SortsBySeq verifies out-of-order server results are
+// returned sorted by seq.
 func TestGetCommandChunks_SortsBySeq(t *testing.T) {
 	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
 

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -86,10 +86,8 @@ func (l *CommandOutputListener) setCommandID(id string) {
 	l.mu.Unlock()
 }
 
-// NewCommandOutputListener constructs a listener without connecting.
-// ac is reserved for header-building; pass nil to use the empty header
-// (useful in tests). commandID may be empty at construction time and set
-// later via setCommandID once SubmitCommand returns.
+// NewCommandOutputListener constructs a listener without connecting. ac may be
+// nil (empty header, for tests); commandID may be set later via setCommandID.
 func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string) *CommandOutputListener {
 	var header http.Header
 	if ac != nil {

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -2,7 +2,6 @@ package event
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -30,7 +29,6 @@ type ChunkEvent struct {
 // Lifecycle: NewCommandOutputListener -> Start -> (consume Chunks) -> Stop.
 // Stop is idempotent and safe to call from any goroutine.
 type CommandOutputListener struct {
-	ac          *client.AlpaconClient
 	wsURL       string
 	wsHeader    http.Header
 	commandID   string
@@ -96,7 +94,6 @@ func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string)
 		header = http.Header{}
 	}
 	return &CommandOutputListener{
-		ac:        ac,
 		wsURL:     wsURL,
 		wsHeader:  header,
 		commandID: commandID,
@@ -156,8 +153,7 @@ func (l *CommandOutputListener) listenLoop() {
 		default:
 		}
 
-		connected, _ := l.connectAndListen()
-		if connected {
+		if l.connectAndListen() {
 			delay = commandOutputReconnectBase
 		}
 
@@ -173,11 +169,13 @@ func (l *CommandOutputListener) listenLoop() {
 	}
 }
 
-func (l *CommandOutputListener) connectAndListen() (connected bool, err error) {
+// connectAndListen dials, reads frames until the connection drops or Stop is
+// called, and returns whether a connection was established (to reset backoff).
+func (l *CommandOutputListener) connectAndListen() (connected bool) {
 	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
 	conn, _, dialErr := dialer.Dial(l.wsURL, l.wsHeader)
 	if dialErr != nil {
-		return false, fmt.Errorf("event websocket connection failed: %w", dialErr)
+		return false
 	}
 
 	l.mu.Lock()
@@ -196,17 +194,12 @@ func (l *CommandOutputListener) connectAndListen() (connected bool, err error) {
 	for {
 		select {
 		case <-l.done:
-			return true, nil
+			return true
 		default:
 		}
 		_, message, readErr := conn.ReadMessage()
 		if readErr != nil {
-			select {
-			case <-l.done:
-				return true, nil
-			default:
-			}
-			return true, fmt.Errorf("event websocket read error: %w", readErr)
+			return true
 		}
 		l.handleMessage(message)
 	}

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -12,9 +12,10 @@ import (
 
 const (
 	// Mirror sudolistener backoff to keep reconnection behavior consistent.
-	commandOutputReconnectBase = 1 * time.Second
-	commandOutputReconnectMax  = 30 * time.Second
-	commandOutputChunkBuffer   = 256
+	commandOutputReconnectBase  = 1 * time.Second
+	commandOutputReconnectMax   = 30 * time.Second
+	commandOutputChunkBuffer    = 256
+	commandOutputConnectTimeout = 5 * time.Second
 )
 
 // ChunkEvent is a single command_output chunk emitted by the listener.
@@ -164,7 +165,8 @@ func (l *CommandOutputListener) listenLoop() {
 // connectAndListen dials, reads frames until the connection drops or Stop is
 // called, and returns whether a connection was established (to reset backoff).
 func (l *CommandOutputListener) connectAndListen() (connected bool) {
-	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+	// Match the WaitConnected budget so a slow dial can't outlive the wait and leak past fallback.
+	dialer := websocket.Dialer{HandshakeTimeout: commandOutputConnectTimeout}
 	conn, _, dialErr := dialer.Dial(l.wsURL, l.wsHeader)
 	if dialErr != nil {
 		return false

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -2,11 +2,20 @@ package event
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/gorilla/websocket"
+)
+
+const (
+	// Mirror sudolistener backoff to keep reconnection behavior consistent.
+	commandOutputReconnectBase = 1 * time.Second
+	commandOutputReconnectMax  = 30 * time.Second
+	commandOutputChunkBuffer   = 256
 )
 
 // ChunkEvent is a single command_output chunk emitted by the listener.
@@ -63,5 +72,133 @@ func (l *CommandOutputListener) handleMessage(raw []byte) {
 	select {
 	case l.chunks <- ChunkEvent{Seq: env.Payload.Seq, Content: env.Payload.Content}:
 	case <-l.done:
+	}
+}
+
+// NewCommandOutputListener constructs a listener without connecting.
+// ac is reserved for header-building; pass nil to use the empty header
+// (useful in tests). commandID may be empty at construction time and set
+// later via setCommandID once SubmitCommand returns.
+func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string) *CommandOutputListener {
+	var header http.Header
+	if ac != nil {
+		header = ac.SetWebsocketHeader()
+	} else {
+		header = http.Header{}
+	}
+	return &CommandOutputListener{
+		ac:        ac,
+		wsURL:     wsURL,
+		wsHeader:  header,
+		commandID: commandID,
+		chunks:    make(chan ChunkEvent, commandOutputChunkBuffer),
+		done:      make(chan struct{}),
+		stopped:   make(chan struct{}),
+		connected: make(chan struct{}),
+	}
+}
+
+// Start begins the WebSocket receive loop in a background goroutine.
+// It automatically reconnects with exponential backoff until Stop() is called.
+func (l *CommandOutputListener) Start() {
+	go func() {
+		defer close(l.stopped)
+		l.listenLoop()
+	}()
+}
+
+// Chunks returns a receive-only channel of parsed chunk events.
+func (l *CommandOutputListener) Chunks() <-chan ChunkEvent { return l.chunks }
+
+// Done returns a channel closed when the listener has fully stopped.
+func (l *CommandOutputListener) Done() <-chan struct{} { return l.stopped }
+
+// WaitConnected blocks until the first successful WS connection is made or
+// timeout / shutdown intervenes. Returns true on success.
+func (l *CommandOutputListener) WaitConnected(timeout time.Duration) bool {
+	select {
+	case <-l.connected:
+		return true
+	case <-l.done:
+		return false
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// Stop closes the listener; safe to call multiple times and from any goroutine.
+func (l *CommandOutputListener) Stop() {
+	l.closeOnce.Do(func() {
+		close(l.done)
+		l.mu.Lock()
+		if l.conn != nil {
+			_ = l.conn.Close()
+		}
+		l.mu.Unlock()
+	})
+}
+
+func (l *CommandOutputListener) listenLoop() {
+	delay := commandOutputReconnectBase
+	for {
+		select {
+		case <-l.done:
+			return
+		default:
+		}
+
+		connected, _ := l.connectAndListen()
+		if connected {
+			delay = commandOutputReconnectBase
+		}
+
+		select {
+		case <-l.done:
+			return
+		case <-time.After(delay):
+			delay *= 2
+			if delay > commandOutputReconnectMax {
+				delay = commandOutputReconnectMax
+			}
+		}
+	}
+}
+
+func (l *CommandOutputListener) connectAndListen() (connected bool, err error) {
+	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+	conn, _, dialErr := dialer.Dial(l.wsURL, l.wsHeader)
+	if dialErr != nil {
+		return false, fmt.Errorf("event websocket connection failed: %w", dialErr)
+	}
+
+	l.mu.Lock()
+	l.conn = conn
+	l.mu.Unlock()
+
+	l.connectOnce.Do(func() { close(l.connected) })
+
+	defer func() {
+		l.mu.Lock()
+		l.conn = nil
+		l.mu.Unlock()
+		_ = conn.Close()
+	}()
+
+	for {
+		select {
+		case <-l.done:
+			return true, nil
+		default:
+		}
+		_, message, readErr := conn.ReadMessage()
+		if readErr != nil {
+			select {
+			case <-l.done:
+				return true, nil
+			default:
+			}
+			return true, fmt.Errorf("event websocket read error: %w", readErr)
+		}
+		l.handleMessage(message)
 	}
 }

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -34,7 +34,6 @@ type CommandOutputListener struct {
 	commandID   string
 	chunks      chan ChunkEvent
 	done        chan struct{}
-	stopped     chan struct{}
 	connected   chan struct{}
 	connectOnce sync.Once
 	closeOnce   sync.Once
@@ -99,7 +98,6 @@ func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string)
 		commandID: commandID,
 		chunks:    make(chan ChunkEvent, commandOutputChunkBuffer),
 		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
 		connected: make(chan struct{}),
 	}
 }
@@ -107,17 +105,11 @@ func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string)
 // Start begins the WebSocket receive loop in a background goroutine.
 // It automatically reconnects with exponential backoff until Stop() is called.
 func (l *CommandOutputListener) Start() {
-	go func() {
-		defer close(l.stopped)
-		l.listenLoop()
-	}()
+	go l.listenLoop()
 }
 
 // Chunks returns a receive-only channel of parsed chunk events.
 func (l *CommandOutputListener) Chunks() <-chan ChunkEvent { return l.chunks }
-
-// Done returns a channel closed when the listener has fully stopped.
-func (l *CommandOutputListener) Done() <-chan struct{} { return l.stopped }
 
 // WaitConnected blocks until the first successful WS connection is made or
 // timeout / shutdown intervenes. Returns true on success.

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -65,7 +65,10 @@ func (l *CommandOutputListener) handleMessage(raw []byte) {
 	if env.EventType != "command_output" {
 		return
 	}
-	if env.Payload.CommandID != l.commandID {
+	l.mu.Lock()
+	cid := l.commandID
+	l.mu.Unlock()
+	if env.Payload.CommandID != cid {
 		return
 	}
 
@@ -73,6 +76,14 @@ func (l *CommandOutputListener) handleMessage(raw []byte) {
 	case l.chunks <- ChunkEvent{Seq: env.Payload.Seq, Content: env.Payload.Content}:
 	case <-l.done:
 	}
+}
+
+// setCommandID assigns the commandID after construction. Used because
+// SubmitCommand must run after the WS is already connected.
+func (l *CommandOutputListener) setCommandID(id string) {
+	l.mu.Lock()
+	l.commandID = id
+	l.mu.Unlock()
 }
 
 // NewCommandOutputListener constructs a listener without connecting.

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -1,0 +1,67 @@
+package event
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/gorilla/websocket"
+)
+
+// ChunkEvent is a single command_output chunk emitted by the listener.
+type ChunkEvent struct {
+	Seq     int
+	Content string
+}
+
+// CommandOutputListener subscribes to a single command's chunk stream over
+// the event WebSocket and exposes received chunks via the Chunks() channel.
+//
+// Lifecycle: NewCommandOutputListener -> Start -> (consume Chunks) -> Stop.
+// Stop is idempotent and safe to call from any goroutine.
+type CommandOutputListener struct {
+	ac          *client.AlpaconClient
+	wsURL       string
+	wsHeader    http.Header
+	commandID   string
+	chunks      chan ChunkEvent
+	done        chan struct{}
+	stopped     chan struct{}
+	connected   chan struct{}
+	connectOnce sync.Once
+	closeOnce   sync.Once
+	mu          sync.Mutex
+	conn        *websocket.Conn
+}
+
+// commandOutputEnvelope is the WS message format emitted by alpacon-server.
+type commandOutputEnvelope struct {
+	EventType string `json:"event_type"`
+	Payload   struct {
+		CommandID string `json:"command_id"`
+		Seq       int    `json:"seq"`
+		Content   string `json:"content"`
+	} `json:"payload"`
+}
+
+// handleMessage parses one WS frame and pushes a matching chunk onto chunks.
+// Non-matching frames (wrong event_type, wrong command_id, parse failure) are
+// silently dropped.
+func (l *CommandOutputListener) handleMessage(raw []byte) {
+	var env commandOutputEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return
+	}
+	if env.EventType != "command_output" {
+		return
+	}
+	if env.Payload.CommandID != l.commandID {
+		return
+	}
+
+	select {
+	case l.chunks <- ChunkEvent{Seq: env.Payload.Seq, Content: env.Payload.Content}:
+	case <-l.done:
+	}
+}

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -1,0 +1,61 @@
+package event
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandOutputListener_HandleMessage_FiltersAndEmits(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   string
+		wantChunk *ChunkEvent // nil = expect no emission
+	}{
+		{
+			name:      "matching command_output",
+			payload:   `{"event_type":"command_output","payload":{"command_id":"cmd-1","seq":3,"content":"hi"}}`,
+			wantChunk: &ChunkEvent{Seq: 3, Content: "hi"},
+		},
+		{
+			name:    "wrong event_type",
+			payload: `{"event_type":"server_status","payload":{"command_id":"cmd-1","seq":3,"content":"hi"}}`,
+		},
+		{
+			name:    "wrong command_id",
+			payload: `{"event_type":"command_output","payload":{"command_id":"cmd-OTHER","seq":3,"content":"hi"}}`,
+		},
+		{
+			name:    "invalid json",
+			payload: `not json`,
+		},
+		{
+			name:    "empty payload",
+			payload: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &CommandOutputListener{
+				commandID: "cmd-1",
+				chunks:    make(chan ChunkEvent, 1),
+				done:      make(chan struct{}),
+			}
+			l.handleMessage([]byte(tt.payload))
+
+			select {
+			case got := <-l.chunks:
+				if tt.wantChunk == nil {
+					t.Fatalf("expected no emission, got %+v", got)
+				}
+				assert.Equal(t, *tt.wantChunk, got)
+			case <-time.After(50 * time.Millisecond):
+				if tt.wantChunk != nil {
+					t.Fatal("expected emission but got nothing")
+				}
+			}
+		})
+	}
+}

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -132,4 +133,57 @@ func TestCommandOutputListener_StopIsIdempotent(t *testing.T) {
 	l.Stop()
 	l.Stop()
 	l.Stop()
+}
+
+func TestCommandOutputListener_Reconnects(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var connectionCount atomic.Int32
+	cmdID := "cmd-uuid"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		n := connectionCount.Add(1)
+
+		if n == 1 {
+			// First connection: emit one chunk and drop
+			env := `{"event_type":"command_output","payload":{"command_id":"` + cmdID + `","seq":0,"content":"first"}}`
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(env))
+			_ = conn.Close()
+			return
+		}
+		// Second connection: emit second chunk and block
+		env := `{"event_type":"command_output","payload":{"command_id":"` + cmdID + `","seq":1,"content":"second"}}`
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(env))
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	l := NewCommandOutputListener(nil, wsURL, cmdID)
+	l.Start()
+	defer l.Stop()
+
+	require.True(t, l.WaitConnected(2*time.Second))
+
+	got := []ChunkEvent{}
+	timeout := time.After(5 * time.Second)
+	for len(got) < 2 {
+		select {
+		case c := <-l.Chunks():
+			got = append(got, c)
+		case <-timeout:
+			t.Fatalf("timeout, got %+v (connections=%d)", got, connectionCount.Load())
+		}
+	}
+
+	assert.Equal(t, ChunkEvent{Seq: 0, Content: "first"}, got[0])
+	assert.Equal(t, ChunkEvent{Seq: 1, Content: "second"}, got[1])
+	assert.GreaterOrEqual(t, connectionCount.Load(), int32(2))
 }

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -1,10 +1,16 @@
 package event
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommandOutputListener_HandleMessage_FiltersAndEmits(t *testing.T) {
@@ -58,4 +64,72 @@ func TestCommandOutputListener_HandleMessage_FiltersAndEmits(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	cmdID := "cmd-uuid"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Emit two chunks
+		for _, c := range []ChunkEvent{{Seq: 0, Content: "a"}, {Seq: 1, Content: "b"}} {
+			env := map[string]any{
+				"event_type": "command_output",
+				"payload": map[string]any{
+					"command_id": cmdID,
+					"seq":        c.Seq,
+					"content":    c.Content,
+				},
+			}
+			b, _ := json.Marshal(env)
+			_ = conn.WriteMessage(websocket.TextMessage, b)
+		}
+
+		// Block until client disconnects
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	l := NewCommandOutputListener(nil, wsURL, cmdID)
+	l.Start()
+	defer l.Stop()
+
+	require.True(t, l.WaitConnected(2*time.Second), "should connect")
+
+	got := []ChunkEvent{}
+	timeout := time.After(2 * time.Second)
+	for len(got) < 2 {
+		select {
+		case c := <-l.Chunks():
+			got = append(got, c)
+		case <-timeout:
+			t.Fatalf("timeout, got %+v", got)
+		}
+	}
+
+	assert.Equal(t, []ChunkEvent{{Seq: 0, Content: "a"}, {Seq: 1, Content: "b"}}, got)
+}
+
+func TestCommandOutputListener_StopIsIdempotent(t *testing.T) {
+	l := &CommandOutputListener{
+		chunks:    make(chan ChunkEvent, 1),
+		done:      make(chan struct{}),
+		stopped:   make(chan struct{}),
+		connected: make(chan struct{}),
+	}
+	l.Stop()
+	l.Stop()
+	l.Stop()
 }

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -127,7 +127,6 @@ func TestCommandOutputListener_StopIsIdempotent(t *testing.T) {
 	l := &CommandOutputListener{
 		chunks:    make(chan ChunkEvent, 1),
 		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
 		connected: make(chan struct{}),
 	}
 	l.Stop()

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -296,11 +296,14 @@ func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk Chunk
 			utils.CliWarning("failed to fetch missing chunks (seq %d..%d): %v; output may be incomplete",
 				lastSeq+1, chunk.Seq-1, err)
 		} else {
+			// Advance only over contiguous seqs, stopping at the first hole, so a
+			// gap-fill racing ahead of persistence can't skip a not-yet-stored seq.
 			for _, c := range missing {
-				if c.Seq > lastSeq && c.Seq <= chunk.Seq {
-					_, _ = fmt.Fprint(out, c.Content)
-					lastSeq = c.Seq
+				if c.Seq != lastSeq+1 || c.Seq > chunk.Seq {
+					break
 				}
+				_, _ = fmt.Fprint(out, c.Content)
+				lastSeq = c.Seq
 			}
 		}
 	}
@@ -331,7 +334,7 @@ func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, o
 // RunCommand so unrecognized statuses are not masked as success.
 func errorFromDetails(d EventDetails) error {
 	switch d.Status {
-	case "completed", "success":
+	case "completed", "success", "failed":
 		if d.Success != nil && !*d.Success {
 			exitCode := 1
 			if d.ExitCode != nil {

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -324,26 +324,32 @@ func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, o
 	return lastSeq
 }
 
+// errorFromDetails maps a terminal command status to an error, mirroring
+// RunCommand so unrecognized statuses are not masked as success.
 func errorFromDetails(d EventDetails) error {
-	if d.Status == "stuck" || d.Status == "error" || d.Status == "cancelled" {
+	switch d.Status {
+	case "completed", "success":
+		if d.Success != nil && !*d.Success {
+			exitCode := 1
+			if d.ExitCode != nil {
+				exitCode = *d.ExitCode
+			}
+			phase := ""
+			if d.ErrorPhase != nil {
+				phase = *d.ErrorPhase
+			}
+			return &RemoteCommandError{Output: d.Result, ExitCode: exitCode, ErrorPhase: phase}
+		}
+		return nil
+	case "stuck", "error", "cancelled":
 		phase := ""
 		if d.ErrorPhase != nil {
 			phase = *d.ErrorPhase
 		}
 		return fmt.Errorf("command failed: [%s] %s (status=%s)", phase, DescribePhase(phase), d.Status)
+	default:
+		return fmt.Errorf("unexpected command status: %s (command may still be running)", d.Status)
 	}
-	if d.Success != nil && !*d.Success {
-		exitCode := 1
-		if d.ExitCode != nil {
-			exitCode = *d.ExitCode
-		}
-		phase := ""
-		if d.ErrorPhase != nil {
-			phase = *d.ErrorPhase
-		}
-		return &RemoteCommandError{Output: d.Result, ExitCode: exitCode, ErrorPhase: phase}
-	}
-	return nil
 }
 
 // runCommandFallback warns the user and delegates to the existing polling flow.
@@ -369,6 +375,8 @@ func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Wri
 	}
 	if details.Result != "" {
 		_, _ = fmt.Fprint(out, details.Result)
+		// Clear so errorFromDetails doesn't return it again and cause a reprint.
+		details.Result = ""
 	}
 	return errorFromDetails(details)
 }

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -285,6 +285,11 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 
 // applyChunk handles a single chunk: skip duplicates, fill gaps with REST,
 // and write content in seq order. Returns the new lastSeq.
+//
+// Gap-fill invariant: when REST returns the same seq as the incoming WS chunk,
+// lastSeq advances to chunk.Seq inside the REST loop and the final `if` clause
+// becomes false — the WS chunk is intentionally skipped, since REST already
+// printed identical content for that seq (REST/WS share the persisted chunk).
 func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk ChunkEvent, out io.Writer) int {
 	if chunk.Seq <= lastSeq {
 		return lastSeq

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -233,14 +233,19 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 		return runCommandFallbackFromID(ac, cmdResp.ID, out, err)
 	}
 
-	// Warm-fire: drain any chunks already persisted.
+	// Warm-fire: drain any chunks already persisted. Advance lastSeq only over
+	// contiguous seqs and stop at the first gap, so a later chunk filling that
+	// gap (e.g. arriving over the WS) is still written instead of being skipped
+	// as a duplicate. The chunks past the gap are picked up in order once the
+	// gap is filled (via applyChunk) or by the terminal drain.
 	lastSeq := -1
 	if existing, err := GetCommandChunks(ac, cmdResp.ID, 0); err == nil {
 		for _, c := range existing {
-			_, _ = fmt.Fprint(out, c.Content)
-			if c.Seq > lastSeq {
-				lastSeq = c.Seq
+			if c.Seq != lastSeq+1 {
+				break
 			}
+			_, _ = fmt.Fprint(out, c.Content)
+			lastSeq = c.Seq
 		}
 	}
 

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -3,6 +3,7 @@ package event
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"time"
@@ -199,4 +200,169 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 			return response, nil
 		}
 	}
+}
+
+// CommandOutcome wraps the terminal result of a streamed command.
+type CommandOutcome struct {
+	Status     string
+	ExitCode   int
+	ErrorPhase string
+	Success    *bool
+}
+
+// RunCommandStreaming is the streaming-aware counterpart to RunCommand.
+// It establishes an event-server WebSocket, subscribes to command_output for
+// the new command, prints chunks to stdout in real time, and returns when the
+// command reaches a terminal state. Any error during WS setup causes a fall
+// back to RunCommand (polling) with a stderr warning.
+func RunCommandStreaming(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (CommandOutcome, error) {
+	return runCommandStreamingWithWriter(ac, serverName, command, username, groupname, env, workSessionID, os.Stdout)
+}
+
+func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer) (CommandOutcome, error) {
+	session, err := CreateEventSession(ac)
+	if err != nil {
+		return runCommandFallback(ac, serverName, command, username, groupname, env, workSessionID, out, err)
+	}
+
+	listener := NewCommandOutputListener(ac, session.WebsocketURL, "")
+	listener.Start()
+	if !listener.WaitConnected(5 * time.Second) {
+		listener.Stop()
+		return runCommandFallback(ac, serverName, command, username, groupname, env, workSessionID, out, fmt.Errorf("event websocket connect timeout"))
+	}
+
+	cmdResp, err := SubmitCommand(ac, serverName, command, username, groupname, env, workSessionID)
+	if err != nil {
+		listener.Stop()
+		return CommandOutcome{}, err
+	}
+	listener.setCommandID(cmdResp.ID)
+
+	if err := SubscribeCommandOutput(ac, session.ChannelID, cmdResp.ID); err != nil {
+		listener.Stop()
+		return runCommandFallback(ac, serverName, command, username, groupname, env, workSessionID, out, err)
+	}
+
+	// Warm-fire: drain any chunks already persisted.
+	lastSeq := -1
+	if existing, err := GetCommandChunks(ac, cmdResp.ID, 0); err == nil {
+		for _, c := range existing {
+			_, _ = fmt.Fprint(out, c.Content)
+			if c.Seq > lastSeq {
+				lastSeq = c.Seq
+			}
+		}
+	}
+
+	// Status polling in background
+	pollResult := make(chan EventDetails, 1)
+	pollErr := make(chan error, 1)
+	go func() {
+		details, err := PollCommandExecution(ac, cmdResp.ID)
+		if err != nil {
+			pollErr <- err
+			return
+		}
+		pollResult <- details
+	}()
+
+	for {
+		select {
+		case chunk := <-listener.Chunks():
+			lastSeq = applyChunk(ac, cmdResp.ID, lastSeq, chunk, out)
+		case details := <-pollResult:
+			lastSeq = drainRemainingChunks(ac, cmdResp.ID, lastSeq, out)
+			_ = lastSeq
+			listener.Stop()
+			return outcomeFromDetails(details), errorFromDetails(details)
+		case err := <-pollErr:
+			listener.Stop()
+			return CommandOutcome{}, err
+		}
+	}
+}
+
+// applyChunk handles a single chunk: skip duplicates, fill gaps with REST,
+// and write content in seq order. Returns the new lastSeq.
+func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk ChunkEvent, out io.Writer) int {
+	if chunk.Seq <= lastSeq {
+		return lastSeq
+	}
+	if chunk.Seq > lastSeq+1 {
+		missing, err := GetCommandChunks(ac, cmdID, lastSeq+1)
+		if err == nil {
+			for _, c := range missing {
+				if c.Seq > lastSeq && c.Seq <= chunk.Seq {
+					_, _ = fmt.Fprint(out, c.Content)
+					lastSeq = c.Seq
+				}
+			}
+		}
+	}
+	if chunk.Seq == lastSeq+1 {
+		_, _ = fmt.Fprint(out, chunk.Content)
+		lastSeq = chunk.Seq
+	}
+	return lastSeq
+}
+
+func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, out io.Writer) int {
+	final, err := GetCommandChunks(ac, cmdID, lastSeq+1)
+	if err != nil {
+		return lastSeq
+	}
+	for _, c := range final {
+		if c.Seq > lastSeq {
+			_, _ = fmt.Fprint(out, c.Content)
+			lastSeq = c.Seq
+		}
+	}
+	return lastSeq
+}
+
+func outcomeFromDetails(d EventDetails) CommandOutcome {
+	out := CommandOutcome{Status: d.Status, Success: d.Success}
+	if d.ExitCode != nil {
+		out.ExitCode = *d.ExitCode
+	}
+	if d.ErrorPhase != nil {
+		out.ErrorPhase = *d.ErrorPhase
+	}
+	return out
+}
+
+func errorFromDetails(d EventDetails) error {
+	if d.Status == "stuck" || d.Status == "error" || d.Status == "cancelled" {
+		phase := ""
+		if d.ErrorPhase != nil {
+			phase = *d.ErrorPhase
+		}
+		return fmt.Errorf("command failed: [%s] %s (status=%s)", phase, DescribePhase(phase), d.Status)
+	}
+	if d.Success != nil && !*d.Success {
+		exitCode := 1
+		if d.ExitCode != nil {
+			exitCode = *d.ExitCode
+		}
+		phase := ""
+		if d.ErrorPhase != nil {
+			phase = *d.ErrorPhase
+		}
+		return &RemoteCommandError{Output: d.Result, ExitCode: exitCode, ErrorPhase: phase}
+	}
+	return nil
+}
+
+// runCommandFallback warns the user and delegates to the existing polling flow.
+func runCommandFallback(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer, cause error) (CommandOutcome, error) {
+	_, _ = fmt.Fprintf(os.Stderr, "warning: real-time output unavailable (%v); falling back to polling\n", cause)
+	result, err := RunCommand(ac, serverName, command, username, groupname, env, workSessionID)
+	if err != nil {
+		return CommandOutcome{}, err
+	}
+	if result != "" {
+		_, _ = fmt.Fprint(out, result)
+	}
+	return CommandOutcome{Status: "completed"}, nil
 }

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -365,15 +365,13 @@ func errorFromDetails(d EventDetails) error {
 
 // runCommandFallback warns the user and delegates to the existing polling flow.
 func runCommandFallback(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer, cause error) (CommandOutcome, error) {
-	_, _ = fmt.Fprintf(os.Stderr, "warning: real-time output unavailable (%v); falling back to polling\n", cause)
-	result, err := RunCommand(ac, serverName, command, username, groupname, env, workSessionID)
+	cmdResp, err := SubmitCommand(ac, serverName, command, username, groupname, env, workSessionID)
 	if err != nil {
+		// SubmitCommand returned an MFA/auth/etc error; surface it so the
+		// existing retry callbacks in RunCommandWithRetry can handle it.
 		return CommandOutcome{}, err
 	}
-	if result != "" {
-		_, _ = fmt.Fprint(out, result)
-	}
-	return CommandOutcome{Status: "completed"}, nil
+	return runCommandFallbackFromID(ac, cmdResp.ID, out, cause)
 }
 
 // runCommandFallbackFromID is the fallback used when streaming setup fails

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -94,50 +94,6 @@ func SubmitCommand(ac *client.AlpaconClient, serverName, command string, usernam
 	return cmdResponse[0], nil
 }
 
-func RunCommand(ac *client.AlpaconClient, serverName, command string, username, groupname string, env map[string]string, workSessionID string) (string, error) {
-	cmdResponse, err := SubmitCommand(ac, serverName, command, username, groupname, env, workSessionID)
-	if err != nil {
-		return "", err
-	}
-
-	result, err := PollCommandExecution(ac, cmdResponse.ID)
-	if err != nil {
-		return "", err
-	}
-
-	if result.Status == "stuck" || result.Status == "error" || result.Status == "cancelled" {
-		if result.ErrorPhase != nil && *result.ErrorPhase != "" {
-			return "", fmt.Errorf("command failed: [%s] %s (status=%s)",
-				*result.ErrorPhase, DescribePhase(*result.ErrorPhase), result.Status)
-		}
-		return "", fmt.Errorf("command failed with status: %s", result.Status)
-	}
-
-	if result.Success != nil && !*result.Success {
-		// Trust the server contract: alpamon sets success=(exitCode==0), so a
-		// non-nil exit_code is propagated as-is.
-		exitCode := 1
-		if result.ExitCode != nil {
-			exitCode = *result.ExitCode
-		}
-		errorPhase := ""
-		if result.ErrorPhase != nil {
-			errorPhase = *result.ErrorPhase
-		}
-		return result.Result, &RemoteCommandError{
-			Output:     result.Result,
-			ExitCode:   exitCode,
-			ErrorPhase: errorPhase,
-		}
-	}
-
-	if result.Success == nil && result.Status != "completed" && result.Status != "success" {
-		return result.Result, fmt.Errorf("command ended with unrecognised status: %s", result.Status)
-	}
-
-	return result.Result, nil
-}
-
 func GetCommandByID(ac *client.AlpaconClient, cmdID string) (EventDetails, error) {
 	responseBody, err := ac.SendGetRequest(utils.BuildURL(getEventURL, cmdID, nil))
 	if err != nil {
@@ -203,7 +159,7 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 }
 
 // RunCommandStreaming runs a command and streams its output to stdout over the
-// event WebSocket, falling back to RunCommand (polling) when WS setup fails.
+// event WebSocket, falling back to polling (runCommandFallback) when WS setup fails.
 func RunCommandStreaming(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) error {
 	return runCommandStreamingWithWriter(ac, serverName, command, username, groupname, env, workSessionID, os.Stdout)
 }
@@ -330,8 +286,8 @@ func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, o
 	return lastSeq
 }
 
-// errorFromDetails maps a terminal command status to an error, mirroring
-// RunCommand so unrecognized statuses are not masked as success.
+// errorFromDetails maps a terminal command status to an error so unrecognized
+// statuses are not masked as success.
 func errorFromDetails(d EventDetails) error {
 	switch d.Status {
 	case "completed", "success", "failed":
@@ -372,8 +328,8 @@ func runCommandFallback(ac *client.AlpaconClient, serverName, command, username,
 }
 
 // runCommandFallbackFromID polls an already-submitted command by ID (instead of
-// re-submitting) and writes its buffered result to out. Used when streaming
-// setup fails after SubmitCommand has created the command.
+// re-submitting) and writes its output to out. Used when streaming setup fails
+// after SubmitCommand has created the command.
 func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Writer, cause error) error {
 	utils.CliWarning("real-time output unavailable (%v); falling back to polling", cause)
 	details, err := PollCommandExecution(ac, cmdID)

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -236,8 +236,8 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 	// Warm-fire: drain any chunks already persisted. Advance lastSeq only over
 	// contiguous seqs and stop at the first gap, so a later chunk filling that
 	// gap (e.g. arriving over the WS) is still written instead of being skipped
-	// as a duplicate. The chunks past the gap are picked up in order once the
-	// gap is filled (via applyChunk) or by the terminal drain.
+	// as a duplicate. Chunks past the gap are picked up by applyChunk or the
+	// terminal drain once the gap is filled.
 	lastSeq := -1
 	if existing, err := GetCommandChunks(ac, cmdResp.ID, 0); err == nil {
 		for _, c := range existing {

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -266,6 +266,9 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 		case details := <-pollResult:
 			_ = drainRemainingChunks(ac, cmdResp.ID, lastSeq, out)
 			listener.Stop()
+			// Chunks are already streamed; clear so errorFromDetails doesn't
+			// return the result again and cause a reprint.
+			details.Result = ""
 			return errorFromDetails(details)
 		case err := <-pollErr:
 			listener.Stop()

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -241,7 +241,7 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 
 	if err := SubscribeCommandOutput(ac, session.ChannelID, cmdResp.ID); err != nil {
 		listener.Stop()
-		return runCommandFallback(ac, serverName, command, username, groupname, env, workSessionID, out, err)
+		return runCommandFallbackFromID(ac, cmdResp.ID, out, err)
 	}
 
 	// Warm-fire: drain any chunks already persisted.
@@ -296,7 +296,11 @@ func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk Chunk
 	}
 	if chunk.Seq > lastSeq+1 {
 		missing, err := GetCommandChunks(ac, cmdID, lastSeq+1)
-		if err == nil {
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr,
+				"warning: failed to fetch missing chunks (seq %d..%d): %v; output may be incomplete\n",
+				lastSeq+1, chunk.Seq-1, err)
+		} else {
 			for _, c := range missing {
 				if c.Seq > lastSeq && c.Seq <= chunk.Seq {
 					_, _ = fmt.Fprint(out, c.Content)
@@ -370,4 +374,24 @@ func runCommandFallback(ac *client.AlpaconClient, serverName, command, username,
 		_, _ = fmt.Fprint(out, result)
 	}
 	return CommandOutcome{Status: "completed"}, nil
+}
+
+// runCommandFallbackFromID is the fallback used when streaming setup fails
+// AFTER SubmitCommand has already created the command on the server. It
+// polls the existing command by ID instead of re-submitting, then writes
+// the buffered result to out. Returns the same shape as
+// runCommandStreamingWithWriter so callers can ignore the difference.
+func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Writer, cause error) (CommandOutcome, error) {
+	_, _ = fmt.Fprintf(os.Stderr, "warning: real-time output unavailable (%v); falling back to polling\n", cause)
+	details, err := PollCommandExecution(ac, cmdID)
+	if err != nil {
+		return CommandOutcome{}, err
+	}
+	if details.Result != "" {
+		_, _ = fmt.Fprint(out, details.Result)
+	}
+	if termErr := errorFromDetails(details); termErr != nil {
+		return outcomeFromDetails(details), termErr
+	}
+	return outcomeFromDetails(details), nil
 }

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -202,24 +202,16 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 	}
 }
 
-// CommandOutcome wraps the terminal result of a streamed command.
-type CommandOutcome struct {
-	Status     string
-	ExitCode   int
-	ErrorPhase string
-	Success    *bool
-}
-
 // RunCommandStreaming is the streaming-aware counterpart to RunCommand.
 // It establishes an event-server WebSocket, subscribes to command_output for
 // the new command, prints chunks to stdout in real time, and returns when the
 // command reaches a terminal state. Any error during WS setup causes a fall
 // back to RunCommand (polling) with a stderr warning.
-func RunCommandStreaming(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (CommandOutcome, error) {
+func RunCommandStreaming(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) error {
 	return runCommandStreamingWithWriter(ac, serverName, command, username, groupname, env, workSessionID, os.Stdout)
 }
 
-func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer) (CommandOutcome, error) {
+func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer) error {
 	session, err := CreateEventSession(ac)
 	if err != nil {
 		return runCommandFallback(ac, serverName, command, username, groupname, env, workSessionID, out, err)
@@ -235,7 +227,7 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 	cmdResp, err := SubmitCommand(ac, serverName, command, username, groupname, env, workSessionID)
 	if err != nil {
 		listener.Stop()
-		return CommandOutcome{}, err
+		return err
 	}
 	listener.setCommandID(cmdResp.ID)
 
@@ -272,13 +264,12 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 		case chunk := <-listener.Chunks():
 			lastSeq = applyChunk(ac, cmdResp.ID, lastSeq, chunk, out)
 		case details := <-pollResult:
-			lastSeq = drainRemainingChunks(ac, cmdResp.ID, lastSeq, out)
-			_ = lastSeq
+			_ = drainRemainingChunks(ac, cmdResp.ID, lastSeq, out)
 			listener.Stop()
-			return outcomeFromDetails(details), errorFromDetails(details)
+			return errorFromDetails(details)
 		case err := <-pollErr:
 			listener.Stop()
-			return CommandOutcome{}, err
+			return err
 		}
 	}
 }
@@ -319,6 +310,9 @@ func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk Chunk
 func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, out io.Writer) int {
 	final, err := GetCommandChunks(ac, cmdID, lastSeq+1)
 	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr,
+			"warning: failed to fetch trailing chunks (from seq %d): %v; output may be incomplete\n",
+			lastSeq+1, err)
 		return lastSeq
 	}
 	for _, c := range final {
@@ -328,17 +322,6 @@ func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, o
 		}
 	}
 	return lastSeq
-}
-
-func outcomeFromDetails(d EventDetails) CommandOutcome {
-	out := CommandOutcome{Status: d.Status, Success: d.Success}
-	if d.ExitCode != nil {
-		out.ExitCode = *d.ExitCode
-	}
-	if d.ErrorPhase != nil {
-		out.ErrorPhase = *d.ErrorPhase
-	}
-	return out
 }
 
 func errorFromDetails(d EventDetails) error {
@@ -364,12 +347,12 @@ func errorFromDetails(d EventDetails) error {
 }
 
 // runCommandFallback warns the user and delegates to the existing polling flow.
-func runCommandFallback(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer, cause error) (CommandOutcome, error) {
+func runCommandFallback(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer, cause error) error {
 	cmdResp, err := SubmitCommand(ac, serverName, command, username, groupname, env, workSessionID)
 	if err != nil {
 		// SubmitCommand returned an MFA/auth/etc error; surface it so the
 		// existing retry callbacks in RunCommandWithRetry can handle it.
-		return CommandOutcome{}, err
+		return err
 	}
 	return runCommandFallbackFromID(ac, cmdResp.ID, out, cause)
 }
@@ -377,19 +360,15 @@ func runCommandFallback(ac *client.AlpaconClient, serverName, command, username,
 // runCommandFallbackFromID is the fallback used when streaming setup fails
 // AFTER SubmitCommand has already created the command on the server. It
 // polls the existing command by ID instead of re-submitting, then writes
-// the buffered result to out. Returns the same shape as
-// runCommandStreamingWithWriter so callers can ignore the difference.
-func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Writer, cause error) (CommandOutcome, error) {
+// the buffered result to out.
+func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Writer, cause error) error {
 	_, _ = fmt.Fprintf(os.Stderr, "warning: real-time output unavailable (%v); falling back to polling\n", cause)
 	details, err := PollCommandExecution(ac, cmdID)
 	if err != nil {
-		return CommandOutcome{}, err
+		return err
 	}
 	if details.Result != "" {
 		_, _ = fmt.Fprint(out, details.Result)
 	}
-	if termErr := errorFromDetails(details); termErr != nil {
-		return outcomeFromDetails(details), termErr
-	}
-	return outcomeFromDetails(details), nil
+	return errorFromDetails(details)
 }

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -380,7 +380,9 @@ func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Wri
 	if err != nil {
 		return err
 	}
-	if details.Result != "" {
+	// Output lives in chunks under the streaming contract (Result is empty), so
+	// drain them; fall back to Result only when no chunks were produced.
+	if lastSeq := drainRemainingChunks(ac, cmdID, -1, out); lastSeq < 0 && details.Result != "" {
 		_, _ = fmt.Fprint(out, details.Result)
 	}
 	return errorFromDetails(details)

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -260,8 +260,14 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 		case chunk := <-listener.Chunks():
 			lastSeq = applyChunk(ac, cmdResp.ID, lastSeq, chunk, out)
 		case details := <-pollResult:
-			_ = drainRemainingChunks(ac, cmdResp.ID, lastSeq, out)
+			lastSeq = drainRemainingChunks(ac, cmdResp.ID, lastSeq, out)
 			listener.Stop()
+			// If nothing was ever streamed (no WS chunks, none persisted), fall back
+			// to the buffered Result so output is never silently dropped. On a normal
+			// streamed run lastSeq has advanced and this is skipped.
+			if lastSeq < 0 && details.Result != "" {
+				_, _ = fmt.Fprint(out, details.Result)
+			}
 			// Output is already streamed; errorFromDetails keeps it on the error
 			// for inspection (e.g. sudo-denial hint) but cmd/exec never reprints it.
 			return errorFromDetails(details)
@@ -282,8 +288,7 @@ func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk Chunk
 	if chunk.Seq > lastSeq+1 {
 		missing, err := GetCommandChunks(ac, cmdID, lastSeq+1)
 		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr,
-				"warning: failed to fetch missing chunks (seq %d..%d): %v; output may be incomplete\n",
+			utils.CliWarning("failed to fetch missing chunks (seq %d..%d): %v; output may be incomplete",
 				lastSeq+1, chunk.Seq-1, err)
 		} else {
 			for _, c := range missing {
@@ -304,8 +309,7 @@ func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk Chunk
 func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, out io.Writer) int {
 	final, err := GetCommandChunks(ac, cmdID, lastSeq+1)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr,
-			"warning: failed to fetch trailing chunks (from seq %d): %v; output may be incomplete\n",
+		utils.CliWarning("failed to fetch trailing chunks (from seq %d): %v; output may be incomplete",
 			lastSeq+1, err)
 		return lastSeq
 	}
@@ -363,7 +367,7 @@ func runCommandFallback(ac *client.AlpaconClient, serverName, command, username,
 // re-submitting) and writes its buffered result to out. Used when streaming
 // setup fails after SubmitCommand has created the command.
 func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Writer, cause error) error {
-	_, _ = fmt.Fprintf(os.Stderr, "warning: real-time output unavailable (%v); falling back to polling\n", cause)
+	utils.CliWarning("real-time output unavailable (%v); falling back to polling", cause)
 	details, err := PollCommandExecution(ac, cmdID)
 	if err != nil {
 		return err

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -336,10 +336,15 @@ func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Wri
 	if err != nil {
 		return err
 	}
-	// Output lives in chunks under the streaming contract (Result is empty), so
-	// drain them; fall back to Result only when no chunks were produced.
-	if lastSeq := drainRemainingChunks(ac, cmdID, -1, out); lastSeq < 0 && details.Result != "" {
-		_, _ = fmt.Fprint(out, details.Result)
+	// Command has finished: reconstruct output from chunks best-effort, falling
+	// back to Result when chunks are empty or unavailable. No warning on failure—
+	// the polling-fallback warning above already covers it.
+	output := details.Result
+	if reconstructed, oerr := GetCommandOutput(ac, cmdID); oerr == nil && reconstructed != "" {
+		output = reconstructed
+	}
+	if output != "" {
+		_, _ = fmt.Fprint(out, output)
 	}
 	return errorFromDetails(details)
 }

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -202,11 +202,8 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 	}
 }
 
-// RunCommandStreaming is the streaming-aware counterpart to RunCommand.
-// It establishes an event-server WebSocket, subscribes to command_output for
-// the new command, prints chunks to stdout in real time, and returns when the
-// command reaches a terminal state. Any error during WS setup causes a fall
-// back to RunCommand (polling) with a stderr warning.
+// RunCommandStreaming runs a command and streams its output to stdout over the
+// event WebSocket, falling back to RunCommand (polling) when WS setup fails.
 func RunCommandStreaming(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) error {
 	return runCommandStreamingWithWriter(ac, serverName, command, username, groupname, env, workSessionID, os.Stdout)
 }
@@ -247,7 +244,6 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 		}
 	}
 
-	// Status polling in background
 	pollResult := make(chan EventDetails, 1)
 	pollErr := make(chan error, 1)
 	go func() {
@@ -277,13 +273,9 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 	}
 }
 
-// applyChunk handles a single chunk: skip duplicates, fill gaps with REST,
-// and write content in seq order. Returns the new lastSeq.
-//
-// Gap-fill invariant: when REST returns the same seq as the incoming WS chunk,
-// lastSeq advances to chunk.Seq inside the REST loop and the final `if` clause
-// becomes false — the WS chunk is intentionally skipped, since REST already
-// printed identical content for that seq (REST/WS share the persisted chunk).
+// applyChunk skips duplicates, fills gaps via REST, and writes content in seq
+// order, returning the new lastSeq. When REST already returned the incoming
+// chunk's seq, the final clause is intentionally skipped to avoid reprinting it.
 func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk ChunkEvent, out io.Writer) int {
 	if chunk.Seq <= lastSeq {
 		return lastSeq
@@ -359,17 +351,15 @@ func errorFromDetails(d EventDetails) error {
 func runCommandFallback(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer, cause error) error {
 	cmdResp, err := SubmitCommand(ac, serverName, command, username, groupname, env, workSessionID)
 	if err != nil {
-		// SubmitCommand returned an MFA/auth/etc error; surface it so the
-		// existing retry callbacks in RunCommandWithRetry can handle it.
+		// Surface MFA/auth errors so RunCommandWithRetry's callbacks can handle them.
 		return err
 	}
 	return runCommandFallbackFromID(ac, cmdResp.ID, out, cause)
 }
 
-// runCommandFallbackFromID is the fallback used when streaming setup fails
-// AFTER SubmitCommand has already created the command on the server. It
-// polls the existing command by ID instead of re-submitting, then writes
-// the buffered result to out.
+// runCommandFallbackFromID polls an already-submitted command by ID (instead of
+// re-submitting) and writes its buffered result to out. Used when streaming
+// setup fails after SubmitCommand has created the command.
 func runCommandFallbackFromID(ac *client.AlpaconClient, cmdID string, out io.Writer, cause error) error {
 	_, _ = fmt.Fprintf(os.Stderr, "warning: real-time output unavailable (%v); falling back to polling\n", cause)
 	details, err := PollCommandExecution(ac, cmdID)

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -340,6 +340,9 @@ func errorFromDetails(d EventDetails) error {
 		if d.ErrorPhase != nil {
 			phase = *d.ErrorPhase
 		}
+		if phase == "" {
+			return fmt.Errorf("command failed with status: %s", d.Status)
+		}
 		return fmt.Errorf("command failed: [%s] %s (status=%s)", phase, DescribePhase(phase), d.Status)
 	default:
 		return fmt.Errorf("unexpected command status: %s (command may still be running)", d.Status)

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -181,7 +181,7 @@ func runCommandStreamingWithWriter(ac *client.AlpaconClient, serverName, command
 
 	listener := NewCommandOutputListener(ac, session.WebsocketURL, "")
 	listener.Start()
-	if !listener.WaitConnected(5 * time.Second) {
+	if !listener.WaitConnected(commandOutputConnectTimeout) {
 		listener.Stop()
 		return runCommandFallback(ac, serverName, command, username, groupname, env, workSessionID, out, fmt.Errorf("event websocket connect timeout"))
 	}
@@ -208,7 +208,7 @@ func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer
 	}
 	listener := NewCommandOutputListener(ac, session.WebsocketURL, cmdID)
 	listener.Start()
-	if !listener.WaitConnected(5 * time.Second) {
+	if !listener.WaitConnected(commandOutputConnectTimeout) {
 		listener.Stop()
 		return runCommandFallbackFromID(ac, cmdID, out, true, fmt.Errorf("event websocket connect timeout"))
 	}

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -685,9 +685,8 @@ func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
 
-	outcome, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 	require.NoError(t, err)
-	assert.Equal(t, "completed", outcome.Status)
 	assert.Equal(t, "hello\nworld\n", stdoutBuf.String())
 }
 
@@ -783,7 +782,7 @@ func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
 
-	_, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 	require.NoError(t, err)
 	assert.Equal(t, "s0\ns1\ns2\ns3\n", stdoutBuf.String())
 }
@@ -862,7 +861,7 @@ func TestRunCommandStreaming_DuplicateSeqIgnored(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
 
-	_, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 	require.NoError(t, err)
 	assert.Equal(t, "s0\ns1\ns2\n", stdoutBuf.String())
 }
@@ -928,9 +927,8 @@ func TestRunCommandStreaming_FallbackOnSubscribeFailureReusesCommand(t *testing.
 
 	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
 
-	outcome, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 	require.NoError(t, err)
-	assert.Equal(t, "completed", outcome.Status)
 	assert.Equal(t, "reused-output\n", stdoutBuf.String())
 
 	// THE KEY ASSERTION: SubmitCommand was called exactly once
@@ -976,8 +974,7 @@ func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
 
-	outcome, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 	require.NoError(t, err)
-	assert.Equal(t, "completed", outcome.Status)
 	assert.Equal(t, "fallback-output\n", stdoutBuf.String())
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -692,6 +692,59 @@ func TestRunCommandStreaming_DuplicateSeqIgnored(t *testing.T) {
 	assert.Equal(t, "s0\ns1\ns2\n", stdoutBuf.String())
 }
 
+// TestRunCommandStreaming_FailedStatusPropagatesExitCode guards that terminal
+// status "failed" yields a *RemoteCommandError carrying the exit code.
+func TestRunCommandStreaming_FailedStatusPropagatesExitCode(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:        "cmd-uuid",
+		serverID:     "srv-uuid",
+		wsChunks:     []ChunkEvent{{Seq: 0, Content: "before-exit\n"}},
+		runningPolls: 1,
+		terminal:     EventDetails{Status: "failed", Success: boolPtr(false), ExitCode: intPtr(23)},
+	})
+
+	err := runCommandStreamingWithWriter(ac, "srv", "exit 23", "", "", nil, "", stdoutBuf)
+	require.Error(t, err)
+	var remoteErr *RemoteCommandError
+	require.True(t, errors.As(err, &remoteErr), "failed status must yield *RemoteCommandError")
+	assert.Equal(t, 23, remoteErr.ExitCode)
+	assert.Equal(t, "before-exit\n", stdoutBuf.String())
+}
+
+// TestRunCommandStreaming_GapFillRaceDoesNotDropChunk guards that when a gap-fill
+// fetch returns a hole (seq 1,3; 2 not yet persisted), applyChunk stops at the
+// hole so the later WS seq 2 isn't dropped as a duplicate.
+func TestRunCommandStreaming_GapFillRaceDoesNotDropChunk(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		// WS order 0,3,2: seq 3 opens a gap; seq 2 arrives only afterwards.
+		wsChunks: []ChunkEvent{{Seq: 0, Content: "s0\n"}, {Seq: 3, Content: "s3\n"}, {Seq: 2, Content: "s2\n"}},
+		chunksFor: func(fromSeq int) []Chunk {
+			persisted := []Chunk{{Seq: 1, Content: "s1\n"}, {Seq: 2, Content: "s2\n"}, {Seq: 3, Content: "s3\n"}}
+			if fromSeq == 1 {
+				// Race: seq 2 is not yet persisted when the gap-fill fetch runs.
+				return []Chunk{{Seq: 1, Content: "s1\n"}, {Seq: 3, Content: "s3\n"}}
+			}
+			var out []Chunk
+			for _, c := range persisted {
+				if c.Seq >= fromSeq {
+					out = append(out, c)
+				}
+			}
+			return out
+		},
+		runningPolls: 3,
+		terminal:     EventDetails{Status: "completed", Success: boolPtr(true)},
+	})
+
+	err := runCommandStreamingWithWriter(ac, "srv", "seq", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "s0\ns1\ns2\ns3\n", stdoutBuf.String())
+}
+
 func TestRunCommandStreaming_FallbackOnSubscribeFailureReusesCommand(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	cmdID := "cmd-uuid"

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -983,3 +983,20 @@ func TestRunCommandStreaming_DrainsTrailingChunksOnTerminal(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "s0\ns1\ns2\n", stdoutBuf.String())
 }
+
+// TestRunCommandStreaming_FallbackToResultWhenNothingStreamed covers the
+// last-resort path: when no chunks arrive over the WS and none are persisted,
+// the buffered Result must still be written so output is never silently dropped.
+func TestRunCommandStreaming_FallbackToResultWhenNothingStreamed(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:        "cmd-uuid",
+		serverID:     "srv-uuid",
+		runningPolls: 1,
+		terminal:     EventDetails{Status: "completed", Success: boolPtr(true), Result: "buffered-only\n"},
+	})
+
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "buffered-only\n", stdoutBuf.String())
+}

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -977,4 +978,210 @@ func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
 	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 	require.NoError(t, err)
 	assert.Equal(t, "fallback-output\n", stdoutBuf.String())
+}
+
+// streamingServerConfig configures the fake event servers used by the
+// streaming-path tests below.
+type streamingServerConfig struct {
+	cmdID        string
+	serverID     string
+	wsChunks     []ChunkEvent      // emitted over the WS once subscribed
+	chunksFor    func(int) []Chunk // REST chunk endpoint, keyed by seq__gte (warm-fire / gap-fill / drain)
+	runningPolls int               // number of "running" detail polls before the terminal one
+	terminal     EventDetails      // returned by the detail poll once runningPolls elapse
+}
+
+// newStreamingServers starts a WS + API server pair for streaming tests and
+// returns a client pointed at the API server. Servers are torn down via
+// t.Cleanup. The WS emits cfg.wsChunks after the subscription POST arrives.
+func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.AlpaconClient {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	subscribed := make(chan struct{})
+	var subOnce sync.Once
+
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		select {
+		case <-subscribed:
+		case <-time.After(10 * time.Second):
+			t.Error("timeout waiting for subscription signal")
+			return
+		}
+		for _, c := range cfg.wsChunks {
+			env := map[string]any{
+				"event_type": "command_output",
+				"payload":    map[string]any{"command_id": cfg.cmdID, "seq": c.Seq, "content": c.Content},
+			}
+			b, _ := json.Marshal(env)
+			_ = conn.WriteMessage(websocket.TextMessage, b)
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(wsServer.Close)
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+
+	var pollCount int
+	var mu sync.Mutex
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/servers/servers/" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"` + cfg.serverID + `","name":"srv"}]}`))
+		case r.URL.Path == "/api/events/sessions/" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch"}`))
+		case r.URL.Path == "/api/events/commands/" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`[{"id":"` + cfg.cmdID + `"}]`))
+		case r.URL.Path == "/api/events/subscriptions/" && r.Method == http.MethodPost:
+			subOnce.Do(func() { close(subscribed) })
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		case r.URL.Path == "/api/events/commands/"+cfg.cmdID+"/chunks/" && r.Method == http.MethodGet:
+			fromSeq, _ := strconv.Atoi(r.URL.Query().Get("seq__gte"))
+			var results []Chunk
+			if cfg.chunksFor != nil {
+				results = cfg.chunksFor(fromSeq)
+			}
+			_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{Count: len(results), Results: results})
+		case r.URL.Path == "/api/events/commands/"+cfg.cmdID+"/" && r.Method == http.MethodGet:
+			mu.Lock()
+			pollCount++
+			n := pollCount
+			mu.Unlock()
+			if n <= cfg.runningPolls {
+				_, _ = w.Write([]byte(`{"id":"` + cfg.cmdID + `","status":"running"}`))
+				return
+			}
+			term := cfg.terminal
+			term.ID = cfg.cmdID
+			_ = json.NewEncoder(w).Encode(term)
+		default:
+			t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(apiServer.Close)
+
+	return &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+}
+
+// TestRunCommandStreaming_NoDuplicateOutputOnFailure guards the duplicate-output
+// fix: a failed command's terminal poll carries the full buffered Result, but
+// the chunks were already streamed live, so errorFromDetails must receive a
+// cleared Result and stdout must contain the output exactly once.
+func TestRunCommandStreaming_NoDuplicateOutputOnFailure(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:        "cmd-uuid",
+		serverID:     "srv-uuid",
+		wsChunks:     []ChunkEvent{{Seq: 0, Content: "hello\n"}, {Seq: 1, Content: "world\n"}},
+		runningPolls: 2,
+		terminal:     EventDetails{Status: "completed", Success: boolPtr(false), Result: "hello\nworld\n"},
+	})
+
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+
+	// Streamed chunks appear once; the buffered Result is not appended.
+	assert.Equal(t, "hello\nworld\n", stdoutBuf.String())
+	// The returned error must carry a cleared Output so cmd/exec does not reprint it.
+	var remoteErr *RemoteCommandError
+	require.ErrorAs(t, err, &remoteErr)
+	assert.Equal(t, "", remoteErr.Output, "buffered result must be cleared to prevent duplicate output")
+}
+
+// TestRunCommandStreaming_TerminalStatusErrors covers errorFromDetails' non-nil
+// branches reached through the streaming select loop, pinning the exit-code /
+// error-mapping contract for failed, infra-error, and unrecognized statuses.
+func TestRunCommandStreaming_TerminalStatusErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		terminal EventDetails
+		check    func(t *testing.T, err error)
+	}{
+		{
+			name:     "success false returns RemoteCommandError with exit code",
+			terminal: EventDetails{Status: "completed", Success: boolPtr(false), ExitCode: intPtr(7)},
+			check: func(t *testing.T, err error) {
+				var re *RemoteCommandError
+				require.ErrorAs(t, err, &re)
+				assert.Equal(t, 7, re.ExitCode)
+			},
+		},
+		{
+			name:     "stuck status returns infra error",
+			terminal: EventDetails{Status: "stuck"},
+			check: func(t *testing.T, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "status=stuck")
+			},
+		},
+		{
+			name:     "error status returns infra error",
+			terminal: EventDetails{Status: "error"},
+			check: func(t *testing.T, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "status=error")
+			},
+		},
+		{
+			name:     "cancelled status returns infra error",
+			terminal: EventDetails{Status: "cancelled"},
+			check: func(t *testing.T, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "status=cancelled")
+			},
+		},
+		{
+			name:     "unrecognized status returns unexpected-status error",
+			terminal: EventDetails{Status: "denied"},
+			check: func(t *testing.T, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unexpected command status")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdoutBuf := &bytes.Buffer{}
+			ac := newStreamingServers(t, streamingServerConfig{
+				cmdID:        "cmd-uuid",
+				serverID:     "srv-uuid",
+				runningPolls: 1,
+				terminal:     tt.terminal,
+			})
+			err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+			tt.check(t, err)
+		})
+	}
+}
+
+// TestRunCommandStreaming_DrainsTrailingChunksOnTerminal covers the
+// drain-on-terminal path: trailing chunks produced as the command finishes
+// never arrive over the WS and are recovered only by the final REST drain.
+func TestRunCommandStreaming_DrainsTrailingChunksOnTerminal(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		wsChunks: []ChunkEvent{{Seq: 0, Content: "s0\n"}},
+		chunksFor: func(fromSeq int) []Chunk {
+			// Warm-fire (seq>=0) is empty; the final drain (seq>=1) yields the tail.
+			if fromSeq >= 1 {
+				return []Chunk{{Seq: 1, Content: "s1\n"}, {Seq: 2, Content: "s2\n"}}
+			}
+			return nil
+		},
+		runningPolls: 2,
+		terminal:     EventDetails{Status: "completed", Success: boolPtr(true)},
+	})
+
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "s0\ns1\ns2\n", stdoutBuf.String())
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -757,6 +757,51 @@ func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
 	assert.Equal(t, "fallback-output\n", stdoutBuf.String())
 }
 
+// TestRunCommandStreaming_FallbackQuietWhenChunksUnavailable: when the chunks
+// endpoint errors, the polling fallback emits the buffered Result, not an error.
+func TestRunCommandStreaming_FallbackQuietWhenChunksUnavailable(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	cmdID := "cmd-uuid"
+	serverID := "srv-uuid"
+
+	var pollCount int
+	var mu sync.Mutex
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"` + serverID + `","name":"srv"}]}`))
+		case "/api/events/sessions/":
+			w.WriteHeader(http.StatusInternalServerError) // force fallback
+		case "/api/events/commands/":
+			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
+		case "/api/events/commands/" + cmdID + "/chunks/":
+			w.WriteHeader(http.StatusNotFound) // server without chunk support
+		case "/api/events/commands/" + cmdID + "/":
+			mu.Lock()
+			pollCount++
+			n := pollCount
+			mu.Unlock()
+			if n < 2 {
+				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
+			} else {
+				success := true
+				resp := EventDetails{ID: cmdID, Status: "completed", Success: &success, Result: "buffered-output\n"}
+				_ = json.NewEncoder(w).Encode(resp)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "buffered-output\n", stdoutBuf.String())
+}
+
 // streamingServerConfig configures the fake event servers for streaming tests.
 type streamingServerConfig struct {
 	cmdID        string

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -786,6 +786,9 @@ func TestRunCommandStreaming_FallbackOnSubscribeFailureReusesCommand(t *testing.
 		case "/api/events/subscriptions/":
 			// Force subscribe failure -> fallback path with existing cmdID
 			w.WriteHeader(http.StatusInternalServerError)
+		case "/api/events/commands/" + cmdID + "/chunks/":
+			// No chunks persisted: fallback must use the buffered Result.
+			_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{})
 		case "/api/events/commands/" + cmdID + "/":
 			mu.Lock()
 			pollCount++
@@ -816,6 +819,52 @@ func TestRunCommandStreaming_FallbackOnSubscribeFailureReusesCommand(t *testing.
 	assert.Equal(t, 1, submitCount, "fallback must not re-submit the command")
 }
 
+// TestRunCommandStreaming_FallbackDrainsChunks guards that the polling fallback
+// reconstructs output from chunks when the server leaves Result empty (the
+// chunk-streaming contract), instead of silently dropping it.
+func TestRunCommandStreaming_FallbackDrainsChunks(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	cmdID := "cmd-uuid"
+	serverID := "srv-uuid"
+
+	var pollCount int
+	var mu sync.Mutex
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"` + serverID + `","name":"srv"}]}`))
+		case "/api/events/sessions/":
+			w.WriteHeader(http.StatusInternalServerError) // force fallback
+		case "/api/events/commands/":
+			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
+		case "/api/events/commands/" + cmdID + "/chunks/":
+			resp := api.ListResponse[Chunk]{Count: 2, Results: []Chunk{{Seq: 0, Content: "chunk-a\n"}, {Seq: 1, Content: "chunk-b\n"}}}
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/api/events/commands/" + cmdID + "/":
+			mu.Lock()
+			pollCount++
+			n := pollCount
+			mu.Unlock()
+			if n < 2 {
+				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
+			} else {
+				// Result empty: output lives only in chunks (server contract).
+				_ = json.NewEncoder(w).Encode(EventDetails{ID: cmdID, Status: "completed", Success: boolPtr(true), Result: ""})
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "chunk-a\nchunk-b\n", stdoutBuf.String())
+}
+
 func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	cmdID := "cmd-uuid"
@@ -833,6 +882,9 @@ func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 		case "/api/events/commands/":
 			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
+		case "/api/events/commands/" + cmdID + "/chunks/":
+			// No chunks persisted: fallback must use the buffered Result.
+			_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{})
 		case "/api/events/commands/" + cmdID + "/":
 			mu.Lock()
 			pollCount++

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -189,13 +189,9 @@ func (c *runCommandBodyCapture) snapshot() (hadKey bool, ws string, seen bool) {
 	return c.hadWorkSessionKey, c.workSession, c.postSeen
 }
 
-// newRunCommandBodyCaptureServer returns a test server that:
-//   - responds to GET /api/servers/servers/?name=... with a 1-item server list
-//   - captures the POST body for /api/events/commands/ and returns a minimal
-//     CommandResponse list
-//   - responds to PollCommandExecution's GET /api/events/commands/{id}/ with
-//     a terminal status so RunCommand returns synchronously instead of
-//     leaving a long-running goroutine behind.
+// newRunCommandBodyCaptureServer returns a test server that responds to
+// GET /api/servers/servers/?name=... with a 1-item server list and captures the
+// POST body for /api/events/commands/, returning a minimal CommandResponse list.
 func newRunCommandBodyCaptureServer(t *testing.T, capture *runCommandBodyCapture) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -218,28 +214,18 @@ func newRunCommandBodyCaptureServer(t *testing.T, capture *runCommandBodyCapture
 			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "cmd-1"}})
 			return
 		}
-		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/events/commands/") {
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(EventDetails{
-				ID:     "cmd-1",
-				Status: "completed",
-				Result: "done",
-			})
-			return
-		}
 		http.NotFound(w, r)
 	}))
 }
 
-func TestRunCommand_BodyIncludesWorkSession_WhenSet(t *testing.T) {
-	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
+func TestSubmitCommand_BodyIncludesWorkSession_WhenSet(t *testing.T) {
 	var capture runCommandBodyCapture
 	ts := newRunCommandBodyCaptureServer(t, &capture)
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
-	_, err := RunCommand(ac, "server-x", "ls", "", "", nil, "ses-abc")
+	_, err := SubmitCommand(ac, "server-x", "ls", "", "", nil, "ses-abc")
 	require.NoError(t, err)
 
 	hadKey, ws, _ := capture.snapshot()
@@ -247,73 +233,21 @@ func TestRunCommand_BodyIncludesWorkSession_WhenSet(t *testing.T) {
 	assert.Equal(t, "ses-abc", ws)
 }
 
-func TestRunCommand_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
-	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
+func TestSubmitCommand_BodyOmitsWorkSession_WhenEmpty(t *testing.T) {
 	var capture runCommandBodyCapture
 	ts := newRunCommandBodyCaptureServer(t, &capture)
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
-	_, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
+	_, err := SubmitCommand(ac, "server-x", "ls", "", "", nil, "")
 	require.NoError(t, err)
 
 	hadKey, _, _ := capture.snapshot()
 	assert.False(t, hadKey, "body must omit work_session field when ID is empty")
 }
 
-func TestRunCommand_InfraStatusReturnsError(t *testing.T) {
-	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
-	for _, status := range []string{"stuck", "error", "cancelled"} {
-		t.Run(status, func(t *testing.T) {
-			ts := newRunCommandServerWithDetails(t, EventDetails{ID: "cmd-1", Status: status})
-			defer ts.Close()
-
-			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-			result, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
-			require.Error(t, err)
-			assert.Empty(t, result)
-			assert.Contains(t, err.Error(), status)
-		})
-	}
-}
-
-func TestRunCommand_UnrecognisedTerminalStatusReturnsError(t *testing.T) {
-	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
-	ts := newRunCommandServerWithDetails(t, EventDetails{ID: "cmd-1", Status: "denied"})
-	defer ts.Close()
-
-	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	_, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unrecognised status")
-	assert.Contains(t, err.Error(), "denied")
-}
-
-func TestRunCommand_SuccessFalseReturnsRemoteCommandError(t *testing.T) {
-	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
-	ts := newRunCommandServerWithDetails(t, EventDetails{
-		ID:      "cmd-1",
-		Status:  "completed",
-		Success: boolPtr(false),
-		Result:  "command output here",
-	})
-	defer ts.Close()
-
-	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	result, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
-	require.Error(t, err)
-
-	var remoteErr *RemoteCommandError
-	require.True(t, errors.As(err, &remoteErr), "err must be *RemoteCommandError")
-	assert.Equal(t, "command output here", result)
-	assert.Equal(t, "command output here", remoteErr.Output)
-	assert.Equal(t, 1, remoteErr.ExitCode, "legacy response without exit_code must fall back to 1")
-	assert.Empty(t, remoteErr.ErrorPhase, "no phase when server omits error_phase")
-}
-
-func TestRunCommand_PropagatesExitCode(t *testing.T) {
-	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
+func TestErrorFromDetails_PropagatesExitCode(t *testing.T) {
 	tests := []struct {
 		name           string
 		respSuccess    *bool
@@ -362,85 +296,20 @@ func TestRunCommand_PropagatesExitCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts := newRunCommandServerWithDetails(t, EventDetails{
-				ID:         "cmd-1",
+			err := errorFromDetails(EventDetails{
 				Status:     "completed",
 				Success:    tt.respSuccess,
 				ExitCode:   tt.respExitCode,
 				ErrorPhase: tt.respErrorPhase,
 				Result:     tt.respResult,
 			})
-			defer ts.Close()
-
-			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-			result, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
 			require.Error(t, err)
 
 			var remoteErr *RemoteCommandError
 			require.True(t, errors.As(err, &remoteErr), "err must be *RemoteCommandError")
-			assert.Equal(t, tt.wantOutput, result)
 			assert.Equal(t, tt.wantOutput, remoteErr.Output)
 			assert.Equal(t, tt.wantExitCode, remoteErr.ExitCode)
 			assert.Equal(t, tt.wantErrorPhase, remoteErr.ErrorPhase)
-		})
-	}
-}
-
-func TestRunCommand_StuckWithErrorPhase(t *testing.T) {
-	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
-	tests := []struct {
-		name           string
-		respStatus     string
-		respErrorPhase *string
-		wantSubstrings []string
-	}{
-		{
-			name:           "stuck_agent_timeout",
-			respStatus:     "stuck",
-			respErrorPhase: strPtr("agent_timeout"),
-			wantSubstrings: []string{"agent_timeout", "status=stuck"},
-		},
-		{
-			name:           "stuck_agent_disconnected",
-			respStatus:     "stuck",
-			respErrorPhase: strPtr("agent_disconnected"),
-			wantSubstrings: []string{"agent_disconnected", "status=stuck"},
-		},
-		{
-			name:           "stuck_no_phase_keeps_legacy_message",
-			respStatus:     "stuck",
-			respErrorPhase: nil,
-			wantSubstrings: []string{"command failed with status: stuck"},
-		},
-		{
-			name:           "error_with_phase",
-			respStatus:     "error",
-			respErrorPhase: strPtr("agent_disconnected"),
-			wantSubstrings: []string{"agent_disconnected", "status=error"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ts := newRunCommandServerWithDetails(t, EventDetails{
-				ID:         "cmd-1",
-				Status:     tt.respStatus,
-				ErrorPhase: tt.respErrorPhase,
-			})
-			defer ts.Close()
-
-			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-			result, err := RunCommand(ac, "server-x", "ls", "", "", nil, "")
-			require.Error(t, err)
-			assert.Empty(t, result)
-
-			var remoteErr *RemoteCommandError
-			assert.False(t, errors.As(err, &remoteErr),
-				"stuck/error must remain infra error, not RemoteCommandError")
-
-			for _, sub := range tt.wantSubstrings {
-				assert.Contains(t, err.Error(), sub)
-			}
 		})
 	}
 }
@@ -552,7 +421,7 @@ func TestExecTimeout_InvalidEnvFallsBackToDefault(t *testing.T) {
 	assert.Equal(t, 30*time.Minute, execTimeout())
 }
 
-func TestRunCommand_401WithDetailSurfacesServerReason(t *testing.T) {
+func TestSubmitCommand_401WithDetailSurfacesServerReason(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
@@ -572,34 +441,12 @@ func TestRunCommand_401WithDetailSurfacesServerReason(t *testing.T) {
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	_, err := RunCommand(ac, "server-x", "id", "root", "", nil, "ses-abc")
+	_, err := SubmitCommand(ac, "server-x", "id", "root", "", nil, "ses-abc")
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "denied by policy")
 	assert.NotContains(t, err.Error(), "authentication failed")
 	assert.Contains(t, err.Error(), "alpacon login")
-}
-
-func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/servers/servers/"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(api.ListResponse[map[string]any]{
-				Count:   1,
-				Results: []map[string]any{{"id": "srv-1", "name": "server-x"}},
-			})
-		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/api/events/commands/"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "cmd-1"}})
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/api/events/commands/"):
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(details)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
 }
 
 func TestRunCommandStreaming_NormalFlow(t *testing.T) {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -607,8 +607,7 @@ func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 	cmdID := "cmd-uuid"
 
 	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
-	// subscribed is closed when the API server receives the subscription POST,
-	// signalling the WS server that it's safe to emit chunks (commandID is set by then).
+	// Closed on the subscription POST to signal the WS server it may emit chunks.
 	subscribed := make(chan struct{})
 	var wsURL string
 
@@ -647,7 +646,6 @@ func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/api/servers/servers/" && r.Method == http.MethodGet:
-			// minimal server lookup response
 			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-uuid","name":"srv"}]}`))
 		case r.URL.Path == "/api/events/sessions/" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch-uuid"}`))
@@ -932,7 +930,7 @@ func TestRunCommandStreaming_FallbackOnSubscribeFailureReusesCommand(t *testing.
 	require.NoError(t, err)
 	assert.Equal(t, "reused-output\n", stdoutBuf.String())
 
-	// THE KEY ASSERTION: SubmitCommand was called exactly once
+	// Key assertion: SubmitCommand was called exactly once
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal(t, 1, submitCount, "fallback must not re-submit the command")
@@ -980,8 +978,7 @@ func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
 	assert.Equal(t, "fallback-output\n", stdoutBuf.String())
 }
 
-// streamingServerConfig configures the fake event servers used by the
-// streaming-path tests below.
+// streamingServerConfig configures the fake event servers for streaming tests.
 type streamingServerConfig struct {
 	cmdID        string
 	serverID     string
@@ -991,9 +988,8 @@ type streamingServerConfig struct {
 	terminal     EventDetails      // returned by the detail poll once runningPolls elapse
 }
 
-// newStreamingServers starts a WS + API server pair for streaming tests and
-// returns a client pointed at the API server. Servers are torn down via
-// t.Cleanup. The WS emits cfg.wsChunks after the subscription POST arrives.
+// newStreamingServers starts a WS + API server pair and returns a client for
+// them. The WS emits cfg.wsChunks after the subscription POST arrives.
 func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.AlpaconClient {
 	t.Helper()
 	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
@@ -1072,9 +1068,7 @@ func newStreamingServers(t *testing.T, cfg streamingServerConfig) *client.Alpaco
 }
 
 // TestRunCommandStreaming_NoDuplicateOutputOnFailure guards the duplicate-output
-// fix: a failed command's terminal poll carries the full buffered Result, but
-// the chunks were already streamed live, so errorFromDetails must receive a
-// cleared Result and stdout must contain the output exactly once.
+// fix: a failed command's buffered Result must not be reprinted after streaming.
 func TestRunCommandStreaming_NoDuplicateOutputOnFailure(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{
@@ -1087,17 +1081,15 @@ func TestRunCommandStreaming_NoDuplicateOutputOnFailure(t *testing.T) {
 
 	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 
-	// Streamed chunks appear once; the buffered Result is not appended.
 	assert.Equal(t, "hello\nworld\n", stdoutBuf.String())
-	// The returned error must carry a cleared Output so cmd/exec does not reprint it.
+	// Output must be cleared so cmd/exec does not reprint it.
 	var remoteErr *RemoteCommandError
 	require.ErrorAs(t, err, &remoteErr)
 	assert.Equal(t, "", remoteErr.Output, "buffered result must be cleared to prevent duplicate output")
 }
 
 // TestRunCommandStreaming_TerminalStatusErrors covers errorFromDetails' non-nil
-// branches reached through the streaming select loop, pinning the exit-code /
-// error-mapping contract for failed, infra-error, and unrecognized statuses.
+// branches reached through the streaming select loop.
 func TestRunCommandStreaming_TerminalStatusErrors(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1161,9 +1153,8 @@ func TestRunCommandStreaming_TerminalStatusErrors(t *testing.T) {
 	}
 }
 
-// TestRunCommandStreaming_DrainsTrailingChunksOnTerminal covers the
-// drain-on-terminal path: trailing chunks produced as the command finishes
-// never arrive over the WS and are recovered only by the final REST drain.
+// TestRunCommandStreaming_DrainsTrailingChunksOnTerminal covers the drain path:
+// trailing chunks never seen over the WS are recovered by the final REST drain.
 func TestRunCommandStreaming_DrainsTrailingChunksOnTerminal(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -866,3 +866,46 @@ func TestRunCommandStreaming_DuplicateSeqIgnored(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "s0\ns1\ns2\n", stdoutBuf.String())
 }
+
+func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	cmdID := "cmd-uuid"
+	serverID := "srv-uuid"
+
+	var pollCount int
+	var mu sync.Mutex
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"` + serverID + `","name":"srv"}]}`))
+		case "/api/events/sessions/":
+			// Force fallback
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/api/events/commands/":
+			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
+		case "/api/events/commands/" + cmdID + "/":
+			mu.Lock()
+			pollCount++
+			n := pollCount
+			mu.Unlock()
+			if n < 2 {
+				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
+			} else {
+				success := true
+				resp := EventDetails{ID: cmdID, Status: "completed", Success: &success, Result: "fallback-output\n"}
+				_ = json.NewEncoder(w).Encode(resp)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+
+	outcome, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", outcome.Status)
+	assert.Equal(t, "fallback-output\n", stdoutBuf.String())
+}

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -904,27 +904,36 @@ func TestRunCommandStreaming_TerminalStatusErrors(t *testing.T) {
 			},
 		},
 		{
-			name:     "stuck status returns infra error",
+			name:     "stuck status without phase keeps legacy message",
 			terminal: EventDetails{Status: "stuck"},
 			check: func(t *testing.T, err error) {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "status=stuck")
+				assert.Contains(t, err.Error(), "command failed with status: stuck")
 			},
 		},
 		{
-			name:     "error status returns infra error",
+			name:     "error status without phase keeps legacy message",
 			terminal: EventDetails{Status: "error"},
 			check: func(t *testing.T, err error) {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "status=error")
+				assert.Contains(t, err.Error(), "command failed with status: error")
 			},
 		},
 		{
-			name:     "cancelled status returns infra error",
+			name:     "cancelled status without phase keeps legacy message",
 			terminal: EventDetails{Status: "cancelled"},
 			check: func(t *testing.T, err error) {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "status=cancelled")
+				assert.Contains(t, err.Error(), "command failed with status: cancelled")
+			},
+		},
+		{
+			name:     "stuck status with phase carries phase identifier",
+			terminal: EventDetails{Status: "stuck", ErrorPhase: strPtr("agent_timeout")},
+			check: func(t *testing.T, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "[agent_timeout]")
+				assert.Contains(t, err.Error(), "status=stuck")
 			},
 		},
 		{

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/api/types"
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -597,4 +599,94 @@ func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptes
 			http.NotFound(w, r)
 		}
 	}))
+}
+
+func TestRunCommandStreaming_NormalFlow(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	cmdID := "cmd-uuid"
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	// subscribed is closed when the API server receives the subscription POST,
+	// signalling the WS server that it's safe to emit chunks (commandID is set by then).
+	subscribed := make(chan struct{})
+	var wsURL string
+
+	// WS server: wait for subscription then emit two chunks
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		// Wait until the subscriber has called setCommandID before sending chunks.
+		select {
+		case <-subscribed:
+		case <-time.After(10 * time.Second):
+			t.Error("timeout waiting for subscription signal")
+			return
+		}
+		for _, c := range []ChunkEvent{{Seq: 0, Content: "hello\n"}, {Seq: 1, Content: "world\n"}} {
+			env := map[string]any{
+				"event_type": "command_output",
+				"payload":    map[string]any{"command_id": cmdID, "seq": c.Seq, "content": c.Content},
+			}
+			b, _ := json.Marshal(env)
+			_ = conn.WriteMessage(websocket.TextMessage, b)
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer wsServer.Close()
+	wsURL = "ws" + strings.TrimPrefix(wsServer.URL, "http")
+
+	var pollCount int
+	var mu sync.Mutex
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/servers/servers/" && r.Method == http.MethodGet:
+			// minimal server lookup response
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-uuid","name":"srv"}]}`))
+		case r.URL.Path == "/api/events/sessions/" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch-uuid"}`))
+		case r.URL.Path == "/api/events/commands/" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
+		case r.URL.Path == "/api/events/subscriptions/" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+			// Signal the WS server that setCommandID has been called (happens before SubscribeCommandOutput).
+			select {
+			case <-subscribed:
+			default:
+				close(subscribed)
+			}
+		case r.URL.Path == "/api/events/commands/"+cmdID+"/chunks/" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
+		case r.URL.Path == "/api/events/commands/"+cmdID+"/" && r.Method == http.MethodGet:
+			mu.Lock()
+			pollCount++
+			n := pollCount
+			mu.Unlock()
+			// Stay running for first 2 polls, then success
+			if n < 3 {
+				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
+			} else {
+				success := true
+				resp := EventDetails{ID: cmdID, Status: "completed", Success: &success, Result: ""}
+				_ = json.NewEncoder(w).Encode(resp)
+			}
+		default:
+			t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+
+	outcome, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", outcome.Status)
+	assert.Equal(t, "hello\nworld\n", stdoutBuf.String())
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -867,6 +867,78 @@ func TestRunCommandStreaming_DuplicateSeqIgnored(t *testing.T) {
 	assert.Equal(t, "s0\ns1\ns2\n", stdoutBuf.String())
 }
 
+func TestRunCommandStreaming_FallbackOnSubscribeFailureReusesCommand(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	cmdID := "cmd-uuid"
+	serverID := "srv-uuid"
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	// WS server just upgrades and waits; subscribe will fail so chunks shouldn't matter
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer wsServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+
+	var submitCount int
+	var pollCount int
+	var mu sync.Mutex
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"` + serverID + `","name":"srv"}]}`))
+		case "/api/events/sessions/":
+			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch"}`))
+		case "/api/events/commands/":
+			mu.Lock()
+			submitCount++
+			mu.Unlock()
+			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
+		case "/api/events/subscriptions/":
+			// Force subscribe failure -> fallback path with existing cmdID
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/api/events/commands/" + cmdID + "/":
+			mu.Lock()
+			pollCount++
+			n := pollCount
+			mu.Unlock()
+			if n < 2 {
+				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
+			} else {
+				success := true
+				resp := EventDetails{ID: cmdID, Status: "completed", Success: &success, Result: "reused-output\n"}
+				_ = json.NewEncoder(w).Encode(resp)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+
+	outcome, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", outcome.Status)
+	assert.Equal(t, "reused-output\n", stdoutBuf.String())
+
+	// THE KEY ASSERTION: SubmitCommand was called exactly once
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, submitCount, "fallback must not re-submit the command")
+}
+
 func TestRunCommandStreaming_FallbackOnSessionFailure(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	cmdID := "cmd-uuid"

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -604,85 +604,13 @@ func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptes
 
 func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
-	cmdID := "cmd-uuid"
-
-	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
-	// Closed on the subscription POST to signal the WS server it may emit chunks.
-	subscribed := make(chan struct{})
-	var wsURL string
-
-	// WS server: wait for subscription then emit two chunks
-	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		require.NoError(t, err)
-		defer func() { _ = conn.Close() }()
-		// Wait until the subscriber has called setCommandID before sending chunks.
-		select {
-		case <-subscribed:
-		case <-time.After(10 * time.Second):
-			t.Error("timeout waiting for subscription signal")
-			return
-		}
-		for _, c := range []ChunkEvent{{Seq: 0, Content: "hello\n"}, {Seq: 1, Content: "world\n"}} {
-			env := map[string]any{
-				"event_type": "command_output",
-				"payload":    map[string]any{"command_id": cmdID, "seq": c.Seq, "content": c.Content},
-			}
-			b, _ := json.Marshal(env)
-			_ = conn.WriteMessage(websocket.TextMessage, b)
-		}
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
-			}
-		}
-	}))
-	defer wsServer.Close()
-	wsURL = "ws" + strings.TrimPrefix(wsServer.URL, "http")
-
-	var pollCount int
-	var mu sync.Mutex
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/api/servers/servers/" && r.Method == http.MethodGet:
-			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-uuid","name":"srv"}]}`))
-		case r.URL.Path == "/api/events/sessions/" && r.Method == http.MethodPost:
-			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch-uuid"}`))
-		case r.URL.Path == "/api/events/commands/" && r.Method == http.MethodPost:
-			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
-		case r.URL.Path == "/api/events/subscriptions/" && r.Method == http.MethodPost:
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{}`))
-			// Signal the WS server that setCommandID has been called (happens before SubscribeCommandOutput).
-			select {
-			case <-subscribed:
-			default:
-				close(subscribed)
-			}
-		case r.URL.Path == "/api/events/commands/"+cmdID+"/chunks/" && r.Method == http.MethodGet:
-			_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
-		case r.URL.Path == "/api/events/commands/"+cmdID+"/" && r.Method == http.MethodGet:
-			mu.Lock()
-			pollCount++
-			n := pollCount
-			mu.Unlock()
-			// Stay running for first 2 polls, then success
-			if n < 3 {
-				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
-			} else {
-				success := true
-				resp := EventDetails{ID: cmdID, Status: "completed", Success: &success, Result: ""}
-				_ = json.NewEncoder(w).Encode(resp)
-			}
-		default:
-			t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer apiServer.Close()
-
-	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:        "cmd-uuid",
+		serverID:     "srv-uuid",
+		wsChunks:     []ChunkEvent{{Seq: 0, Content: "hello\n"}, {Seq: 1, Content: "world\n"}},
+		runningPolls: 2,
+		terminal:     EventDetails{Status: "completed", Success: boolPtr(true)},
+	})
 
 	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 	require.NoError(t, err)
@@ -691,95 +619,20 @@ func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 
 func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
-	cmdID := "cmd-uuid"
-	serverID := "srv-uuid"
-
-	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
-	subscribed := make(chan struct{})
-	var subOnce sync.Once
-
-	// WS emits seq 0 and seq 3 (gap)
-	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		require.NoError(t, err)
-		defer func() { _ = conn.Close() }()
-		select {
-		case <-subscribed:
-		case <-time.After(10 * time.Second):
-			t.Errorf("ws: timed out waiting for subscribed signal")
-			return
-		}
-		for _, seq := range []int{0, 3} {
-			env := map[string]any{
-				"event_type": "command_output",
-				"payload":    map[string]any{"command_id": cmdID, "seq": seq, "content": fmt.Sprintf("s%d\n", seq)},
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		// WS delivers seq 0 then 3; the missing 1,2 come from the gap-fill fetch.
+		wsChunks: []ChunkEvent{{Seq: 0, Content: "s0\n"}, {Seq: 3, Content: "s3\n"}},
+		chunksFor: func(fromSeq int) []Chunk {
+			if fromSeq == 1 {
+				return []Chunk{{Seq: 1, Content: "s1\n"}, {Seq: 2, Content: "s2\n"}}
 			}
-			b, _ := json.Marshal(env)
-			_ = conn.WriteMessage(websocket.TextMessage, b)
-		}
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
-			}
-		}
-	}))
-	defer wsServer.Close()
-	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
-
-	var chunkRequests int
-	var pollCount int
-	var mu sync.Mutex
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/api/servers/servers/" && r.Method == http.MethodGet:
-			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"` + serverID + `","name":"srv"}]}`))
-		case r.URL.Path == "/api/events/sessions/" && r.Method == http.MethodPost:
-			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch"}`))
-		case r.URL.Path == "/api/events/commands/" && r.Method == http.MethodPost:
-			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
-		case r.URL.Path == "/api/events/subscriptions/" && r.Method == http.MethodPost:
-			subOnce.Do(func() { close(subscribed) })
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{}`))
-		case r.URL.Path == "/api/events/commands/"+cmdID+"/chunks/" && r.Method == http.MethodGet:
-			mu.Lock()
-			chunkRequests++
-			n := chunkRequests
-			mu.Unlock()
-			// First call (warm-fire) → empty.
-			// Subsequent (gap fill at seq>=1) → return seq 1 and 2.
-			if n == 1 {
-				_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
-				return
-			}
-			resp := api.ListResponse[Chunk]{
-				Count: 2,
-				Results: []Chunk{
-					{Seq: 1, Content: "s1\n"},
-					{Seq: 2, Content: "s2\n"},
-				},
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-		case r.URL.Path == "/api/events/commands/"+cmdID+"/" && r.Method == http.MethodGet:
-			mu.Lock()
-			pollCount++
-			n := pollCount
-			mu.Unlock()
-			if n < 3 {
-				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
-			} else {
-				success := true
-				resp := EventDetails{ID: cmdID, Status: "completed", Success: &success}
-				_ = json.NewEncoder(w).Encode(resp)
-			}
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer apiServer.Close()
-
-	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+			return nil
+		},
+		runningPolls: 2,
+		terminal:     EventDetails{Status: "completed", Success: boolPtr(true)},
+	})
 
 	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 	require.NoError(t, err)
@@ -788,77 +641,19 @@ func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
 
 func TestRunCommandStreaming_DuplicateSeqIgnored(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
-	cmdID := "cmd-uuid"
-	serverID := "srv-uuid"
-
-	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
-	subscribed := make(chan struct{})
-	var subOnce sync.Once
-
-	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		require.NoError(t, err)
-		defer func() { _ = conn.Close() }()
-		select {
-		case <-subscribed:
-		case <-time.After(10 * time.Second):
-			t.Errorf("ws: timed out waiting for subscribed signal")
-			return
-		}
-		// Emit 0, 1, 1, 2 — second 1 must be dropped
-		for _, seq := range []int{0, 1, 1, 2} {
-			env := map[string]any{
-				"event_type": "command_output",
-				"payload":    map[string]any{"command_id": cmdID, "seq": seq, "content": fmt.Sprintf("s%d\n", seq)},
-			}
-			b, _ := json.Marshal(env)
-			_ = conn.WriteMessage(websocket.TextMessage, b)
-		}
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
-			}
-		}
-	}))
-	defer wsServer.Close()
-	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
-
-	var pollCount int
-	var mu sync.Mutex
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/api/servers/servers/":
-			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"` + serverID + `","name":"srv"}]}`))
-		case "/api/events/sessions/":
-			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch"}`))
-		case "/api/events/commands/":
-			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
-		case "/api/events/subscriptions/":
-			subOnce.Do(func() { close(subscribed) })
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{}`))
-		case "/api/events/commands/" + cmdID + "/chunks/":
-			_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
-		case "/api/events/commands/" + cmdID + "/":
-			mu.Lock()
-			pollCount++
-			n := pollCount
-			mu.Unlock()
-			if n < 3 {
-				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
-			} else {
-				success := true
-				resp := EventDetails{ID: cmdID, Status: "completed", Success: &success}
-				_ = json.NewEncoder(w).Encode(resp)
-			}
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer apiServer.Close()
-
-	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		// The second seq 1 must be dropped.
+		wsChunks: []ChunkEvent{
+			{Seq: 0, Content: "s0\n"},
+			{Seq: 1, Content: "s1\n"},
+			{Seq: 1, Content: "s1\n"},
+			{Seq: 2, Content: "s2\n"},
+		},
+		runningPolls: 2,
+		terminal:     EventDetails{Status: "completed", Success: boolPtr(true)},
+	})
 
 	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
 	require.NoError(t, err)

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -639,6 +639,38 @@ func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
 	assert.Equal(t, "s0\ns1\ns2\ns3\n", stdoutBuf.String())
 }
 
+// TestRunCommandStreaming_WarmFireGapDoesNotSkipLaterChunk guards against
+// advancing lastSeq past a gap during the warm-fire drain. If the persisted
+// chunks contain a hole (seq 0,1,3 with 2 missing), lastSeq must stop at the
+// last contiguous seq (1) so a later seq 2 arriving over the WS is still
+// written rather than skipped as a duplicate. seq 3 is then filled by the
+// terminal drain in order.
+func TestRunCommandStreaming_WarmFireGapDoesNotSkipLaterChunk(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	ac := newStreamingServers(t, streamingServerConfig{
+		cmdID:    "cmd-uuid",
+		serverID: "srv-uuid",
+		// seq 2 is absent from the persisted set; it arrives only over the WS.
+		wsChunks: []ChunkEvent{{Seq: 2, Content: "s2\n"}},
+		chunksFor: func(fromSeq int) []Chunk {
+			persisted := []Chunk{{Seq: 0, Content: "s0\n"}, {Seq: 1, Content: "s1\n"}, {Seq: 3, Content: "s3\n"}}
+			var out []Chunk
+			for _, c := range persisted {
+				if c.Seq >= fromSeq {
+					out = append(out, c)
+				}
+			}
+			return out
+		},
+		runningPolls: 1,
+		terminal:     EventDetails{Status: "completed", Success: boolPtr(true)},
+	})
+
+	err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "s0\ns1\ns2\ns3\n", stdoutBuf.String())
+}
+
 func TestRunCommandStreaming_DuplicateSeqIgnored(t *testing.T) {
 	stdoutBuf := &bytes.Buffer{}
 	ac := newStreamingServers(t, streamingServerConfig{

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -690,3 +690,179 @@ func TestRunCommandStreaming_NormalFlow(t *testing.T) {
 	assert.Equal(t, "completed", outcome.Status)
 	assert.Equal(t, "hello\nworld\n", stdoutBuf.String())
 }
+
+func TestRunCommandStreaming_GapFilledByREST(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	cmdID := "cmd-uuid"
+	serverID := "srv-uuid"
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	subscribed := make(chan struct{})
+	var subOnce sync.Once
+
+	// WS emits seq 0 and seq 3 (gap)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		select {
+		case <-subscribed:
+		case <-time.After(10 * time.Second):
+			t.Errorf("ws: timed out waiting for subscribed signal")
+			return
+		}
+		for _, seq := range []int{0, 3} {
+			env := map[string]any{
+				"event_type": "command_output",
+				"payload":    map[string]any{"command_id": cmdID, "seq": seq, "content": fmt.Sprintf("s%d\n", seq)},
+			}
+			b, _ := json.Marshal(env)
+			_ = conn.WriteMessage(websocket.TextMessage, b)
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer wsServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+
+	var chunkRequests int
+	var pollCount int
+	var mu sync.Mutex
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/servers/servers/" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"` + serverID + `","name":"srv"}]}`))
+		case r.URL.Path == "/api/events/sessions/" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch"}`))
+		case r.URL.Path == "/api/events/commands/" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
+		case r.URL.Path == "/api/events/subscriptions/" && r.Method == http.MethodPost:
+			subOnce.Do(func() { close(subscribed) })
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		case r.URL.Path == "/api/events/commands/"+cmdID+"/chunks/" && r.Method == http.MethodGet:
+			mu.Lock()
+			chunkRequests++
+			n := chunkRequests
+			mu.Unlock()
+			// First call (warm-fire) → empty.
+			// Subsequent (gap fill at seq>=1) → return seq 1 and 2.
+			if n == 1 {
+				_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
+				return
+			}
+			resp := api.ListResponse[Chunk]{
+				Count: 2,
+				Results: []Chunk{
+					{Seq: 1, Content: "s1\n"},
+					{Seq: 2, Content: "s2\n"},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/api/events/commands/"+cmdID+"/" && r.Method == http.MethodGet:
+			mu.Lock()
+			pollCount++
+			n := pollCount
+			mu.Unlock()
+			if n < 3 {
+				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
+			} else {
+				success := true
+				resp := EventDetails{ID: cmdID, Status: "completed", Success: &success}
+				_ = json.NewEncoder(w).Encode(resp)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+
+	_, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "s0\ns1\ns2\ns3\n", stdoutBuf.String())
+}
+
+func TestRunCommandStreaming_DuplicateSeqIgnored(t *testing.T) {
+	stdoutBuf := &bytes.Buffer{}
+	cmdID := "cmd-uuid"
+	serverID := "srv-uuid"
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	subscribed := make(chan struct{})
+	var subOnce sync.Once
+
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		select {
+		case <-subscribed:
+		case <-time.After(10 * time.Second):
+			t.Errorf("ws: timed out waiting for subscribed signal")
+			return
+		}
+		// Emit 0, 1, 1, 2 — second 1 must be dropped
+		for _, seq := range []int{0, 1, 1, 2} {
+			env := map[string]any{
+				"event_type": "command_output",
+				"payload":    map[string]any{"command_id": cmdID, "seq": seq, "content": fmt.Sprintf("s%d\n", seq)},
+			}
+			b, _ := json.Marshal(env)
+			_ = conn.WriteMessage(websocket.TextMessage, b)
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer wsServer.Close()
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+
+	var pollCount int
+	var mu sync.Mutex
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"` + serverID + `","name":"srv"}]}`))
+		case "/api/events/sessions/":
+			_, _ = w.Write([]byte(`{"id":"s","websocket_url":"` + wsURL + `","channel_id":"ch"}`))
+		case "/api/events/commands/":
+			_, _ = w.Write([]byte(`[{"id":"` + cmdID + `"}]`))
+		case "/api/events/subscriptions/":
+			subOnce.Do(func() { close(subscribed) })
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/events/commands/" + cmdID + "/chunks/":
+			_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
+		case "/api/events/commands/" + cmdID + "/":
+			mu.Lock()
+			pollCount++
+			n := pollCount
+			mu.Unlock()
+			if n < 3 {
+				_, _ = w.Write([]byte(`{"id":"` + cmdID + `","status":"running"}`))
+			} else {
+				success := true
+				resp := EventDetails{ID: cmdID, Status: "completed", Success: &success}
+				_ = json.NewEncoder(w).Encode(resp)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: apiServer.Client(), BaseURL: apiServer.URL}
+
+	_, err := runCommandStreamingWithWriter(ac, "srv", "echo hi", "", "", nil, "", stdoutBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "s0\ns1\ns2\n", stdoutBuf.String())
+}

--- a/api/event/subscribe.go
+++ b/api/event/subscribe.go
@@ -57,3 +57,21 @@ func SubscribeSudoEvent(ac *client.AlpaconClient, channelID, sessionID string) e
 
 	return nil
 }
+
+// SubscribeCommandOutput subscribes the given channel to command_output events
+// for a specific command. target_id=commandID ensures the channel only receives
+// chunks for this one command.
+func SubscribeCommandOutput(ac *client.AlpaconClient, channelID, commandID string) error {
+	req := &EventSubscriptionRequest{
+		Channel:   channelID,
+		EventType: "command_output",
+		TargetID:  commandID,
+	}
+
+	_, err := ac.SendPostRequest(eventSubscriptionsURL, req)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to command_output events: %w", err)
+	}
+
+	return nil
+}

--- a/api/event/subscribe.go
+++ b/api/event/subscribe.go
@@ -58,9 +58,8 @@ func SubscribeSudoEvent(ac *client.AlpaconClient, channelID, sessionID string) e
 	return nil
 }
 
-// SubscribeCommandOutput subscribes the given channel to command_output events
-// for a specific command. target_id=commandID ensures the channel only receives
-// chunks for this one command.
+// SubscribeCommandOutput subscribes the channel to command_output events for the
+// given command (target_id scopes delivery to that command's chunks).
 func SubscribeCommandOutput(ac *client.AlpaconClient, channelID, commandID string) error {
 	req := &EventSubscriptionRequest{
 		Channel:   channelID,

--- a/api/event/subscribe_test.go
+++ b/api/event/subscribe_test.go
@@ -2,12 +2,14 @@ package event
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateEventSession(t *testing.T) {
@@ -94,4 +96,33 @@ func TestSubscribeSudoEvent_ServerError(t *testing.T) {
 
 	err := SubscribeSudoEvent(ac, "channel-456", "session-123")
 	assert.Error(t, err)
+}
+
+func TestSubscribeCommandOutput_SendsExpectedPayload(t *testing.T) {
+	channelID := "channel-uuid"
+	cmdID := "command-uuid"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "events/subscriptions")
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var req EventSubscriptionRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		assert.Equal(t, channelID, req.Channel)
+		assert.Equal(t, "command_output", req.EventType)
+		assert.Equal(t, cmdID, req.TargetID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	err := SubscribeCommandOutput(ac, channelID, cmdID)
+	assert.NoError(t, err)
 }

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -18,7 +18,7 @@ var phaseDescriptions = map[string]string{
 
 // RemoteCommandError is returned when the remote command completed but exited
 // with a non-zero status. Callers populate ExitCode from the server response;
-// RunCommand falls back to 1 when the server omits exit_code.
+// errorFromDetails falls back to 1 when the server omits exit_code.
 type RemoteCommandError struct {
 	Output     string
 	ExitCode   int

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -148,8 +148,8 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			return
 		}
 
-		result, err := RunCommandWithRetry(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
+		err = RunCommandWithRetry(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
 		utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
-		HandleCommandResult(result, err)
+		HandleCommandResult(err)
 	},
 }

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -43,6 +43,12 @@ Run the command again later to check for completion.`,
 			return
 		}
 
+		// Output is stored as chunks (Result is empty under the streaming
+		// contract); reconstruct it, falling back to Result for legacy commands.
+		if output, oerr := event.GetCommandOutput(alpaconClient, jobID); oerr == nil && output != "" {
+			details.Result = output
+		}
+
 		stdoutLine, stderrLine, exitCode := logsCommandOutcome(details)
 		if stdoutLine != "" {
 			fmt.Println(stdoutLine)

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -16,10 +16,13 @@ import (
 // error handling and retry logic. Used by both exec and websh commands.
 // workSessionID is forwarded to the server as the work_session field; pass ""
 // to omit it.
+//
+// Output is streamed to os.Stdout during execution (not buffered). The returned
+// string is always empty and is kept only for signature compatibility.
 func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (string, error) {
-	result, err := event.RunCommand(ac, serverName, command, username, groupname, env, workSessionID)
+	outcome, err := event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
 	if phased, ok := asPhasedError(err); ok {
-		return result, phased
+		return "", phased
 	}
 	if err != nil {
 		err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
@@ -35,19 +38,20 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 			},
 			RefreshToken: ac.RefreshToken,
 			RetryOperation: func() error {
-				result, err = event.RunCommand(ac, serverName, command, username, groupname, env, workSessionID)
+				outcome, err = event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
 				return err
 			},
 		})
 		// RetryOperation may surface a phased error; re-check after HandleCommonErrors.
 		if phased, ok := asPhasedError(err); ok {
-			return result, phased
+			return "", phased
 		}
 		if err != nil {
 			return "", fmt.Errorf("failed to execute command on '%s' server: %w", serverName, err)
 		}
 	}
-	return result, nil
+	_ = outcome
+	return "", nil
 }
 
 // HandleCommandResult prints result on success, or exits appropriately on error.
@@ -72,7 +76,9 @@ func HandleCommandResult(result string, err error) {
 		utils.CliErrorWithExit("%s", err)
 		return
 	}
-	fmt.Println(result)
+	if result != "" {
+		fmt.Println(result)
+	}
 }
 
 // asPhasedError unwraps err to a RemoteCommandError or ClientTimeoutError.

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -19,8 +19,7 @@ import (
 //
 // Output is streamed to os.Stdout during execution (not buffered).
 func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) error {
-	var err error
-	_, err = event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
+	err := event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
 	if phased, ok := asPhasedError(err); ok {
 		return phased
 	}
@@ -38,8 +37,7 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 			},
 			RefreshToken: ac.RefreshToken,
 			RetryOperation: func() error {
-				_, err = event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
-				return err
+				return event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
 			},
 		})
 		// RetryOperation may surface a phased error; re-check after HandleCommonErrors.

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -17,12 +17,12 @@ import (
 // workSessionID is forwarded to the server as the work_session field; pass ""
 // to omit it.
 //
-// Output is streamed to os.Stdout during execution (not buffered). The returned
-// string is always empty and is kept only for signature compatibility.
-func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (string, error) {
-	outcome, err := event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
+// Output is streamed to os.Stdout during execution (not buffered).
+func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) error {
+	var err error
+	_, err = event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
 	if phased, ok := asPhasedError(err); ok {
-		return "", phased
+		return phased
 	}
 	if err != nil {
 		err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
@@ -38,28 +38,28 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 			},
 			RefreshToken: ac.RefreshToken,
 			RetryOperation: func() error {
-				outcome, err = event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
+				_, err = event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
 				return err
 			},
 		})
 		// RetryOperation may surface a phased error; re-check after HandleCommonErrors.
 		if phased, ok := asPhasedError(err); ok {
-			return "", phased
+			return phased
 		}
 		if err != nil {
-			return "", fmt.Errorf("failed to execute command on '%s' server: %w", serverName, err)
+			return fmt.Errorf("failed to execute command on '%s' server: %w", serverName, err)
 		}
 	}
-	_ = outcome
-	return "", nil
+	return nil
 }
 
-// HandleCommandResult prints result on success, or exits appropriately on error.
-func HandleCommandResult(result string, err error) {
+// HandleCommandResult exits appropriately on error. Chunks are already streamed
+// to stdout during execution, so no result string is needed.
+func HandleCommandResult(err error) {
 	if err != nil {
 		var remoteErr *event.RemoteCommandError
 		if errors.As(err, &remoteErr) {
-			stdoutLine, stderrLine, exitCode := remoteCommandOutcome(result, remoteErr)
+			stdoutLine, stderrLine, exitCode := remoteCommandOutcome(remoteErr)
 			if stdoutLine != "" {
 				fmt.Println(stdoutLine)
 			}
@@ -74,10 +74,6 @@ func HandleCommandResult(result string, err error) {
 			os.Exit(1)
 		}
 		utils.CliErrorWithExit("%s", err)
-		return
-	}
-	if result != "" {
-		fmt.Println(result)
 	}
 }
 
@@ -110,9 +106,9 @@ func detachResultLines(jobID string) (string, string) {
 
 // remoteCommandOutcome is the testable core of HandleCommandResult's
 // RemoteCommandError branch. stderrLine already includes its trailing newline.
-func remoteCommandOutcome(result string, remoteErr *event.RemoteCommandError) (stdoutLine, stderrLine string, exitCode int) {
-	if result != "" {
-		stdoutLine = result
+func remoteCommandOutcome(remoteErr *event.RemoteCommandError) (stdoutLine, stderrLine string, exitCode int) {
+	if remoteErr.Output != "" {
+		stdoutLine = remoteErr.Output
 	}
 	if remoteErr.ErrorPhase != "" {
 		stderrLine = fmt.Sprintf("%s: [%s] %s\n",

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -12,12 +12,9 @@ import (
 	"github.com/alpacax/alpacon-cli/utils"
 )
 
-// RunCommandWithRetry executes a remote command with MFA and username-required
-// error handling and retry logic. Used by both exec and websh commands.
-// workSessionID is forwarded to the server as the work_session field; pass ""
-// to omit it.
-//
-// Output is streamed to os.Stdout during execution (not buffered).
+// RunCommandWithRetry executes a remote command with MFA/username-required error
+// handling and retry logic, streaming output to stdout. Used by exec and websh.
+// workSessionID is forwarded as the work_session field; pass "" to omit it.
 func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) error {
 	err := event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID)
 	if phased, ok := asPhasedError(err); ok {

--- a/cmd/exec/run_test.go
+++ b/cmd/exec/run_test.go
@@ -45,17 +45,15 @@ func TestAsPhasedError(t *testing.T) {
 
 func TestRemoteCommandOutcome(t *testing.T) {
 	tests := []struct {
-		name              string
-		result            string
-		remoteErr         *event.RemoteCommandError
-		wantStdoutLine    string
-		wantStderrEmpty   bool
-		wantStderrPhrase  string
-		wantExitCode      int
+		name             string
+		remoteErr        *event.RemoteCommandError
+		wantStdoutLine   string
+		wantStderrEmpty  bool
+		wantStderrPhrase string
+		wantExitCode     int
 	}{
 		{
-			name:   "result_and_phase_propagate_exit_124",
-			result: "command timed out",
+			name: "result_and_phase_propagate_exit_124",
 			remoteErr: &event.RemoteCommandError{
 				Output:     "command timed out",
 				ExitCode:   124,
@@ -66,8 +64,7 @@ func TestRemoteCommandOutcome(t *testing.T) {
 			wantExitCode:     124,
 		},
 		{
-			name:   "non_zero_exit_without_phase_skips_stderr_line",
-			result: "rsync: some files vanished",
+			name: "non_zero_exit_without_phase_skips_stderr_line",
 			remoteErr: &event.RemoteCommandError{
 				Output:     "rsync: some files vanished",
 				ExitCode:   23,
@@ -78,8 +75,7 @@ func TestRemoteCommandOutcome(t *testing.T) {
 			wantExitCode:    23,
 		},
 		{
-			name:   "empty_result_with_phase_still_emits_stderr",
-			result: "",
+			name: "empty_result_with_phase_still_emits_stderr",
 			remoteErr: &event.RemoteCommandError{
 				Output:     "",
 				ExitCode:   1,
@@ -90,8 +86,7 @@ func TestRemoteCommandOutcome(t *testing.T) {
 			wantExitCode:     1,
 		},
 		{
-			name:   "legacy_fallback_exit_1_no_phase",
-			result: "boom",
+			name: "legacy_fallback_exit_1_no_phase",
 			remoteErr: &event.RemoteCommandError{
 				Output:     "boom",
 				ExitCode:   1,
@@ -105,7 +100,7 @@ func TestRemoteCommandOutcome(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stdoutLine, stderrLine, exitCode := remoteCommandOutcome(tt.result, tt.remoteErr)
+			stdoutLine, stderrLine, exitCode := remoteCommandOutcome(tt.remoteErr)
 
 			assert.Equal(t, tt.wantStdoutLine, stdoutLine, "stdout line should match")
 			assert.Equal(t, tt.wantExitCode, exitCode, "exit code should match")

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -231,9 +231,9 @@ Note: All flags must be placed before the server name.
 				}
 			}
 			command := execCmd.ShellJoin(commandArgs)
-			result, err := execCmd.RunCommandWithRetry(alpaconClient, serverName, command, username, groupname, env, workSessionID)
+			err := execCmd.RunCommandWithRetry(alpaconClient, serverName, command, username, groupname, env, workSessionID)
 			utils.HandleWorkSessionError(err, "command", serverName, authMethod, workSessionID)
-			execCmd.HandleCommandResult(result, err)
+			execCmd.HandleCommandResult(err)
 		} else {
 			session, err := websh.CreateWebshSession(alpaconClient, serverName, username, groupname, share, readOnly, workSessionID)
 


### PR DESCRIPTION
## Summary
- `alpacon exec` now streams remote command output chunk-by-chunk as the command runs, instead of buffering until completion. Implemented via a new `event.RunCommandStreaming` path that subscribes to chunks over WebSocket (`SubscribeCommandOutput`) and writes each chunk's stdout/stderr to the output sink as it arrives.
- Resilience: if the WS subscribe fails on dial, the call falls back to polling on the same command id (no duplicate submission). If chunks are missed mid-stream or after the command finishes, a REST gap-fill (`GetCommandChunks`) reconstructs them by sequence; on failure the user sees an `output may be incomplete` warning on stderr.
- Caller surface simplified: `RunCommandStreaming` returns only `error` (terminal status is conveyed through `RemoteCommandError` / `ClientTimeoutError`) and takes an `io.Writer` sink instead of writing to stdout directly. `cmd/exec` and `cmd/websh` are updated accordingly. The old buffered `event.RunCommand` helper has been removed; its polling logic survives only as the WS-failure fallback (`PollCommandExecution` + REST gap-fill).

## Merge note — sudo approval integration
After merging `main`, `exec` runs through the sudo presence/approval flow (`RunExecWithApprovalWait`), and the approval/presence helpers detect denials from `RemoteCommandError.Output` rather than a buffered result string (error-only signatures).
- To keep stdout a clean machine-readable channel for the pending-approval signal (exit code 4, `{"status":"pending_approval", ...}`), `--output json` mode **buffers** command output and flushes it on success or plain failure, rather than streaming live.
- Default (table) mode still streams chunk-by-chunk in real time.

## Test plan
- [ ] `go test -race -v ./api/event/... ./cmd/exec/... ./cmd/websh/...` passes
- [ ] `go build ./...` and `go vet ./...` clean
- [ ] Manual: `alpacon exec <server> -- bash -c 'for i in 1 2 3; do echo $i; sleep 1; done'` prints `1`, `2`, `3` one second apart (not all at once)
- [ ] Manual: kill the WS path mid-run (network blip) and confirm REST gap-fill recovers the missing chunks; verify stderr warning if gap-fill itself fails
- [ ] Manual: exit codes still propagate correctly (`echo x; exit 23` → exit code 23 on the CLI)
- [ ] Manual: `alpacon websh <server>` interactive session behaves as before
- [ ] Manual: `--output json` exec of a sudo command pending approval emits a clean JSON pending-approval signal on stdout (no interleaved command output) and exits 4
