### PR TITLE
fix(release): gate GitHub Release behind draft until all jobs succeed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -202,11 +202,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
       - name: Promote draft Release to public
         env:
+          # gh reads GH_REPO (not GITHUB_REPOSITORY), so gh resolves the repo
+          # without an actions/checkout step.
+          GH_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Every build/test/publish job has succeeded, so flip the draft

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -216,4 +216,6 @@ jobs:
           case "${GITHUB_REF_NAME}" in
             *-*) latest_flag="--latest=false" ;;
           esac
+          # --draft=false is idempotent: re-running after a previously published
+          # Release leaves it public, so retries on the same tag are safe.
           gh release edit "${GITHUB_REF_NAME}" --draft=false ${latest_flag}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Create GitHub Release with auto notes
+      - name: Create draft GitHub Release with auto notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -25,14 +25,13 @@ jobs:
             echo "Release ${GITHUB_REF_NAME} already exists — skipping."
             exit 0
           fi
-          # Tags with a SemVer pre-release suffix (e.g. v1.2.3-rc1, v1.2.3-beta.1)
-          # are published as prereleases so they don't surface as the latest
-          # release to end users.
+          # Create as a draft to hide it until all jobs succeed (publish-release makes it public).
+          # Pre-release tags (e.g. v1.2.3-rc1) are published as prereleases so they aren't shown as latest.
           prerelease_flag=""
           case "${GITHUB_REF_NAME}" in
             *-*) prerelease_flag="--prerelease" ;;
           esac
-          gh release create "${GITHUB_REF_NAME}" --generate-notes ${prerelease_flag}
+          gh release create "${GITHUB_REF_NAME}" --draft --generate-notes ${prerelease_flag}
 
   build-and-test:
     needs: [create-release]
@@ -195,3 +194,26 @@ jobs:
           PACKAGECLOUD-REPO: alpacon
           PACKAGECLOUD-DISTRIB: rpm_any/rpm_any
           PACKAGECLOUD-TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: [packagecloud-deploy]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Promote draft Release to public
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Every build/test/publish job has succeeded, so flip the draft
+          # Release public. Pre-release tags (e.g. v1.2.3-rc1) must not become
+          # the latest release shown to end users.
+          latest_flag="--latest"
+          case "${GITHUB_REF_NAME}" in
+            *-*) latest_flag="--latest=false" ;;
+          esac
+          gh release edit "${GITHUB_REF_NAME}" --draft=false ${latest_flag}


### PR DESCRIPTION
## Problem

The `create-release` job published the GitHub Release immediately at the start of the workflow. If any downstream job (build, test, GoReleaser, PackageCloud deploy) failed, a public Release with no artifacts was left behind. GoReleaser's `mode: keep-existing` meant a re-run would skip recreating the Release, leaving it permanently broken.

## Solution

Use a draft → publish gate:

1. **`create-release`**: Creates the Release as a draft (`--draft`) so it is invisible to the public.
2. **`publish-release`** (new job): Runs last, after all jobs succeed, and promotes the draft to public with `gh release edit --draft=false`.

Pre-release tags (e.g. `v1.2.3-rc1`) are published with `--latest=false` so they don't surface as the latest release.

## Changes

- `create-release`: Added `--draft` flag to `gh release create`
- Added `publish-release` job that depends on `packagecloud-deploy`

## Test plan

- [ ] Trigger a release with a stable tag — confirm Release is draft during the run and goes public only after all jobs succeed
- [ ] Simulate a failure in `goreleaser` or `packagecloud-deploy` — confirm Release stays as draft
- [ ] Trigger a release with a pre-release tag (e.g. `v1.2.3-rc1`) — confirm it is marked as prerelease and not shown as latest