### PR TITLE
feat(edit): add 'alpacon edit' to edit remote files with a local editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ $ alpacon cp -u admin -g developers <SOURCE> <DESTINATION>
 $ alpacon edit <server>:/etc/nginx/nginx.conf    # open a remote file in your local editor
 ```
 
-`<server>:<path>` denotes a remote target. Saving in `edit` overwrites the remote file; ownership and permissions may be reset by server policy.
+`<server>:<path>` denotes a remote target. Saving in `edit` overwrites the remote file; ownership and permissions may be reset by server policy. `edit` only opens existing remote files—it downloads first, so it won't create a new one. `--editor` is tokenized without a shell (the file path is appended as the last argument), so shell syntax such as pipes (`|`), redirections (`>>`), or `&&` won't work.
 
 ### TCP tunneling
 ```bash

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Available Commands:
   completion   Generate the autocompletion script for the specified shell
   cp           Copy files between local and remote locations
   csr          Manage certificate signing requests (CSRs)
+  edit         Edit a remote file with your local editor
   event        Retrieve and display recent Alpacon events
   exec         Execute a command on a remote server
   group        Manage groups, members, and permissions
@@ -453,6 +454,10 @@ $ alpacon cp /Users/alpacon.txt myserver:/home/alpacon/
 
 # Download files
 $ alpacon cp myserver:/home/alpacon/alpacon.txt .
+
+# Edit a remote file with your local editor
+$ alpacon edit myserver:/etc/nginx/nginx.conf
+# Saving overwrites the remote file; its ownership and permissions may be reset according to server policy.
 
 # To use a specified username and groupname for the transfer:
 $ alpacon cp -u [USER NAME] -g [GROUP NAME] [SOURCE] [DESTINATION]

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -353,6 +354,49 @@ func UploadFile(ac *client.AlpaconClient, src []string, dest, username, groupnam
 	return executeBulkUpload(ac, request, readers, sizes)
 }
 
+// UploadLocalFileAs uploads one local file to the exact remote file path.
+// It preserves the remote basename instead of deriving the destination name
+// from the local temp file name.
+func UploadLocalFileAs(ac *client.AlpaconClient, localPath, serverName, remotePath, username, groupname, workSessionID string) error {
+	remoteName, err := utils.RemoteFileName(remotePath)
+	if err != nil {
+		return err
+	}
+	remoteDir := pathpkg.Dir(remotePath)
+	if remoteDir == "." {
+		remoteDir = ""
+	} else if !strings.HasSuffix(remoteDir, "/") {
+		remoteDir += "/"
+	}
+
+	serverID, err := server.GetServerIDByName(ac, serverName)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(localPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	request := &UploadRequest{
+		Name:           remoteName,
+		Path:           remoteDir,
+		Server:         serverID,
+		Username:       username,
+		Groupname:      groupname,
+		AllowOverwrite: true,
+		WorkSession:    workSessionID,
+	}
+	return executeSingleUpload(ac, request, readOnly{f}, stat.Size())
+}
+
 func createFolderZipTempFile(folderPath string) (*os.File, int64, error) {
 	return utils.SpoolToTempFile("alpacon-folder-*.zip", func(w io.Writer) error {
 		return utils.ZipToWriter(folderPath, w)
@@ -505,34 +549,41 @@ func reserveDownloadArchiveTempPath(dest string) (string, error) {
 	return name, nil
 }
 
-func saveDownloadedURL(httpClient *http.Client, url, dest, remotePath string, recursive bool, maxAttempts int) (int64, error) {
+// saveDownloadedURL writes the downloaded content and returns the resolved local path.
+func saveDownloadedURL(httpClient *http.Client, url, dest, remotePath string, recursive bool, maxAttempts int) (string, int64, error) {
 	if recursive {
 		filePath, err := reserveDownloadArchiveTempPath(dest)
 		if err != nil {
-			return 0, err
+			return "", 0, err
 		}
 		defer func() { _ = utils.DeleteFile(filePath) }()
 
 		written, err := fetchFromURLToFile(httpClient, url, filePath, maxAttempts)
 		if err != nil {
-			return written, err
+			return dest, written, err
 		}
 		if err := utils.Unzip(filePath, dest); err != nil {
-			return written, fmt.Errorf("failed to extract downloaded folder: %w", err)
+			return dest, written, fmt.Errorf("failed to extract downloaded folder: %w", err)
 		}
 
-		return written, nil
+		return dest, written, nil
 	}
 
 	filePath, err := downloadedFilePath(dest, remotePath)
 	if err != nil {
-		return 0, err
+		return "", 0, err
 	}
 
-	return fetchFromURLToFile(httpClient, url, filePath, maxAttempts)
+	written, err := fetchFromURLToFile(httpClient, url, filePath, maxAttempts)
+	return filePath, written, err
 }
 
 func downloadSingleFile(ac *client.AlpaconClient, remotePath, dest, serverID, username, groupname, resourceType, workSessionID string, recursive bool) error {
+	_, err := downloadSingleFileWithResult(ac, remotePath, dest, serverID, username, groupname, resourceType, workSessionID, recursive)
+	return err
+}
+
+func downloadSingleFileWithResult(ac *client.AlpaconClient, remotePath, dest, serverID, username, groupname, resourceType, workSessionID string, recursive bool) (DownloadedFile, error) {
 	downloadRequest := &DownloadRequest{
 		Path:         remotePath,
 		Name:         filepath.Base(remotePath),
@@ -549,41 +600,43 @@ func downloadSingleFile(ac *client.AlpaconClient, remotePath, dest, serverID, us
 
 	postBody, err := ac.SendPostRequest(downloadAPIURL, downloadRequest)
 	if err != nil {
-		return err
+		return DownloadedFile{}, err
 	}
 
 	var downloadResponse DownloadResponse
 	if err := json.Unmarshal(postBody, &downloadResponse); err != nil {
-		return err
+		return DownloadedFile{}, err
 	}
 
 	status, err := event.PollCommandExecution(ac, downloadResponse.Command)
 	if err != nil {
-		return err
+		return DownloadedFile{}, err
 	}
 
 	if status.Status == "stuck" || status.Status == "error" {
-		return fmt.Errorf("command failed with status: %s", status.Status)
+		return DownloadedFile{}, fmt.Errorf("command failed with status: %s", status.Status)
 	}
 	if status.Status == "failed" {
-		return fmt.Errorf("%s", status.Result)
+		return DownloadedFile{}, fmt.Errorf("%s", status.Result)
 	}
 
-	written, err := saveDownloadedURL(ac.HTTPClient, downloadResponse.DownloadURL, dest, remotePath, recursive, 100)
+	localPath, written, err := saveDownloadedURL(ac.HTTPClient, downloadResponse.DownloadURL, dest, remotePath, recursive, 100)
 	if err != nil {
-		return err
+		return DownloadedFile{}, err
 	}
 
 	timeout := calcPollTimeout(1, written)
 	success, message, err := PollTransferStatus(ac, "download", downloadResponse.ID, timeout)
 	if err != nil {
-		return fmt.Errorf("download transfer status check failed: %w", err)
+		return DownloadedFile{}, fmt.Errorf("download transfer status check failed: %w", err)
 	}
 	if !success {
-		return fmt.Errorf("%s", message)
+		return DownloadedFile{}, fmt.Errorf("%s", message)
 	}
 
-	return nil
+	// Report the bytes actually written to disk; the edit size guard must reflect
+	// the local file, not a possibly stale or incorrect server-reported size.
+	return DownloadedFile{Path: localPath, Size: written}, nil
 }
 
 // downloadBulk downloads multiple remote files as a single zip archive using the bulk API.
@@ -685,6 +738,14 @@ func DownloadFile(ac *client.AlpaconClient, sources []string, dest, username, gr
 	}
 
 	return downloadSingleFile(ac, remotePaths[0], dest, serverID, username, groupname, resourceType, workSessionID, recursive)
+}
+
+func DownloadFileToPath(ac *client.AlpaconClient, serverName, remotePath, localPath, username, groupname, workSessionID string) (DownloadedFile, error) {
+	serverID, err := server.GetServerIDByName(ac, serverName)
+	if err != nil {
+		return DownloadedFile{}, err
+	}
+	return downloadSingleFileWithResult(ac, remotePath, localPath, serverID, username, groupname, "file", workSessionID, false)
 }
 
 // calcPollTimeout returns a dynamic poll timeout based on file count and total size.

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -833,8 +833,9 @@ func TestSaveDownloadedURL_RecursiveUsesTempArchive(t *testing.T) {
 	existingArchive := filepath.Join(dest, "folder.zip")
 	require.NoError(t, os.WriteFile(existingArchive, []byte("existing-archive"), 0644))
 
-	written, err := saveDownloadedURL(ts.Client(), ts.URL, dest, "/remote/folder", true, 1)
+	savedPath, written, err := saveDownloadedURL(ts.Client(), ts.URL, dest, "/remote/folder", true, 1)
 	require.NoError(t, err)
+	assert.Equal(t, dest, savedPath)
 	assert.Equal(t, int64(len(zipContent)), written)
 
 	content, readErr := os.ReadFile(existingArchive)
@@ -1024,6 +1025,64 @@ func TestExecuteSingleUpload_WorkSession(t *testing.T) {
 			if tt.wantKeyPresent {
 				assert.Equal(t, tt.wantWorkSession, v)
 			}
+		})
+	}
+}
+
+func TestUploadLocalFileAsUsesRemoteBasenameAndDirectory(t *testing.T) {
+	var uploadReq UploadRequest
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/api/servers/servers"):
+			_ = json.NewEncoder(w).Encode(api.ListResponse[server.ServerDetails]{
+				Count:   1,
+				Results: []server.ServerDetails{{ID: "srv-123", Name: "prod"}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/webftp/uploads/":
+			_ = json.NewDecoder(r.Body).Decode(&uploadReq)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(UploadResponse{
+				ID:        "upload-1",
+				Name:      "app.conf",
+				UploadURL: "http://" + r.Host + "/s3/app.conf",
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/s3/app.conf":
+			body, _ := io.ReadAll(r.Body)
+			assert.Equal(t, "edited", string(body))
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/status/"):
+			_ = json.NewEncoder(w).Encode(TransferStatusResponse{Success: boolPtr(true)})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/upload"):
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	localFile := filepath.Join(t.TempDir(), ".alpacon-edit-random")
+	require.NoError(t, os.WriteFile(localFile, []byte("edited"), 0600))
+
+	err := UploadLocalFileAs(ac, localFile, "prod", "/etc/app.conf", "root", "ops", "ws-1")
+	require.NoError(t, err)
+	assert.Equal(t, "app.conf", uploadReq.Name)
+	assert.Equal(t, "/etc/", uploadReq.Path)
+	assert.Equal(t, "srv-123", uploadReq.Server)
+	assert.Equal(t, "root", uploadReq.Username)
+	assert.Equal(t, "ops", uploadReq.Groupname)
+	assert.True(t, uploadReq.AllowOverwrite)
+	assert.Equal(t, "ws-1", uploadReq.WorkSession)
+}
+
+func TestUploadLocalFileAsRejectsInvalidRemoteBasename(t *testing.T) {
+	for _, remotePath := range []string{"/tmp/..", "/tmp/app.conf/", `/tmp/..\saved`} {
+		t.Run(remotePath, func(t *testing.T) {
+			err := UploadLocalFileAs(&client.AlpaconClient{}, "/tmp/local", "prod", remotePath, "", "", "")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "file name")
 		})
 	}
 }

--- a/api/ftp/types.go
+++ b/api/ftp/types.go
@@ -35,6 +35,11 @@ type DownloadResponse struct {
 	Command     string              `json:"command"`
 }
 
+type DownloadedFile struct {
+	Path string
+	Size int64
+}
+
 type UploadResponse struct {
 	ID        string              `json:"id"`
 	Name      string              `json:"name"`

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -49,7 +49,12 @@ Use -u/--username and -g/--groupname the same way you would with 'alpacon cp'.
 Interactive browser login requires an active WorkSession with the webftp scope.
 
 The file is downloaded in full before editing; files larger than 10 MB prompt
-for confirmation (skipped with --force) before opening in the editor.`,
+for confirmation (skipped with --force) before opening in the editor.
+
+This edits existing remote files only—the file is downloaded first, so it
+cannot create a new one. The --editor value is tokenized without a shell (the
+file path is appended as the last argument), so shell syntax such as pipes,
+redirections, or '&&' will not work.`,
 	Example: `  alpacon edit my-server:/etc/nginx/nginx.conf
   alpacon edit my-server:/etc/nginx/nginx.conf --editor "code --wait"
   alpacon edit my-server:/var/log/large.txt --force`,

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -1,0 +1,441 @@
+package edit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	ftpapi "github.com/alpacax/alpacon-cli/api/ftp"
+	"github.com/alpacax/alpacon-cli/api/iam"
+	"github.com/alpacax/alpacon-cli/api/mfa"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/cmd/worksession"
+	"github.com/alpacax/alpacon-cli/config"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+const maxEditPromptSize int64 = 10 * 1024 * 1024
+
+var EditCmd = &cobra.Command{
+	Use:   "edit [USER@]SERVER:PATH",
+	Short: "Edit a remote file with your local editor",
+	Long: `Download a single remote file, open it in your local editor, and upload
+changes back to the original path when the editor exits.
+
+The command uses the same WebFTP transport and permission behavior as 'alpacon cp'.
+Use -u/--username and -g/--groupname the same way you would with 'alpacon cp'.
+Interactive browser login requires an active WorkSession with the webftp scope.
+
+The file is downloaded in full before editing; files larger than 10 MB prompt
+for confirmation (skipped with --force) before opening in the editor.`,
+	Example: `  alpacon edit my-server:/etc/nginx/nginx.conf
+  alpacon edit root@my-server:/etc/nginx/nginx.conf --editor "code --wait"
+  alpacon edit my-server:/var/log/large.txt --force`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		editorFlag, _ := cmd.Flags().GetString("editor")
+		usernameFlag, _ := cmd.Flags().GetString("username")
+		groupname, _ := cmd.Flags().GetString("groupname")
+		force, _ := cmd.Flags().GetBool("force")
+		flagWorkSession, _ := cmd.Flags().GetString("work-session")
+
+		target, err := parseEditTarget(args[0], usernameFlag)
+		if err != nil {
+			utils.CliErrorWithExit("%s", err)
+		}
+
+		workSessionID := worksession.ResolveAndAnnounce(flagWorkSession)
+		authMethod := config.ResolveAuthMethod()
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		deps := realEditDeps(alpaconClient, groupname)
+		result, err := runEdit(editOptions{
+			Target:        target,
+			Editor:        editorFlag,
+			Force:         force,
+			WorkSessionID: workSessionID,
+		}, deps)
+		if err != nil {
+			printPreservedTempPath(result)
+			utils.HandleWorkSessionError(err, "webftp", target.Server, authMethod, workSessionID)
+			utils.CliErrorWithExit("Failed to edit '%s:%s': %s", target.Server, target.RemotePath, err)
+		}
+
+		if !result.Changed {
+			utils.CliInfo("No changes")
+			return
+		}
+		utils.CliSuccess("Uploaded changes to %s:%s", target.Server, target.RemotePath)
+	},
+}
+
+type editTarget struct {
+	Server     string
+	RemotePath string
+	Username   string
+}
+
+type editOptions struct {
+	Target        editTarget
+	Editor        string
+	Force         bool
+	WorkSessionID string
+}
+
+type editResult struct {
+	TempPath string
+	Changed  bool
+}
+
+type editDeps struct {
+	download     func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error)
+	upload       func(target editTarget, localPath, workSessionID string) error
+	runEditor    func(editor, filePath string) error
+	confirmLarge func(size int64) bool
+	removeAll    func(path string) error
+	tempRoot     string
+}
+
+func init() {
+	EditCmd.Flags().String("editor", "", "Editor command to run (default: ALPACON_EDITOR, VISUAL, EDITOR, then vi)")
+	EditCmd.Flags().Bool("force", false, "Edit files larger than 10 MB without prompting")
+	EditCmd.Flags().StringP("username", "u", "", "Specify username")
+	EditCmd.Flags().StringP("groupname", "g", "", "Specify groupname")
+	EditCmd.Flags().String("work-session", "", "Attach this edit to a work-session (overrides 'work-session use')")
+}
+
+func realEditDeps(ac *client.AlpaconClient, groupname string) editDeps {
+	return editDeps{
+		download: func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error) {
+			downloaded, err := ftpapi.DownloadFileToPath(ac, target.Server, target.RemotePath, localPath, target.Username, groupname, workSessionID)
+			if err != nil {
+				err = utils.HandleCommonErrors(err, target.Server, editErrorCallbacks(ac, func() error {
+					var retryErr error
+					downloaded, retryErr = ftpapi.DownloadFileToPath(ac, target.Server, target.RemotePath, localPath, target.Username, groupname, workSessionID)
+					return retryErr
+				}))
+			}
+			return downloaded, err
+		},
+		upload: func(target editTarget, localPath, workSessionID string) error {
+			err := ftpapi.UploadLocalFileAs(ac, localPath, target.Server, target.RemotePath, target.Username, groupname, workSessionID)
+			if err != nil {
+				err = utils.HandleCommonErrors(err, target.Server, editErrorCallbacks(ac, func() error {
+					return ftpapi.UploadLocalFileAs(ac, localPath, target.Server, target.RemotePath, target.Username, groupname, workSessionID)
+				}))
+			}
+			return err
+		},
+		runEditor:    runLocalEditor,
+		confirmLarge: confirmLargeEdit,
+	}
+}
+
+func editErrorCallbacks(ac *client.AlpaconClient, retry func() error) utils.ErrorHandlerCallbacks {
+	return utils.ErrorHandlerCallbacks{
+		OnMFARequired: func(serverName string) error {
+			return mfa.HandleMFAError(ac, serverName)
+		},
+		OnUsernameRequired: func() error {
+			_, err := iam.HandleUsernameRequired()
+			return err
+		},
+		CheckMFACompleted: func() (bool, error) {
+			return mfa.CheckMFACompletion(ac)
+		},
+		RefreshToken:   ac.RefreshToken,
+		RetryOperation: retry,
+	}
+}
+
+func parseEditTarget(arg, usernameFlag string) (editTarget, error) {
+	if !utils.IsRemoteTarget(arg) {
+		return editTarget{}, fmt.Errorf("remote path must be in format [USER@]SERVER:PATH")
+	}
+	sshTarget := utils.ParseSSHTarget(arg)
+	if sshTarget.Host == "" || sshTarget.Path == "" {
+		return editTarget{}, fmt.Errorf("remote path must include both server and path")
+	}
+	username := usernameFlag
+	if username == "" {
+		username = sshTarget.User
+	}
+	return editTarget{Server: sshTarget.Host, RemotePath: sshTarget.Path, Username: username}, nil
+}
+
+func resolveEditor(flagValue string) string {
+	if strings.TrimSpace(flagValue) != "" {
+		return strings.TrimSpace(flagValue)
+	}
+	if alpaconEditor := strings.TrimSpace(os.Getenv("ALPACON_EDITOR")); alpaconEditor != "" {
+		return alpaconEditor
+	}
+	if visual := strings.TrimSpace(os.Getenv("VISUAL")); visual != "" {
+		return visual
+	}
+	if editor := strings.TrimSpace(os.Getenv("EDITOR")); editor != "" {
+		return editor
+	}
+	return "vi"
+}
+
+func runEdit(opts editOptions, deps editDeps) (editResult, error) {
+	deps = normalizeEditDeps(deps)
+	tempPath, err := editTempPath(deps.tempRoot, opts.Target)
+	result := editResult{TempPath: tempPath}
+	if err != nil {
+		return result, err
+	}
+
+	downloaded, err := deps.download(opts.Target, tempPath, opts.WorkSessionID)
+	if err != nil {
+		cleanupEditTemp(tempPath, deps.removeAll)
+		return result, err
+	}
+	if downloaded.Path != "" {
+		result.TempPath = downloaded.Path
+	}
+
+	// Restrict the downloaded file to the owner; edit handles sensitive remote files.
+	// The containing directories are already 0700, so this is defense-in-depth.
+	// Note: editors that save by writing a new inode and renaming over the file
+	// reset the mode to the process umask, but the 0700 parent still gates access.
+	if err := os.Chmod(result.TempPath, 0600); err != nil {
+		cleanupEditTemp(result.TempPath, deps.removeAll)
+		return result, fmt.Errorf("failed to secure temp file: %w", err)
+	}
+
+	// The size guard runs post-download: it uses the actual bytes written to
+	// disk, which are only known after the fetch, so the guard prevents opening
+	// an oversized file in the editor rather than saving bandwidth.
+	if downloaded.Size > maxEditPromptSize && !opts.Force && !deps.confirmLarge(downloaded.Size) {
+		cleanupEditTemp(result.TempPath, deps.removeAll)
+		return result, fmt.Errorf("remote file is larger than 10 MB; rerun with --force to edit it")
+	}
+
+	before, err := hashFile(result.TempPath)
+	if err != nil {
+		cleanupEditTemp(result.TempPath, deps.removeAll)
+		return result, err
+	}
+
+	editorErr := deps.runEditor(resolveEditor(opts.Editor), result.TempPath)
+
+	after, err := hashFile(result.TempPath)
+	if err != nil {
+		if editorErr != nil {
+			return result, fmt.Errorf("editor failed: %w", editorErr)
+		}
+		return result, err
+	}
+	result.Changed = before != after
+
+	if editorErr != nil {
+		// The editor failed: preserve the temp only if the user actually changed
+		// it, otherwise it is just an unmodified copy of the remote file.
+		if !result.Changed {
+			cleanupEditTemp(result.TempPath, deps.removeAll)
+		}
+		return result, fmt.Errorf("editor failed: %w", editorErr)
+	}
+
+	if !result.Changed {
+		cleanupEditTemp(result.TempPath, deps.removeAll)
+		return result, nil
+	}
+
+	if err := deps.upload(opts.Target, result.TempPath, opts.WorkSessionID); err != nil {
+		return result, err
+	}
+
+	cleanupEditTemp(result.TempPath, deps.removeAll)
+	return result, nil
+}
+
+func cleanupEditTemp(filePath string, removeAll func(string) error) {
+	if filePath == "" {
+		return
+	}
+	sessionDir := filepath.Dir(filePath)
+	if err := removeAll(sessionDir); err != nil {
+		// Surface failures: the temp may hold a copy of a sensitive remote file.
+		utils.CliWarning("Failed to remove temp directory %s: %s", sessionDir, err)
+		return
+	}
+	// Prune the now-empty per-file (<hash>) and per-server parents.
+	// os.Remove only succeeds on empty directories, so concurrent sessions are left intact.
+	hashDir := filepath.Dir(sessionDir)
+	serverDir := filepath.Dir(hashDir)
+	_ = os.Remove(hashDir)
+	_ = os.Remove(serverDir)
+}
+
+func normalizeEditDeps(deps editDeps) editDeps {
+	if deps.runEditor == nil {
+		deps.runEditor = runLocalEditor
+	}
+	if deps.confirmLarge == nil {
+		deps.confirmLarge = func(int64) bool { return true }
+	}
+	if deps.removeAll == nil {
+		deps.removeAll = os.RemoveAll
+	}
+	return deps
+}
+
+func editTempPath(root string, target editTarget) (string, error) {
+	base, err := utils.RemoteFileName(target.RemotePath)
+	if err != nil {
+		return "", err
+	}
+	if root == "" {
+		root = defaultEditRoot()
+	}
+	sum := sha256.Sum256([]byte(target.Server + ":" + target.RemotePath))
+	parent := filepath.Join(root, sanitizePathPart(target.Server), hex.EncodeToString(sum[:])[:16])
+	if err := os.MkdirAll(parent, 0700); err != nil {
+		return "", err
+	}
+	dir, err := os.MkdirTemp(parent, "session-")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, base), nil
+}
+
+func defaultEditRoot() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".alpacon", "edit")
+	}
+	return filepath.Join(os.TempDir(), "alpacon-edit")
+}
+
+func sanitizePathPart(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			return r
+		}
+		return '_'
+	}, s)
+}
+
+func hashFile(filePath string) ([32]byte, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return [32]byte{}, err
+	}
+	var sum [32]byte
+	copy(sum[:], h.Sum(nil))
+	return sum, nil
+}
+
+func runLocalEditor(editor, filePath string) error {
+	parts, err := splitEditorCommand(editor)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(parts[0], append(parts[1:], filePath)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func splitEditorCommand(command string) ([]string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil, fmt.Errorf("editor command is empty")
+	}
+
+	var parts []string
+	var current strings.Builder
+	var quote rune
+	escaped := false
+	argStarted := false
+	for _, r := range command {
+		switch {
+		case escaped:
+			if r != '\\' && r != '\'' && r != '"' && r != ' ' && r != '\t' && r != '\n' {
+				current.WriteRune('\\')
+			}
+			current.WriteRune(r)
+			escaped = false
+			argStarted = true
+		case r == '\\':
+			escaped = true
+			argStarted = true
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+				argStarted = true
+			}
+		case r == '\'' || r == '"':
+			quote = r
+			argStarted = true
+		case r == ' ' || r == '\t' || r == '\n':
+			if argStarted {
+				parts = append(parts, current.String())
+				current.Reset()
+				argStarted = false
+			}
+		default:
+			current.WriteRune(r)
+			argStarted = true
+		}
+	}
+	if escaped {
+		current.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("editor command has unmatched quote")
+	}
+	if argStarted {
+		parts = append(parts, current.String())
+	}
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("editor command is empty")
+	}
+	return parts, nil
+}
+
+func confirmLargeEdit(size int64) bool {
+	if !utils.IsInteractiveShell() {
+		return false
+	}
+	return utils.PromptForBool(fmt.Sprintf("Remote file is %s. Edit anyway?", formatBytes(size)))
+}
+
+// formatBytes renders a size in MB; its only caller guards on size > 10 MB.
+func formatBytes(size int64) string {
+	const mb = 1024 * 1024
+	return fmt.Sprintf("%.1f MB", float64(size)/float64(mb))
+}
+
+func printPreservedTempPath(result editResult) {
+	// Only claim preservation when the user actually changed the file; an
+	// unchanged temp is either already cleaned up or just a copy of the remote.
+	if !result.Changed || result.TempPath == "" {
+		return
+	}
+	if _, err := os.Stat(result.TempPath); err == nil {
+		utils.CliWarning("Edited file preserved at %s", result.TempPath)
+	}
+}

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -35,7 +35,7 @@ Interactive browser login requires an active WorkSession with the webftp scope.
 The file is downloaded in full before editing; files larger than 10 MB prompt
 for confirmation (skipped with --force) before opening in the editor.`,
 	Example: `  alpacon edit my-server:/etc/nginx/nginx.conf
-  alpacon edit root@my-server:/etc/nginx/nginx.conf --editor "code --wait"
+  alpacon edit my-server:/etc/nginx/nginx.conf --editor "code --wait"
   alpacon edit my-server:/var/log/large.txt --force`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -22,6 +22,22 @@ import (
 
 const maxEditPromptSize int64 = 10 * 1024 * 1024
 
+// guiEditors are editors that, without a wait flag, spawn a window and return
+// immediately—so edit would hash an unchanged file and skip the upload.
+var guiEditors = map[string]bool{
+	"code":          true,
+	"code-insiders": true,
+	"codium":        true,
+	"vscodium":      true,
+	"cursor":        true,
+	"windsurf":      true,
+	"subl":          true,
+	"sublime_text":  true,
+	"atom":          true,
+	"mate":          true,
+	"zed":           true,
+}
+
 var EditCmd = &cobra.Command{
 	Use:   "edit [USER@]SERVER:PATH",
 	Short: "Edit a remote file with your local editor",
@@ -189,6 +205,28 @@ func resolveEditor(flagValue string) string {
 	return "vi"
 }
 
+// guiEditorWaitWarning returns a warning when the resolved editor is a known GUI
+// editor invoked without a wait flag. Such editors return before the user saves,
+// so the before/after hash is unchanged and edit reports "No changes" and skips
+// the upload—the classic git core.editor footgun.
+func guiEditorWaitWarning(editor string) string {
+	parts, err := splitEditorCommand(editor)
+	if err != nil || len(parts) == 0 {
+		return ""
+	}
+	name := strings.ToLower(filepath.Base(parts[0]))
+	name = strings.TrimSuffix(name, ".exe")
+	if !guiEditors[name] {
+		return ""
+	}
+	for _, arg := range parts[1:] {
+		if arg == "-w" || arg == "--wait" {
+			return ""
+		}
+	}
+	return fmt.Sprintf("'%s' looks like a GUI editor launched without a wait flag; it may return before you save, so changes would not be uploaded. Add a wait flag, e.g. --editor \"%s --wait\"", name, name)
+}
+
 func runEdit(opts editOptions, deps editDeps) (editResult, error) {
 	deps = normalizeEditDeps(deps)
 	tempPath, err := editTempPath(deps.tempRoot, opts.Target)
@@ -229,7 +267,11 @@ func runEdit(opts editOptions, deps editDeps) (editResult, error) {
 		return result, err
 	}
 
-	editorErr := deps.runEditor(resolveEditor(opts.Editor), result.TempPath)
+	editor := resolveEditor(opts.Editor)
+	if warning := guiEditorWaitWarning(editor); warning != "" {
+		utils.CliWarning("%s", warning)
+	}
+	editorErr := deps.runEditor(editor, result.TempPath)
 
 	after, err := hashFile(result.TempPath)
 	if err != nil {

--- a/cmd/edit/edit_test.go
+++ b/cmd/edit/edit_test.go
@@ -1,0 +1,347 @@
+package edit
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ftpapi "github.com/alpacax/alpacon-cli/api/ftp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEditor(t *testing.T) {
+	t.Setenv("ALPACON_EDITOR", "zed --wait")
+	t.Setenv("VISUAL", "vim")
+	t.Setenv("EDITOR", "nano")
+	assert.Equal(t, "code --wait", resolveEditor("code --wait"))
+	assert.Equal(t, "zed --wait", resolveEditor(""))
+
+	t.Setenv("ALPACON_EDITOR", "")
+	assert.Equal(t, "vim", resolveEditor(""))
+
+	t.Setenv("VISUAL", "")
+	assert.Equal(t, "nano", resolveEditor(""))
+
+	t.Setenv("EDITOR", "")
+	assert.Equal(t, "vi", resolveEditor(""))
+}
+
+func TestRunLocalEditorSupportsQuotedArguments(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "args.log")
+	scriptPath := filepath.Join(dir, "editor.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$1\"\n"), 0700))
+	targetPath := filepath.Join(dir, "target file.txt")
+	require.NoError(t, os.WriteFile(targetPath, []byte("content"), 0600))
+
+	err := runLocalEditor(scriptPath+" "+logPath+" \"two words\"", targetPath)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Equal(t, logPath+"\ntwo words\n"+targetPath+"\n", string(got))
+}
+
+func TestSplitEditorCommandPreservesWindowsBackslashes(t *testing.T) {
+	parts, err := splitEditorCommand(`"C:\Program Files\Vim\vim.exe" --wait`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{`C:\Program Files\Vim\vim.exe`, "--wait"}, parts)
+}
+
+func TestSplitEditorCommandPreservesEmptyQuotedArgument(t *testing.T) {
+	parts, err := splitEditorCommand(`emacsclient -a "" -c`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"emacsclient", "-a", "", "-c"}, parts)
+}
+
+func TestParseEditTarget(t *testing.T) {
+	target, err := parseEditTarget("root@prod:/etc/nginx/nginx.conf", "")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", target.Server)
+	assert.Equal(t, "/etc/nginx/nginx.conf", target.RemotePath)
+	assert.Equal(t, "root", target.Username)
+
+	target, err = parseEditTarget("root@prod:/etc/nginx/nginx.conf", "deploy")
+	require.NoError(t, err)
+	assert.Equal(t, "deploy", target.Username)
+
+	target, err = parseEditTarget("prod:/tmp/alice@example.com", "")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", target.Server)
+	assert.Equal(t, "/tmp/alice@example.com", target.RemotePath)
+	assert.Equal(t, "", target.Username)
+}
+
+func TestParseEditTargetRejectsInvalidTargets(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "no colon", input: "prod"},
+		{name: "missing path", input: "prod:"},
+		{name: "missing server", input: ":/etc/app.conf"},
+		{name: "user only without path", input: "root@prod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseEditTarget(tc.input, "")
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestEditTempPathUniquePerInvocation(t *testing.T) {
+	root := t.TempDir()
+	target := editTarget{Server: "prod", RemotePath: "/etc/app.conf"}
+	first, err := editTempPath(root, target)
+	require.NoError(t, err)
+	second, err := editTempPath(root, target)
+	require.NoError(t, err)
+	assert.NotEqual(t, first, second)
+	assert.Equal(t, "app.conf", filepath.Base(first))
+	assert.Equal(t, "app.conf", filepath.Base(second))
+}
+
+func TestEditTempPathRejectsInvalidRemoteBasename(t *testing.T) {
+	for _, remotePath := range []string{"/tmp/..", "/tmp/app.conf/", `/tmp/..\saved`} {
+		t.Run(remotePath, func(t *testing.T) {
+			_, err := editTempPath(t.TempDir(), editTarget{Server: "prod", RemotePath: remotePath})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "file name")
+		})
+	}
+}
+
+func TestRunEditRestrictsDownloadedFilePermissions(t *testing.T) {
+	tempRoot := t.TempDir()
+	var editorPerm os.FileMode
+	deps := editDeps{
+		download: func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error) {
+			require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0700))
+			require.NoError(t, os.WriteFile(localPath, []byte("secret"), 0644))
+			return ftpapi.DownloadedFile{Path: localPath, Size: int64(len("secret"))}, nil
+		},
+		upload: func(target editTarget, localPath, workSessionID string) error {
+			return nil
+		},
+		runEditor: func(editor, filePath string) error {
+			info, err := os.Stat(filePath)
+			if err != nil {
+				return err
+			}
+			editorPerm = info.Mode().Perm()
+			return nil
+		},
+		confirmLarge: func(size int64) bool {
+			return true
+		},
+		tempRoot: tempRoot,
+	}
+
+	_, err := runEdit(editOptions{
+		Target: editTarget{Server: "prod", RemotePath: "/etc/secret.conf"},
+		Editor: "true",
+	}, deps)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), editorPerm, "downloaded file should be restricted to the owner before editing")
+}
+
+func TestRunEditNoChangesSkipsUploadAndRemovesTemp(t *testing.T) {
+	tempRoot := t.TempDir()
+	var uploadCalled bool
+	deps := editDeps{
+		download: func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error) {
+			require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0700))
+			require.NoError(t, os.WriteFile(localPath, []byte("original"), 0600))
+			return ftpapi.DownloadedFile{Path: localPath, Size: int64(len("original"))}, nil
+		},
+		upload: func(target editTarget, localPath, workSessionID string) error {
+			uploadCalled = true
+			return nil
+		},
+		runEditor: func(editor, filePath string) error {
+			return os.WriteFile(filepath.Join(filepath.Dir(filePath), ".app.conf.swp"), []byte("sidecar"), 0600)
+		},
+		confirmLarge: func(size int64) bool {
+			return true
+		},
+		tempRoot: tempRoot,
+	}
+
+	result, err := runEdit(editOptions{
+		Target: editTarget{Server: "prod", RemotePath: "/etc/app.conf"},
+		Editor: "true",
+	}, deps)
+	require.NoError(t, err)
+	assert.False(t, result.Changed)
+	assert.False(t, uploadCalled)
+	_, statErr := os.Stat(result.TempPath)
+	assert.True(t, os.IsNotExist(statErr), "unchanged edit should remove temp file")
+	_, dirErr := os.Stat(filepath.Dir(result.TempPath))
+	assert.True(t, os.IsNotExist(dirErr), "unchanged edit should remove temp directory")
+}
+
+func TestRunEditSuccessfulUploadRemovesEditorSidecarFiles(t *testing.T) {
+	tempRoot := t.TempDir()
+	deps := editDeps{
+		download: func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error) {
+			require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0700))
+			require.NoError(t, os.WriteFile(localPath, []byte("original"), 0600))
+			return ftpapi.DownloadedFile{Path: localPath, Size: int64(len("original"))}, nil
+		},
+		upload: func(target editTarget, localPath, workSessionID string) error {
+			return nil
+		},
+		runEditor: func(editor, filePath string) error {
+			require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(filePath), ".app.conf.swp"), []byte("sidecar"), 0600))
+			return os.WriteFile(filePath, []byte("changed"), 0600)
+		},
+		confirmLarge: func(size int64) bool {
+			return true
+		},
+		tempRoot: tempRoot,
+	}
+
+	result, err := runEdit(editOptions{
+		Target: editTarget{Server: "prod", RemotePath: "/etc/app.conf"},
+		Editor: "true",
+	}, deps)
+	require.NoError(t, err)
+	assert.True(t, result.Changed)
+	_, statErr := os.Stat(result.TempPath)
+	assert.True(t, os.IsNotExist(statErr), "successful edit should remove temp file")
+	_, dirErr := os.Stat(filepath.Dir(result.TempPath))
+	assert.True(t, os.IsNotExist(dirErr), "successful edit should remove temp directory")
+}
+
+func TestRunEditUploadFailurePreservesTempPath(t *testing.T) {
+	tempRoot := t.TempDir()
+	uploadErr := errors.New("upload failed")
+	deps := editDeps{
+		download: func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error) {
+			require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0700))
+			require.NoError(t, os.WriteFile(localPath, []byte("original"), 0600))
+			return ftpapi.DownloadedFile{Path: localPath, Size: int64(len("original"))}, nil
+		},
+		upload: func(target editTarget, localPath, workSessionID string) error {
+			return uploadErr
+		},
+		runEditor: func(editor, filePath string) error {
+			return os.WriteFile(filePath, []byte("changed"), 0600)
+		},
+		confirmLarge: func(size int64) bool {
+			return true
+		},
+		tempRoot: tempRoot,
+	}
+
+	result, err := runEdit(editOptions{
+		Target: editTarget{Server: "prod", RemotePath: "/etc/app.conf"},
+		Editor: "true",
+	}, deps)
+	require.ErrorIs(t, err, uploadErr)
+	assert.True(t, result.Changed)
+	content, readErr := os.ReadFile(result.TempPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "changed", string(content))
+}
+
+func TestRunEditEditorFailureWithoutChangeRemovesTemp(t *testing.T) {
+	tempRoot := t.TempDir()
+	editorErr := errors.New("editor exited 1")
+	deps := editDeps{
+		download: func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error) {
+			require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0700))
+			require.NoError(t, os.WriteFile(localPath, []byte("original"), 0600))
+			return ftpapi.DownloadedFile{Path: localPath, Size: int64(len("original"))}, nil
+		},
+		upload: func(target editTarget, localPath, workSessionID string) error {
+			t.Fatal("upload should not be called")
+			return nil
+		},
+		runEditor: func(editor, filePath string) error {
+			return editorErr
+		},
+		confirmLarge: func(size int64) bool { return true },
+		tempRoot:     tempRoot,
+	}
+
+	result, err := runEdit(editOptions{
+		Target: editTarget{Server: "prod", RemotePath: "/etc/app.conf"},
+		Editor: "true",
+	}, deps)
+	require.ErrorIs(t, err, editorErr)
+	assert.False(t, result.Changed)
+	_, statErr := os.Stat(result.TempPath)
+	assert.True(t, os.IsNotExist(statErr), "editor failure without changes should remove temp file")
+}
+
+func TestRunEditEditorFailureAfterChangePreservesTemp(t *testing.T) {
+	tempRoot := t.TempDir()
+	editorErr := errors.New("editor exited 1")
+	deps := editDeps{
+		download: func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error) {
+			require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0700))
+			require.NoError(t, os.WriteFile(localPath, []byte("original"), 0600))
+			return ftpapi.DownloadedFile{Path: localPath, Size: int64(len("original"))}, nil
+		},
+		upload: func(target editTarget, localPath, workSessionID string) error {
+			t.Fatal("upload should not be called")
+			return nil
+		},
+		runEditor: func(editor, filePath string) error {
+			require.NoError(t, os.WriteFile(filePath, []byte("changed"), 0600))
+			return editorErr
+		},
+		confirmLarge: func(size int64) bool { return true },
+		tempRoot:     tempRoot,
+	}
+
+	result, err := runEdit(editOptions{
+		Target: editTarget{Server: "prod", RemotePath: "/etc/app.conf"},
+		Editor: "true",
+	}, deps)
+	require.ErrorIs(t, err, editorErr)
+	assert.True(t, result.Changed)
+	content, readErr := os.ReadFile(result.TempPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "changed", string(content), "editor failure after edits should preserve the changed temp file")
+}
+
+func TestRunEditLargeFileDeclineRemovesTempAndSkipsEditor(t *testing.T) {
+	tempRoot := t.TempDir()
+	var editorCalled bool
+	deps := editDeps{
+		download: func(target editTarget, localPath, workSessionID string) (ftpapi.DownloadedFile, error) {
+			require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0700))
+			require.NoError(t, os.WriteFile(localPath, []byte("large"), 0600))
+			return ftpapi.DownloadedFile{Path: localPath, Size: maxEditPromptSize + 1}, nil
+		},
+		upload: func(target editTarget, localPath, workSessionID string) error {
+			t.Fatal("upload should not be called")
+			return nil
+		},
+		runEditor: func(editor, filePath string) error {
+			editorCalled = true
+			return nil
+		},
+		confirmLarge: func(size int64) bool {
+			return false
+		},
+		tempRoot: tempRoot,
+	}
+
+	result, err := runEdit(editOptions{
+		Target: editTarget{Server: "prod", RemotePath: "/var/log/big.log"},
+		Editor: "true",
+	}, deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--force")
+	assert.False(t, editorCalled)
+	_, statErr := os.Stat(result.TempPath)
+	assert.True(t, os.IsNotExist(statErr), "declined large file edit should remove temp file")
+	_, dirErr := os.Stat(filepath.Dir(result.TempPath))
+	assert.True(t, os.IsNotExist(dirErr), "declined large file edit should remove temp directory")
+}

--- a/cmd/edit/edit_test.go
+++ b/cmd/edit/edit_test.go
@@ -56,6 +56,33 @@ func TestSplitEditorCommandPreservesEmptyQuotedArgument(t *testing.T) {
 	assert.Equal(t, []string{"emacsclient", "-a", "", "-c"}, parts)
 }
 
+func TestGuiEditorWaitWarning(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		warn  bool
+	}{
+		{name: "gui editor without wait flag", input: "code", warn: true},
+		{name: "gui editor full path without wait flag", input: "/usr/local/bin/code", warn: true},
+		{name: "gui editor with --wait", input: "code --wait", warn: false},
+		{name: "gui editor with -w", input: "subl -w", warn: false},
+		{name: "terminal editor", input: "vim", warn: false},
+		{name: "terminal editor with args", input: "nano -w", warn: false},
+		{name: "empty command", input: "", warn: false},
+		{name: "unmatched quote", input: `code "--wait`, warn: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			warning := guiEditorWaitWarning(tc.input)
+			if tc.warn {
+				assert.NotEmpty(t, warning)
+			} else {
+				assert.Empty(t, warning)
+			}
+		})
+	}
+}
+
 func TestParseEditTarget(t *testing.T) {
 	target, err := parseEditTarget("root@prod:/etc/nginx/nginx.conf", "")
 	require.NoError(t, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alpacax/alpacon-cli/cmd/authority"
 	"github.com/alpacax/alpacon-cli/cmd/cert"
 	"github.com/alpacax/alpacon-cli/cmd/csr"
+	"github.com/alpacax/alpacon-cli/cmd/edit"
 	"github.com/alpacax/alpacon-cli/cmd/event"
 	"github.com/alpacax/alpacon-cli/cmd/exec"
 	"github.com/alpacax/alpacon-cli/cmd/ftp"
@@ -97,6 +98,9 @@ func init() {
 
 	// ftp
 	RootCmd.AddCommand(ftp.CpCmd)
+
+	// edit
+	RootCmd.AddCommand(edit.EditCmd)
 
 	// packages
 	RootCmd.AddCommand(packages.PackagesCmd)

--- a/utils/remote_path.go
+++ b/utils/remote_path.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"fmt"
+	pathpkg "path"
+	"path/filepath"
+	"strings"
+)
+
+// RemoteFileName returns the final path component for a remote file path.
+func RemoteFileName(remotePath string) (string, error) {
+	name := pathpkg.Base(remotePath)
+	if remotePath == "" ||
+		strings.HasSuffix(remotePath, "/") ||
+		name == "." ||
+		name == ".." ||
+		strings.Contains(name, `\`) ||
+		filepath.IsAbs(name) ||
+		filepath.VolumeName(name) != "" ||
+		filepath.Base(name) != name {
+		return "", fmt.Errorf("remote path must include a file name: %s", remotePath)
+	}
+	return name, nil
+}

--- a/utils/remote_path_test.go
+++ b/utils/remote_path_test.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteFileName(t *testing.T) {
+	tests := []struct {
+		name       string
+		remotePath string
+		want       string
+		wantErr    bool
+	}{
+		{name: "absolute file", remotePath: "/etc/app.conf", want: "app.conf"},
+		{name: "relative file", remotePath: "logs/app.log", want: "app.log"},
+		{name: "empty path", remotePath: "", wantErr: true},
+		{name: "current directory basename", remotePath: "/tmp/.", wantErr: true},
+		{name: "parent directory basename", remotePath: "/tmp/..", wantErr: true},
+		{name: "trailing slash", remotePath: "/tmp/app.conf/", wantErr: true},
+		{name: "backslash basename", remotePath: `/tmp/..\saved`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RemoteFileName(tt.remotePath)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "file name")
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/utils/ssh_parser.go
+++ b/utils/ssh_parser.go
@@ -1,8 +1,6 @@
 package utils
 
-import (
-	"strings"
-)
+import "strings"
 
 // SSHTarget represents a parsed SSH-like target with user, host, and path components
 type SSHTarget struct {
@@ -17,15 +15,12 @@ type SSHTarget struct {
 // - user@host
 // - host:path
 // - user@host:path
+// An '@' is only treated as the user separator when it precedes the first ':',
+// so a remote path may itself contain '@' (e.g. host:/tmp/alice@example.com).
 func ParseSSHTarget(target string) SSHTarget {
 	result := SSHTarget{}
 
-	// First, check if there's a user@ prefix
-	if strings.Contains(target, "@") {
-		parts := strings.SplitN(target, "@", 2)
-		result.User = parts[0]
-		target = parts[1] // Continue processing with the remainder
-	}
+	result.User, target = splitUserPrefix(target)
 
 	// Now check if there's a :path suffix
 	if strings.Contains(target, ":") {
@@ -42,12 +37,18 @@ func ParseSSHTarget(target string) SSHTarget {
 // IsRemoteTarget checks if a target string represents a remote location
 // A target is considered remote if it contains a colon (:)
 func IsRemoteTarget(target string) bool {
-	// First remove any user@ prefix to check the host:path part
-	if strings.Contains(target, "@") {
-		parts := strings.SplitN(target, "@", 2)
-		target = parts[1]
-	}
+	_, target = splitUserPrefix(target)
 	return strings.Contains(target, ":")
+}
+
+func splitUserPrefix(target string) (string, string) {
+	atIndex := strings.Index(target, "@")
+	colonIndex := strings.Index(target, ":")
+	if atIndex != -1 && (colonIndex == -1 || atIndex < colonIndex) {
+		parts := strings.SplitN(target, "@", 2)
+		return parts[0], parts[1]
+	}
+	return "", target
 }
 
 // IsLocalTarget checks if a target string represents a local location

--- a/utils/ssh_parser_test.go
+++ b/utils/ssh_parser_test.go
@@ -102,6 +102,15 @@ func TestParseSSHTarget(t *testing.T) {
 				Path: "/opt/app/config",
 			},
 		},
+		{
+			name:  "Remote path contains at sign",
+			input: "prod-docker:/tmp/alice@example.com",
+			expected: SSHTarget{
+				User: "",
+				Host: "prod-docker",
+				Path: "/tmp/alice@example.com",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -163,6 +172,11 @@ func TestIsRemoteTarget(t *testing.T) {
 			input:    "user@server:",
 			expected: true,
 		},
+		{
+			name:     "Remote path contains at sign",
+			input:    "prod-docker:/tmp/alice@example.com",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -207,6 +221,11 @@ func TestIsLocalTarget(t *testing.T) {
 		{
 			name:     "Remote path with user and hostname",
 			input:    "root@prod-docker:/var/log/syslog",
+			expected: false,
+		},
+		{
+			name:     "Remote path contains at sign",
+			input:    "prod-docker:/tmp/alice@example.com",
 			expected: false,
 		},
 	}


### PR DESCRIPTION
## Overview
Adds `alpacon edit [USER@]SERVER:PATH`, which downloads a single remote file,
opens it in your local editor, and uploads the changes back to the original
path when the editor exits. Transport and permission behavior reuse the same
WebFTP path as `alpacon cp`.

Closes #194

## Behavior
- `edit [USER@]SERVER:PATH` — download remote file → run editor → upload on change
- Change detection: SHA-256 hash comparison before/after editing (no change → `No changes`, upload skipped)
- Editor resolution order: `--editor` → `ALPACON_EDITOR` → `VISUAL` → `EDITOR` → `vi`
- Files larger than 10 MB prompt for confirmation (skipped with `--force`)
- Supports `-u/--username`, `-g/--groupname`, `--work-session` (same as `cp`)

## `--editor` behavior
The given command is tokenized on whitespace without a shell, and the temp file
path is appended as the final argument before execution. Shell syntax (`|`,
`>>`, `&&`) does not work (injection prevention). GUI editors need a wait option
so the CLI blocks until editing finishes.

```bash
# Terminal editor (blocks until exit — no extra option needed)
alpacon edit my-server:/etc/hosts --editor nano

# GUI editor (needs --wait so it blocks until the tab is closed)
alpacon edit my-server:/etc/hosts --editor "code --wait"
```

## Non-interactive editing
Passing a non-interactive command/script that takes the temp file path as an
argument runs the full download → modify → upload flow without human input,
which is useful for CI and scripted automation.

```bash
# 1) Script (full shell available — most reliable)
cat > /tmp/edit-script.sh <<'SH'
#!/bin/sh
sed -i.bak 's/old/new/g' "$1" && rm -f "$1.bak"
SH
chmod +x /tmp/edit-script.sh
alpacon edit my-server:/tmp/demo.txt --editor /tmp/edit-script.sh

# 2) Inline command (must take the file as its last arg; no shell syntax)
alpacon edit my-server:/tmp/demo.txt --editor "perl -i -pe s/old/new/g"
```

## Changes
- `refactor(utils)`: treat `@` as the user separator only before the first `:` — remote paths may contain `@`
- `feat(utils)`: add `RemoteFileName` remote-path validation (blocks path traversal, absolute paths, etc.)
- `feat(ftp)`: add `DownloadFileToPath` / `UploadLocalFileAs` helpers
- `feat(edit)`: add the `alpacon edit` command and register it on root
- `docs`: document the edit command and its upload caveat in README

## Security considerations
- Temp files are owner-only (dir 0700 / file 0600) and cleaned up on exit
- The editor command is tokenized and executed without a shell (shell-injection prevention)
- On upload, the remote file's ownership and permissions may be reset according to server policy (noted in README)

## Testing
- Unit tests pass for `cmd/edit`, `utils`, `api/ftp`
- Real-server E2E verification:
  - Change → upload: modified a remote file via a non-interactive script and confirmed the change by re-downloading
  - No change (`--editor /usr/bin/true`): prints `No changes`, upload skipped

## How to verify
```bash
go build -o alpacon .

# Interactive
alpacon edit my-server:/etc/nginx/nginx.conf

# Non-interactive (automated verification)
printf 'line1\nline2\n' > /tmp/src.txt
alpacon cp /tmp/src.txt my-server:/tmp/demo.txt
cat > /tmp/fake-editor.sh <<'SH'
#!/bin/sh
echo "edited-by-alpacon" >> "$1"
SH
chmod +x /tmp/fake-editor.sh
alpacon edit my-server:/tmp/demo.txt --editor /tmp/fake-editor.sh
alpacon cp my-server:/tmp/demo.txt /tmp/verify.txt && cat /tmp/verify.txt
```
