### PR TITLE
feat(worksession): add machine-readable signals to WorkSession CLI

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -23,6 +23,12 @@ const (
 	checkPrivilegesURL = "/api/iam/users/-"
 )
 
+type apiError struct {
+	message string
+	code    string
+	source  string
+}
+
 func NewAlpaconAPIClient() (*AlpaconClient, error) {
 	validConfig, err := config.LoadConfig()
 	if err != nil {
@@ -354,12 +360,6 @@ func isAccessTokenExpired(cfg config.Config) bool {
 	}
 
 	return time.Now().After(expireTime.Add(-10 * time.Second))
-}
-
-type apiError struct {
-	message string
-	code    string
-	source  string
 }
 
 func (e *apiError) Error() string {

--- a/client/client.go
+++ b/client/client.go
@@ -118,10 +118,9 @@ func parseAuthStatusErrorPayload(body []byte) (message string, code string, sour
 	if !ok || message == "" {
 		return "", "", "", false
 	}
-	if code != "" || source != "" {
-		return message, code, source, true
-	}
-
+	// Require a non-empty "detail" so 401/403 responses surface a clean server
+	// message (while still preserving code/source) instead of the truncated
+	// raw-body fallback parseAPIErrorPayload returns when only code/source exist.
 	var parsed map[string]any
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return "", "", "", false

--- a/client/client.go
+++ b/client/client.go
@@ -94,31 +94,17 @@ func getUserPrivileges(isStaff, isSuperuser bool) string {
 func checkAuthStatus(statusCode int, body []byte) error {
 	switch statusCode {
 	case http.StatusUnauthorized:
-		if msg := extractServerDetail(body); msg != "" {
-			return fmt.Errorf("%s (run 'alpacon login' if your session has expired)", msg)
+		if msg, code, source, ok := parseAPIErrorPayload(body); ok && msg != "" {
+			return newAPIError(fmt.Sprintf("%s (run 'alpacon login' if your session has expired)", msg), code, source)
 		}
 		return errors.New("authentication failed: please run 'alpacon login' again")
 	case http.StatusForbidden:
-		if msg := extractServerDetail(body); msg != "" {
-			return errors.New(msg)
+		if msg, code, source, ok := parseAPIErrorPayload(body); ok && msg != "" {
+			return newAPIError(msg, code, source)
 		}
 		return errors.New("permission denied: you do not have the required privileges for this action")
 	}
 	return nil
-}
-
-func extractServerDetail(body []byte) string {
-	if len(bytes.TrimSpace(body)) == 0 {
-		return ""
-	}
-	var parsed map[string]any
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return ""
-	}
-	if detail, ok := parsed["detail"].(string); ok {
-		return strings.TrimSpace(detail)
-	}
-	return ""
 }
 
 func (ac *AlpaconClient) SetWebsocketHeader() http.Header {
@@ -351,26 +337,57 @@ func isAccessTokenExpired(cfg config.Config) bool {
 	return time.Now().After(expireTime.Add(-10 * time.Second))
 }
 
+type apiError struct {
+	message string
+	code    string
+	source  string
+}
+
+func (e *apiError) Error() string {
+	return e.message
+}
+
+func (e *apiError) ErrorCode() string {
+	return e.code
+}
+
+func (e *apiError) ErrorSource() string {
+	return e.source
+}
+
+func newAPIError(message, code, source string) error {
+	return &apiError{message: message, code: code, source: source}
+}
+
 // parseAPIError extracts a human-readable error message from a JSON API error response.
 // Handles common formats: {"detail": "..."}, {"field": ["error", ...]}, {"non_field_errors": ["..."]}
 func parseAPIError(body []byte) error {
+	message, code, source, ok := parseAPIErrorPayload(body)
+	if ok {
+		return newAPIError(message, code, source)
+	}
+	return errors.New(message)
+}
+
+func parseAPIErrorPayload(body []byte) (message string, code string, source string, ok bool) {
 	raw := string(body)
 
 	if strings.TrimSpace(raw) == "" {
-		return errors.New("server returned an empty error response")
+		return "server returned an empty error response", "", "", false
 	}
 
 	var parsed map[string]any
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		// Not valid JSON (e.g., HTML error page) — return truncated
-		return errors.New(truncateBody(raw))
+		return truncateBody(raw), "", "", false
 	}
 
+	code = stringField(parsed, "code")
+	source = stringField(parsed, "source")
+
 	// Case 1: {"detail": "..."}
-	if detail, ok := parsed["detail"]; ok {
-		if s, ok := detail.(string); ok {
-			return errors.New(s)
-		}
+	if detail := strings.TrimSpace(stringField(parsed, "detail")); detail != "" {
+		return detail, code, source, true
 	}
 
 	// Case 2: field validation errors {"field": ["msg1", "msg2"], ...}
@@ -400,11 +417,16 @@ func parseAPIError(body []byte) error {
 	}
 
 	if len(messages) > 0 {
-		return errors.New(strings.Join(messages, "; "))
+		return strings.Join(messages, "; "), code, source, true
 	}
 
 	// Fallback: return truncated raw body
-	return errors.New(truncateBody(raw))
+	return truncateBody(raw), code, source, true
+}
+
+func stringField(values map[string]any, field string) string {
+	value, _ := values[field].(string)
+	return strings.TrimSpace(value)
 }
 
 func truncateBody(s string) string {

--- a/client/client.go
+++ b/client/client.go
@@ -94,17 +94,36 @@ func getUserPrivileges(isStaff, isSuperuser bool) string {
 func checkAuthStatus(statusCode int, body []byte) error {
 	switch statusCode {
 	case http.StatusUnauthorized:
-		if msg, code, source, ok := parseAPIErrorPayload(body); ok && msg != "" {
+		if msg, code, source, ok := parseAuthStatusErrorPayload(body); ok {
 			return newAPIError(fmt.Sprintf("%s (run 'alpacon login' if your session has expired)", msg), code, source)
 		}
 		return errors.New("authentication failed: please run 'alpacon login' again")
 	case http.StatusForbidden:
-		if msg, code, source, ok := parseAPIErrorPayload(body); ok && msg != "" {
+		if msg, code, source, ok := parseAuthStatusErrorPayload(body); ok {
 			return newAPIError(msg, code, source)
 		}
 		return errors.New("permission denied: you do not have the required privileges for this action")
 	}
 	return nil
+}
+
+func parseAuthStatusErrorPayload(body []byte) (message string, code string, source string, ok bool) {
+	message, code, source, ok = parseAPIErrorPayload(body)
+	if !ok || message == "" {
+		return "", "", "", false
+	}
+	if code != "" || source != "" {
+		return message, code, source, true
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", "", "", false
+	}
+	if stringField(parsed, "detail") == "" {
+		return "", "", "", false
+	}
+	return message, code, source, true
 }
 
 func (ac *AlpaconClient) SetWebsocketHeader() http.Header {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,6 +59,27 @@ func TestSendRequest_403SurfacesServerDetail(t *testing.T) {
 	ac := newTestClient(ts.URL)
 	_, err := ac.SendGetRequest("/api/test/")
 	assert.ErrorContains(t, err, "missing scope: sudo")
+}
+
+func TestSendRequest_403PreservesWorkSessionCodeAndSource(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{
+			"code": "work_session_required",
+			"source": "command",
+			"detail": "WorkSession required"
+		}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	assert.ErrorContains(t, err, "WorkSession required")
+
+	code, source := utils.ParseErrorResponse(err)
+	assert.Equal(t, utils.WorkSessionRequired, code)
+	assert.Equal(t, "command", source)
 }
 
 func TestSendRequest_403WithoutBodyFallsBackToGenericMessage(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -121,6 +121,21 @@ func TestSendRequest_403EmptyDetailFallsBackToGenericMessage(t *testing.T) {
 	assert.NotContains(t, err.Error(), "detail:")
 }
 
+func TestSendRequest_403CodeWithoutDetailFallsBackToGenericMessage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"code": "some_code", "source": "command"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	// No "detail" -> must not leak the raw JSON body as the message.
+	assert.ErrorContains(t, err, "permission denied")
+	assert.NotContains(t, err.Error(), "some_code")
+}
+
 func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {
 	callCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -48,6 +48,20 @@ func TestSendRequest_401WithoutBodyFallsBackToLoginHint(t *testing.T) {
 	assert.ErrorContains(t, err, "authentication failed")
 }
 
+func TestSendRequest_401EmptyJSONFallsBackToLoginHint(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	assert.ErrorContains(t, err, "authentication failed")
+	assert.NotContains(t, err.Error(), "{}")
+}
+
 func TestSendRequest_403SurfacesServerDetail(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -91,6 +105,20 @@ func TestSendRequest_403WithoutBodyFallsBackToGenericMessage(t *testing.T) {
 	ac := newTestClient(ts.URL)
 	_, err := ac.SendGetRequest("/api/test/")
 	assert.ErrorContains(t, err, "permission denied")
+}
+
+func TestSendRequest_403EmptyDetailFallsBackToGenericMessage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail": ""}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	assert.ErrorContains(t, err, "permission denied")
+	assert.NotContains(t, err.Error(), "detail:")
 }
 
 func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {

--- a/cmd/exec/worksession_command_test.go
+++ b/cmd/exec/worksession_command_test.go
@@ -1,0 +1,134 @@
+package exec
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecCommandWorkSessionGateExits3WithJSONDiagnostic(t *testing.T) {
+	var sawCommandPost atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-1","name":"prod"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/events/commands/":
+			sawCommandPost.Store(true)
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{
+				"code": "work_session_required",
+				"source": "command",
+				"detail": "WorkSession required"
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	home := t.TempDir()
+	writeExecCommandTestConfig(t, home, ts.URL)
+
+	helper := osexec.Command(
+		os.Args[0],
+		"-test.run=^TestExecCommandWorkSessionGateHelperProcess$",
+		"--",
+		"exec-worksession-helper",
+		"--output",
+		"json",
+		"prod",
+		"id",
+	)
+	helper.Env = append(os.Environ(),
+		"GO_WANT_EXEC_WORKSESSION_HELPER=1",
+		"ALPACON_WORK_SESSION=",
+		"HOME="+home,
+	)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	helper.Stdout = &stdout
+	helper.Stderr = &stderr
+
+	err := helper.Run()
+	require.Error(t, err)
+	var exitErr *osexec.ExitError
+	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	assert.Equal(t, utils.ExitCodeWorkSessionDenied, exitErr.ExitCode())
+	assert.Empty(t, stdout.String())
+	assert.True(t, sawCommandPost.Load(), "expected exec command to submit the remote command request")
+
+	var envelope struct {
+		OK        bool   `json:"ok"`
+		ExitCode  int    `json:"exit_code"`
+		ErrorCode string `json:"error_code"`
+		Reason    string `json:"reason"`
+		Context   struct {
+			AuthMethod    string   `json:"auth_method"`
+			RequiredScope string   `json:"required_scope"`
+			TargetServers []string `json:"target_servers"`
+		} `json:"context"`
+	}
+	require.NoError(t, json.Unmarshal(stderr.Bytes(), &envelope), "stderr: %s", stderr.String())
+	assert.False(t, envelope.OK)
+	assert.Equal(t, utils.ExitCodeWorkSessionDenied, envelope.ExitCode)
+	assert.Equal(t, utils.WorkSessionRequired, envelope.ErrorCode)
+	assert.Equal(t, "no WorkSession selected for this shell", envelope.Reason)
+	assert.Equal(t, "Browser login", envelope.Context.AuthMethod)
+	assert.Equal(t, "command", envelope.Context.RequiredScope)
+	assert.Equal(t, []string{"prod"}, envelope.Context.TargetServers)
+}
+
+func TestExecCommandWorkSessionGateHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_EXEC_WORKSESSION_HELPER") != "1" {
+		return
+	}
+
+	args, ok := execWorkSessionHelperArgs(os.Args)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "missing exec-worksession-helper marker")
+		os.Exit(2)
+	}
+	ExecCmd.Run(ExecCmd, args)
+}
+
+func execWorkSessionHelperArgs(args []string) ([]string, bool) {
+	for i := 0; i < len(args); i++ {
+		if args[i] == "exec-worksession-helper" {
+			return args[i+1:], true
+		}
+	}
+	return nil, false
+}
+
+func writeExecCommandTestConfig(t *testing.T, home, workspaceURL string) {
+	t.Helper()
+	cfgDir := filepath.Join(home, ".alpacon")
+	require.NoError(t, os.MkdirAll(cfgDir, 0700))
+
+	cfg := map[string]any{
+		"workspace_url":           workspaceURL,
+		"workspace_name":          "test",
+		"access_token":            "access-token",
+		"refresh_token":           "refresh-token",
+		"access_token_expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		"active_work_sessions":    map[string]string{},
+		"insecure":                false,
+	}
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.json"), data, 0600))
+}

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -139,6 +139,7 @@ commands, especially for AI agents and operators managing multiple workspaces.`,
 				if !ws.ExpiresAt.IsZero() {
 					expiresAt = ws.ExpiresAt.UTC().Format(time.RFC3339)
 				}
+				// normalized() mirrors this into ActiveWorksessionCanonical.
 				output.ActiveWorksession = &activeWorkSessionSummary{
 					ID:        ws.ID,
 					Status:    ws.Status,
@@ -146,7 +147,6 @@ commands, especially for AI agents and operators managing multiple workspaces.`,
 					Servers:   serverNames,
 					ExpiresAt: expiresAt,
 				}
-				output.ActiveWorksessionCanonical = output.ActiveWorksession
 			}
 		}
 

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -24,20 +24,49 @@ type activeWorkSessionSummary struct {
 }
 
 type whoamiOutput struct {
-	Username            string                    `json:"username,omitempty"`
-	Email               string                    `json:"email,omitempty"`
-	Phone               string                    `json:"phone,omitempty"`
-	WorkspaceName       string                    `json:"workspace_name"`
-	WorkspaceURL        string                    `json:"workspace_url"`
-	AuthMethod          string                    `json:"auth_method"`
-	ExpiresAt           string                    `json:"expires_at,omitempty"`
-	UID                 int                       `json:"uid,omitempty"`
-	Shell               string                    `json:"shell,omitempty"`
-	HomeDirectory       string                    `json:"home_directory,omitempty"`
-	Role                string                    `json:"role,omitempty"`
-	Groups              []iam.GroupMembership     `json:"groups,omitempty"`
-	WorksessionRequired bool                      `json:"work_session_required"`
-	ActiveWorksession   *activeWorkSessionSummary `json:"active_work_session"`
+	Username            string                `json:"username,omitempty"`
+	Email               string                `json:"email,omitempty"`
+	Phone               string                `json:"phone,omitempty"`
+	WorkspaceName       string                `json:"workspace_name"`
+	WorkspaceURL        string                `json:"workspace_url"`
+	AuthMethod          string                `json:"auth_method"`
+	AuthClassification  string                `json:"auth_classification"`
+	ExpiresAt           string                `json:"expires_at,omitempty"`
+	UID                 int                   `json:"uid,omitempty"`
+	Shell               string                `json:"shell,omitempty"`
+	HomeDirectory       string                `json:"home_directory,omitempty"`
+	Role                string                `json:"role,omitempty"`
+	Groups              []iam.GroupMembership `json:"groups,omitempty"`
+	WorksessionRequired bool                  `json:"work_session_required"`
+	// WorksessionRequiredForAccess and ActiveWorksessionCanonical are the
+	// machine-readable names. The legacy keys remain for compatibility.
+	WorksessionRequiredForAccess bool                      `json:"worksession_required_for_access"`
+	ActiveWorksession            *activeWorkSessionSummary `json:"active_work_session"`
+	ActiveWorksessionCanonical   *activeWorkSessionSummary `json:"active_worksession"`
+}
+
+func (o whoamiOutput) MarshalJSON() ([]byte, error) {
+	type wire whoamiOutput
+	normalized := o.normalized()
+	return json.Marshal(wire(normalized))
+}
+
+func (o whoamiOutput) normalized() whoamiOutput {
+	if o.AuthClassification == "" {
+		o.AuthClassification = authClassificationFromMethod(o.AuthMethod)
+	}
+
+	required := o.WorksessionRequired || o.WorksessionRequiredForAccess
+	o.WorksessionRequired = required
+	o.WorksessionRequiredForAccess = required
+
+	active := o.ActiveWorksession
+	if active == nil {
+		active = o.ActiveWorksessionCanonical
+	}
+	o.ActiveWorksession = active
+	o.ActiveWorksessionCanonical = active
+	return o
 }
 
 var whoamiCmd = &cobra.Command{
@@ -54,12 +83,15 @@ commands, especially for AI agents and operators managing multiple workspaces.`,
 			utils.CliErrorWithExit("Not logged in. Run 'alpacon login' to authenticate.")
 		}
 
+		worksessionRequired := isWorksessionRequired(cfg)
 		output := whoamiOutput{
-			WorkspaceName:       cfg.WorkspaceName,
-			WorkspaceURL:        cfg.WorkspaceURL,
-			AuthMethod:          config.GetAuthMethod(cfg),
-			ExpiresAt:           getExpiresAt(cfg),
-			WorksessionRequired: isWorksessionRequired(cfg),
+			WorkspaceName:                cfg.WorkspaceName,
+			WorkspaceURL:                 cfg.WorkspaceURL,
+			AuthMethod:                   config.GetAuthMethod(cfg),
+			AuthClassification:           getAuthClassification(cfg),
+			ExpiresAt:                    getExpiresAt(cfg),
+			WorksessionRequired:          worksessionRequired,
+			WorksessionRequiredForAccess: worksessionRequired,
 		}
 
 		ac, err := client.NewAlpaconAPIClient()
@@ -114,6 +146,7 @@ commands, especially for AI agents and operators managing multiple workspaces.`,
 					Servers:   serverNames,
 					ExpiresAt: expiresAt,
 				}
+				output.ActiveWorksessionCanonical = output.ActiveWorksession
 			}
 		}
 
@@ -137,6 +170,27 @@ func getRole(isStaff, isSuperuser bool) string {
 		return "staff"
 	}
 	return "user"
+}
+
+func getAuthClassification(cfg config.Config) string {
+	if cfg.AccessToken != "" {
+		return "browser_login"
+	}
+	if cfg.Token != "" {
+		return "token"
+	}
+	return "unknown"
+}
+
+func authClassificationFromMethod(method string) string {
+	switch method {
+	case "Browser login":
+		return "browser_login"
+	case "Token":
+		return "token"
+	default:
+		return "unknown"
+	}
 }
 
 func isTokenAuth(cfg config.Config) bool {
@@ -229,6 +283,8 @@ func formatWSRequired(required bool, active *activeWorkSessionSummary) string {
 }
 
 func printWhoami(output whoamiOutput) {
+	output = output.normalized()
+
 	if utils.OutputFormat == utils.OutputFormatJSON {
 		body, err := json.Marshal(output)
 		if err != nil {
@@ -247,13 +303,14 @@ func printWhoami(output whoamiOutput) {
 		{"Phone", output.Phone},
 		{"Workspace", fmt.Sprintf("%s (%s)", output.WorkspaceName, output.WorkspaceURL)},
 		{"Auth", output.AuthMethod},
+		{"Auth class", output.AuthClassification},
 		{"Expires", formatExpiresHuman(output.ExpiresAt)},
 		{"UID", fmt.Sprintf("%d", output.UID)},
 		{"Shell", output.Shell},
 		{"Home", output.HomeDirectory},
 		{"Role", output.Role},
 		{"Groups", formatGroups(output.Groups)},
-		{"WS required", formatWSRequired(output.WorksessionRequired, output.ActiveWorksession)},
+		{"WS required", formatWSRequired(output.WorksessionRequiredForAccess, output.ActiveWorksessionCanonical)},
 	}
 
 	for _, l := range lines {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -283,9 +283,8 @@ func formatWSRequired(required bool, active *activeWorkSessionSummary) string {
 }
 
 func printWhoami(output whoamiOutput) {
-	output = output.normalized()
-
 	if utils.OutputFormat == utils.OutputFormatJSON {
+		// MarshalJSON normalizes, so no need to pre-normalize here.
 		body, err := json.Marshal(output)
 		if err != nil {
 			utils.CliErrorWithExit("Failed to marshal whoami: %s", err)
@@ -294,6 +293,7 @@ func printWhoami(output whoamiOutput) {
 		return
 	}
 
+	output = output.normalized()
 	lines := []struct {
 		label string
 		value string

--- a/cmd/whoami_test.go
+++ b/cmd/whoami_test.go
@@ -32,6 +32,25 @@ func TestGetAuthMethod(t *testing.T) {
 	}
 }
 
+func TestGetAuthClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      config.Config
+		expected string
+	}{
+		{"browser login", config.Config{AccessToken: "some-access-token"}, "browser_login"},
+		{"token", config.Config{Token: "some-token"}, "token"},
+		{"both tokens prefers browser", config.Config{Token: "some-token", AccessToken: "some-access-token"}, "browser_login"},
+		{"no tokens", config.Config{}, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getAuthClassification(tt.cfg))
+		})
+	}
+}
+
 func TestGetRole(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -186,6 +205,7 @@ func TestPrintWhoamiJSON_PreflightFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			output := whoamiOutput{
+				AuthMethod:          "Browser login",
 				WorksessionRequired: tt.worksessionRequired,
 				ActiveWorksession:   tt.activeWorksession,
 			}
@@ -198,12 +218,21 @@ func TestPrintWhoamiJSON_PreflightFields(t *testing.T) {
 			// Contract: both keys must always be present in the JSON output,
 			// so callers can rely on them without checking for missing fields.
 			_, hasRequired := got["work_session_required"]
+			_, hasRequiredForAccess := got["worksession_required_for_access"]
 			_, hasActive := got["active_work_session"]
+			_, hasActiveCanonical := got["active_worksession"]
+			_, hasAuthClassification := got["auth_classification"]
 			assert.True(t, hasRequired, "work_session_required key must always be present")
+			assert.True(t, hasRequiredForAccess, "worksession_required_for_access key must always be present")
 			assert.True(t, hasActive, "active_work_session key must always be present")
+			assert.True(t, hasActiveCanonical, "active_worksession key must always be present")
+			assert.True(t, hasAuthClassification, "auth_classification key must always be present")
 
 			assert.JSONEq(t, strconv.FormatBool(tt.worksessionRequired), string(got["work_session_required"]))
+			assert.JSONEq(t, strconv.FormatBool(tt.worksessionRequired), string(got["worksession_required_for_access"]))
 			assert.JSONEq(t, tt.wantActiveRaw, string(got["active_work_session"]))
+			assert.JSONEq(t, tt.wantActiveRaw, string(got["active_worksession"]))
+			assert.JSONEq(t, `"browser_login"`, string(got["auth_classification"]))
 		})
 	}
 }

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -177,20 +177,32 @@ session with 'alpacon work-session update <id> --sudo "<command>"'.`,
 			utils.CliErrorWithExit("Failed to create work session: %s.", err)
 		}
 
-		if session.ApprovalRequestID != "" {
-			utils.CliSuccess("Work session created: %s (status: %s, approval request: %s)", session.ID, session.Status, session.ApprovalRequestID)
-		} else {
-			utils.CliSuccess("Work session created: %s (status: %s)", session.ID, session.Status)
+		if utils.OutputFormat != utils.OutputFormatJSON {
+			utils.CliSuccess("%s", createSuccessMessage(session))
 		}
 
 		// Phase 1: post-create decision. Cases without an explicit return delegate to
 		// the --wait branch below (or exit immediately when --wait is not set).
 		switch decideUseAction(session.Status, useAfterCreate) {
 		case useDecisionUseNow:
-			attachActiveOrExit(ac, session.ID, "Work session created (%s) but failed to set as active: %s. Run 'alpacon work-session use %s' to retry.", "")
+			desc, err := RunUse(ac, session.ID)
+			if err != nil {
+				utils.CliErrorWithExit("Work session created (%s) but failed to set as active: %s. Run 'alpacon work-session use %s' to retry.", session.ID, err, session.ID)
+			}
+			message := activeWorkSessionSetMessage("", session.ID, desc)
+			if utils.OutputFormat == utils.OutputFormatJSON {
+				active := session.ID
+				printWorkSessionMutationJSON(newWorkSessionMutationOutput("create", createSuccessMessage(session)+". "+message, session, &active))
+				return
+			}
+			utils.CliSuccess("%s", message)
 			return
 		case useDecisionSkipScheduled:
 			if !waitApproval {
+				if utils.OutputFormat == utils.OutputFormatJSON {
+					printWorkSessionMutationJSON(newWorkSessionMutationOutput("create", createSuccessMessage(session), session, nil))
+					return
+				}
 				utils.CliInfo("Session is scheduled to activate. Run 'alpacon work-session use %s' once active.", session.ID)
 				return
 			}
@@ -201,37 +213,41 @@ session with 'alpacon work-session update <id> --sudo "<command>"'.`,
 		}
 
 		if !waitApproval {
+			if utils.OutputFormat == utils.OutputFormatJSON {
+				printWorkSessionMutationJSON(newWorkSessionMutationOutput("create", createSuccessMessage(session), session, nil))
+			}
 			return
 		}
 
 		// Phase 2: poll. With --use we wait for active; otherwise approved is enough.
-		if err := pollForApproval(ac, session.ID, useAfterCreate); err != nil {
+		finalSession, err := pollForApproval(ac, session.ID, useAfterCreate)
+		if err != nil {
 			utils.CliErrorWithExit("%s", err)
 		}
 
 		if !useAfterCreate {
-			utils.CliSuccess("Work session %s approved.", session.ID)
+			message := fmt.Sprintf("Work session %s approved.", session.ID)
+			if utils.OutputFormat == utils.OutputFormatJSON {
+				printWorkSessionMutationJSON(newWorkSessionMutationOutput("create", message, finalSession, nil))
+				return
+			}
+			utils.CliSuccess("%s", message)
 			return
 		}
 
 		// Phase 3: --wait --use. pollForApproval(untilActive=true) guarantees status reached active.
-		attachActiveOrExit(ac, session.ID, "Work session %s approved but failed to set as active: %s. Run 'alpacon work-session use %s' to retry.", fmt.Sprintf("Work session %s approved. ", session.ID))
+		desc, err := RunUse(ac, session.ID)
+		if err != nil {
+			utils.CliErrorWithExit("Work session %s approved but failed to set as active: %s. Run 'alpacon work-session use %s' to retry.", session.ID, err, session.ID)
+		}
+		message := activeWorkSessionSetMessage(fmt.Sprintf("Work session %s approved. ", session.ID), session.ID, desc)
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			active := session.ID
+			printWorkSessionMutationJSON(newWorkSessionMutationOutput("create", message, finalSession, &active))
+			return
+		}
+		utils.CliSuccess("%s", message)
 	},
-}
-
-// attachActiveOrExit calls RunUse and prints either a success line (with description if present)
-// or exits with the supplied error format (which receives session ID, error, session ID in order).
-// successPrefix is prepended to the success line so callers can distinguish phases.
-func attachActiveOrExit(ac *client.AlpaconClient, id, errFmt, successPrefix string) {
-	desc, err := RunUse(ac, id)
-	if err != nil {
-		utils.CliErrorWithExit(errFmt, id, err, id)
-	}
-	suffix := ""
-	if desc != "" {
-		suffix = fmt.Sprintf(" (%s)", desc)
-	}
-	utils.CliSuccess("%sActive work-session set to %s%s.", successPrefix, id, suffix)
 }
 
 // parseExpiryFlag validates the --expires-in / --expires-at mutual exclusion
@@ -345,27 +361,27 @@ func splitCSV(s string) []string {
 // pollForApproval polls every 10 seconds until the session reaches a terminal state.
 // untilActive=false returns on approved or active; untilActive=true returns only on
 // active (continues polling on approved until the server auto-activates).
-func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) error {
+func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) (*wsapi.WorkSession, error) {
 	for attempt := 1; attempt <= pollMaxAttempts; attempt++ {
 		s, err := wsapi.GetWorkSession(ac, id)
 		if err != nil {
-			return fmt.Errorf("polling failed: %w", err)
+			return nil, fmt.Errorf("polling failed: %w", err)
 		}
 		switch s.Status {
 		case activeWorkSessionStatus:
-			return nil
+			return s, nil
 		case approvedWorkSessionStatus:
 			if !untilActive {
-				return nil
+				return s, nil
 			}
 		case rejectedWorkSessionStatus:
-			return errors.New("work session was rejected")
+			return nil, errors.New("work session was rejected")
 		case expiredWorkSessionStatus:
-			return errors.New("work session expired while waiting for approval")
+			return nil, errors.New("work session expired while waiting for approval")
 		case revokedWorkSessionStatus:
-			return errors.New("work session was revoked")
+			return nil, errors.New("work session was revoked")
 		case completedWorkSessionStatus:
-			return errors.New("work session was completed unexpectedly")
+			return nil, errors.New("work session was completed unexpectedly")
 		}
 		waitMsg := waitMsgApproval
 		if s.Status == approvedWorkSessionStatus {
@@ -376,7 +392,7 @@ func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) erro
 			time.Sleep(pollInterval)
 		}
 	}
-	return fmt.Errorf("timed out waiting for approval after %d attempts", pollMaxAttempts)
+	return nil, fmt.Errorf("timed out waiting for approval after %d attempts", pollMaxAttempts)
 }
 
 func init() {

--- a/cmd/worksession/worksession_extend.go
+++ b/cmd/worksession/worksession_extend.go
@@ -45,7 +45,12 @@ var workSessionExtendCmd = &cobra.Command{
 			utils.CliErrorWithExit("Failed to extend work session: %s.", err)
 		}
 
-		utils.CliSuccess("Work session %s extended to %s.", args[0], expiresAtVal)
+		output := newWorkSessionExtendOutput(args[0], expiresAtVal)
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			printWorkSessionMutationJSON(output)
+			return
+		}
+		utils.CliSuccess("%s", output.Message)
 	},
 }
 

--- a/cmd/worksession/worksession_output.go
+++ b/cmd/worksession/worksession_output.go
@@ -1,0 +1,77 @@
+package worksession
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+type workSessionMutationOutput struct {
+	OK                bool               `json:"ok"`
+	Operation         string             `json:"operation"`
+	Message           string             `json:"message"`
+	WorkSessionID     string             `json:"work_session_id,omitempty"`
+	Status            string             `json:"status,omitempty"`
+	ExpiresAt         string             `json:"expires_at,omitempty"`
+	ApprovalRequestID string             `json:"approval_request_id,omitempty"`
+	ActiveWorksession *string            `json:"active_worksession"`
+	WorkSession       *wsapi.WorkSession `json:"work_session,omitempty"`
+}
+
+func newWorkSessionMutationOutput(operation, message string, session *wsapi.WorkSession, activeWorksession *string) workSessionMutationOutput {
+	output := workSessionMutationOutput{
+		OK:                true,
+		Operation:         operation,
+		Message:           message,
+		ActiveWorksession: activeWorksession,
+		WorkSession:       session,
+	}
+	if session != nil {
+		output.WorkSessionID = session.ID
+		output.Status = session.Status
+		output.ApprovalRequestID = session.ApprovalRequestID
+		output.ExpiresAt = formatMutationExpiresAt(session.ExpiresAt)
+	}
+	return output
+}
+
+func newWorkSessionExtendOutput(id, expiresAt string) workSessionMutationOutput {
+	return workSessionMutationOutput{
+		OK:            true,
+		Operation:     "extend",
+		Message:       fmt.Sprintf("Work session %s extended to %s.", id, expiresAt),
+		WorkSessionID: id,
+		ExpiresAt:     expiresAt,
+	}
+}
+
+func formatMutationExpiresAt(expiresAt time.Time) string {
+	if expiresAt.IsZero() {
+		return ""
+	}
+	return expiresAt.UTC().Format(time.RFC3339)
+}
+
+func createSuccessMessage(session *wsapi.WorkSession) string {
+	if session.ApprovalRequestID != "" {
+		return fmt.Sprintf("Work session created: %s (status: %s, approval request: %s)", session.ID, session.Status, session.ApprovalRequestID)
+	}
+	return fmt.Sprintf("Work session created: %s (status: %s)", session.ID, session.Status)
+}
+
+func activeWorkSessionSetMessage(successPrefix, id, desc string) string {
+	suffix := ""
+	if desc != "" {
+		suffix = fmt.Sprintf(" (%s)", desc)
+	}
+	return fmt.Sprintf("%sActive work-session set to %s%s.", successPrefix, id, suffix)
+}
+
+func printWorkSessionMutationJSON(output workSessionMutationOutput) {
+	if err := utils.PrintJSONValue(os.Stdout, output); err != nil {
+		utils.CliErrorWithExit("Failed to marshal work-session result: %s", err)
+	}
+}

--- a/cmd/worksession/worksession_output_test.go
+++ b/cmd/worksession/worksession_output_test.go
@@ -1,0 +1,70 @@
+package worksession
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkSessionMutationOutputWrapsSession(t *testing.T) {
+	expiresAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	session := &wsapi.WorkSession{
+		ID:                "ses-abc",
+		Description:       "incident",
+		Status:            "active",
+		ApprovalRequestID: "apr-1",
+		ExpiresAt:         expiresAt,
+	}
+	active := session.ID
+
+	output := newWorkSessionMutationOutput("create", "created", session, &active)
+	body, err := json.Marshal(output)
+	require.NoError(t, err)
+
+	var got struct {
+		OK                bool   `json:"ok"`
+		Operation         string `json:"operation"`
+		Message           string `json:"message"`
+		WorkSessionID     string `json:"work_session_id"`
+		Status            string `json:"status"`
+		ExpiresAt         string `json:"expires_at"`
+		ApprovalRequestID string `json:"approval_request_id"`
+		ActiveWorksession string `json:"active_worksession"`
+		WorkSession       struct {
+			ID          string `json:"id"`
+			Description string `json:"description"`
+			Status      string `json:"status"`
+		} `json:"work_session"`
+	}
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.True(t, got.OK)
+	assert.Equal(t, "create", got.Operation)
+	assert.Equal(t, "created", got.Message)
+	assert.Equal(t, "ses-abc", got.WorkSessionID)
+	assert.Equal(t, "active", got.Status)
+	assert.Equal(t, "2026-06-01T12:00:00Z", got.ExpiresAt)
+	assert.Equal(t, "apr-1", got.ApprovalRequestID)
+	assert.Equal(t, "ses-abc", got.ActiveWorksession)
+	assert.Equal(t, "ses-abc", got.WorkSession.ID)
+	assert.Equal(t, "incident", got.WorkSession.Description)
+	assert.Equal(t, "active", got.WorkSession.Status)
+}
+
+func TestWorkSessionExtendOutput(t *testing.T) {
+	output := newWorkSessionExtendOutput("ses-abc", "2026-06-01T12:00:00Z")
+	body, err := json.Marshal(output)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"ok": true,
+		"operation": "extend",
+		"message": "Work session ses-abc extended to 2026-06-01T12:00:00Z.",
+		"work_session_id": "ses-abc",
+		"expires_at": "2026-06-01T12:00:00Z",
+		"active_worksession": null
+	}`, string(body))
+}

--- a/cmd/worksession/worksession_output_test.go
+++ b/cmd/worksession/worksession_output_test.go
@@ -1,11 +1,18 @@
 package worksession
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/config"
+	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,4 +74,234 @@ func TestWorkSessionExtendOutput(t *testing.T) {
 		"expires_at": "2026-06-01T12:00:00Z",
 		"active_worksession": null
 	}`, string(body))
+}
+
+func TestWorkSessionCreateCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-1","name":"prod"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/work-sessions/sessions/":
+			_, _ = w.Write([]byte(`{
+				"id": "ses-created",
+				"description": "incident",
+				"status": "active",
+				"requester_type": "user",
+				"scopes": ["command"],
+				"servers": [{"id":"srv-1","name":"prod"}],
+				"approval_request_id": "",
+				"expires_at": "2026-06-01T12:00:00Z",
+				"added_at": "2026-05-30T00:00:00Z",
+				"updated_at": "2026-05-30T00:00:00Z"
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	setupWorkSessionCommandConfig(t, ts.URL)
+	withWorkSessionCommandJSONMode(t)
+	resetCreateCommandState(t)
+	purpose = "incident"
+	createScopes = []string{"command"}
+	createServers = []string{"prod"}
+	expiresAt = "2026-06-01T12:00:00Z"
+	requesterType = "user"
+
+	stdout, stderr := captureWorkSessionCommandOutput(t, func() {
+		workSessionCreateCmd.Run(workSessionCreateCmd, nil)
+	})
+
+	assert.Empty(t, stderr)
+	assert.NotContains(t, stdout, "Success:")
+	assert.NotContains(t, stderr, "Success:")
+
+	var got struct {
+		OK                bool    `json:"ok"`
+		Operation         string  `json:"operation"`
+		WorkSessionID     string  `json:"work_session_id"`
+		Status            string  `json:"status"`
+		ActiveWorksession *string `json:"active_worksession"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.True(t, got.OK)
+	assert.Equal(t, "create", got.Operation)
+	assert.Equal(t, "ses-created", got.WorkSessionID)
+	assert.Equal(t, "active", got.Status)
+	assert.Nil(t, got.ActiveWorksession)
+}
+
+func TestWorkSessionUseCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodGet || r.URL.Path != "/api/work-sessions/sessions/ses-active/" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"id": "ses-active",
+			"description": "incident",
+			"status": "active",
+			"expires_at": "2026-06-01T12:00:00Z"
+		}`))
+	}))
+	defer ts.Close()
+
+	setupWorkSessionCommandConfig(t, ts.URL)
+	withWorkSessionCommandJSONMode(t)
+	unsetActiveWorkSession = false
+	t.Cleanup(func() { unsetActiveWorkSession = false })
+
+	stdout, stderr := captureWorkSessionCommandOutput(t, func() {
+		workSessionUseCmd.Run(workSessionUseCmd, []string{"ses-active"})
+	})
+
+	assert.Empty(t, stderr)
+	assert.NotContains(t, stdout, "Success:")
+	assert.NotContains(t, stderr, "Success:")
+
+	var got struct {
+		OK                bool    `json:"ok"`
+		Operation         string  `json:"operation"`
+		WorkSessionID     string  `json:"work_session_id"`
+		ActiveWorksession *string `json:"active_worksession"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.True(t, got.OK)
+	assert.Equal(t, "use", got.Operation)
+	assert.Equal(t, "ses-active", got.WorkSessionID)
+	require.NotNil(t, got.ActiveWorksession)
+	assert.Equal(t, "ses-active", *got.ActiveWorksession)
+
+	active, err := config.GetActiveWorkSession()
+	require.NoError(t, err)
+	assert.Equal(t, "ses-active", active)
+}
+
+func TestWorkSessionExtendCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
+	var sawExtend bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost || r.URL.Path != "/api/work-sessions/sessions/ses-active/extend/" {
+			http.NotFound(w, r)
+			return
+		}
+		sawExtend = true
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	setupWorkSessionCommandConfig(t, ts.URL)
+	withWorkSessionCommandJSONMode(t)
+	extendExpiresIn = ""
+	extendExpiresAt = "2026-06-01T12:00:00Z"
+	t.Cleanup(func() {
+		extendExpiresIn = ""
+		extendExpiresAt = ""
+	})
+
+	stdout, stderr := captureWorkSessionCommandOutput(t, func() {
+		workSessionExtendCmd.Run(workSessionExtendCmd, []string{"ses-active"})
+	})
+
+	assert.True(t, sawExtend)
+	assert.Empty(t, stderr)
+	assert.NotContains(t, stdout, "Success:")
+	assert.NotContains(t, stderr, "Success:")
+
+	var got struct {
+		OK            bool   `json:"ok"`
+		Operation     string `json:"operation"`
+		WorkSessionID string `json:"work_session_id"`
+		ExpiresAt     string `json:"expires_at"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.True(t, got.OK)
+	assert.Equal(t, "extend", got.Operation)
+	assert.Equal(t, "ses-active", got.WorkSessionID)
+	assert.Equal(t, "2026-06-01T12:00:00Z", got.ExpiresAt)
+}
+
+func setupWorkSessionCommandConfig(t *testing.T, workspaceURL string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	require.NoError(t, config.CreateConfig(workspaceURL, "ws", "token", "", "", "", "", 0, false))
+}
+
+func withWorkSessionCommandJSONMode(t *testing.T) {
+	t.Helper()
+	old := utils.OutputFormat
+	utils.OutputFormat = utils.OutputFormatJSON
+	t.Cleanup(func() { utils.OutputFormat = old })
+}
+
+func resetCreateCommandState(t *testing.T) {
+	t.Helper()
+	purpose = ""
+	createScopes = nil
+	createServers = nil
+	expiresIn = ""
+	expiresAt = ""
+	requesterType = "user"
+	waitApproval = false
+	useAfterCreate = false
+	createSudo = nil
+	createSudoReason = ""
+	t.Cleanup(func() {
+		purpose = ""
+		createScopes = nil
+		createServers = nil
+		expiresIn = ""
+		expiresAt = ""
+		requesterType = "user"
+		waitApproval = false
+		useAfterCreate = false
+		createSudo = nil
+		createSudoReason = ""
+	})
+}
+
+func captureWorkSessionCommandOutput(t *testing.T, fn func()) (stdout string, stderr string) {
+	t.Helper()
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	require.NoError(t, err)
+	stderrReader, stderrWriter, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	stdoutDone := make(chan string, 1)
+	stderrDone := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, stdoutReader)
+		stdoutDone <- buf.String()
+	}()
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, stderrReader)
+		stderrDone <- buf.String()
+	}()
+
+	fn()
+
+	_ = stdoutWriter.Close()
+	_ = stderrWriter.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	t.Cleanup(func() {
+		_ = stdoutReader.Close()
+		_ = stderrReader.Close()
+	})
+
+	return <-stdoutDone, <-stderrDone
 }

--- a/cmd/worksession/worksession_output_test.go
+++ b/cmd/worksession/worksession_output_test.go
@@ -180,6 +180,30 @@ func TestWorkSessionUseCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
 	assert.Equal(t, "ses-active", active)
 }
 
+func TestWorkSessionUnsetCommandJSONOutput_OperationIsUnset(t *testing.T) {
+	setupWorkSessionCommandConfig(t, "http://example.invalid")
+	withWorkSessionCommandJSONMode(t)
+	require.NoError(t, config.SetActiveWorkSession("ses-active"))
+	unsetActiveWorkSession = true
+	t.Cleanup(func() { unsetActiveWorkSession = false })
+
+	stdout, stderr := captureWorkSessionCommandOutput(t, func() {
+		workSessionUseCmd.Run(workSessionUseCmd, nil)
+	})
+
+	assert.Empty(t, stderr)
+
+	var got struct {
+		OK                bool    `json:"ok"`
+		Operation         string  `json:"operation"`
+		ActiveWorksession *string `json:"active_worksession"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.True(t, got.OK)
+	assert.Equal(t, "unset", got.Operation)
+	assert.Nil(t, got.ActiveWorksession)
+}
+
 func TestWorkSessionExtendCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
 	var sawExtend bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/worksession/worksession_use.go
+++ b/cmd/worksession/worksession_use.go
@@ -103,7 +103,7 @@ func RunUseSession(ac *client.AlpaconClient, uuid string) (*wsapi.WorkSession, e
 		return nil, err
 	}
 	if ws.Status != activeWorkSessionStatus {
-		return nil, fmt.Errorf("work-session %s is in '%s' state and cannot be used", uuid, ws.Status)
+		return nil, fmt.Errorf("work-session %s is in '%s' state and cannot be used", ws.ID, ws.Status)
 	}
 	// Persist the canonical ID from the API rather than the raw argument so config
 	// stays consistent with server-side canonicalization and the printed JSON fields.

--- a/cmd/worksession/worksession_use.go
+++ b/cmd/worksession/worksession_use.go
@@ -76,9 +76,9 @@ Pass --unset (with no SESSION_ID) to clear the active work-session.`,
 		if err != nil {
 			utils.CliErrorWithExit("%s", err)
 		}
-		message := activeWorkSessionSetMessage("", args[0], ws.Description)
+		message := activeWorkSessionSetMessage("", ws.ID, ws.Description)
 		if utils.OutputFormat == utils.OutputFormatJSON {
-			active := args[0]
+			active := ws.ID
 			printWorkSessionMutationJSON(newWorkSessionMutationOutput("use", message, ws, &active))
 			return
 		}
@@ -105,7 +105,9 @@ func RunUseSession(ac *client.AlpaconClient, uuid string) (*wsapi.WorkSession, e
 	if ws.Status != activeWorkSessionStatus {
 		return nil, fmt.Errorf("work-session %s is in '%s' state and cannot be used", uuid, ws.Status)
 	}
-	if err := config.SetActiveWorkSession(uuid); err != nil {
+	// Persist the canonical ID from the API rather than the raw argument so config
+	// stays consistent with server-side canonicalization and the printed JSON fields.
+	if err := config.SetActiveWorkSession(ws.ID); err != nil {
 		return nil, err
 	}
 	return ws, nil

--- a/cmd/worksession/worksession_use.go
+++ b/cmd/worksession/worksession_use.go
@@ -37,11 +37,29 @@ Pass --unset (with no SESSION_ID) to clear the active work-session.`,
 			// Treat missing config / no active workspace / empty entry as already-unset
 			// so --unset is a true no-op and never surfaces a confusing config error.
 			if cur, err := config.GetActiveWorkSession(); err != nil || cur == "" {
+				if utils.OutputFormat == utils.OutputFormatJSON {
+					printWorkSessionMutationJSON(workSessionMutationOutput{
+						OK:                true,
+						Operation:         "use",
+						Message:           "No active work-session to unset.",
+						ActiveWorksession: nil,
+					})
+					return
+				}
 				utils.CliInfo("No active work-session to unset.")
 				return
 			}
 			if err := RunUnset(); err != nil {
 				utils.CliErrorWithExit("%s", err)
+			}
+			if utils.OutputFormat == utils.OutputFormatJSON {
+				printWorkSessionMutationJSON(workSessionMutationOutput{
+					OK:                true,
+					Operation:         "use",
+					Message:           "Active work-session cleared.",
+					ActiveWorksession: nil,
+				})
+				return
 			}
 			utils.CliSuccess("Active work-session cleared.")
 			return
@@ -54,32 +72,43 @@ Pass --unset (with no SESSION_ID) to clear the active work-session.`,
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
-		desc, err := RunUse(ac, args[0])
+		ws, err := RunUseSession(ac, args[0])
 		if err != nil {
 			utils.CliErrorWithExit("%s", err)
 		}
-		if desc != "" {
-			utils.CliSuccess("Active work-session set to %s (%s).", args[0], desc)
-		} else {
-			utils.CliSuccess("Active work-session set to %s.", args[0])
+		message := activeWorkSessionSetMessage("", args[0], ws.Description)
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			active := args[0]
+			printWorkSessionMutationJSON(newWorkSessionMutationOutput("use", message, ws, &active))
+			return
 		}
+		utils.CliSuccess("%s", message)
 	},
 }
 
 // RunUse validates the work-session via the server, then stores it in config.
 // Returns the human-readable description on success.
 func RunUse(ac *client.AlpaconClient, uuid string) (string, error) {
-	ws, err := wsapi.GetWorkSession(ac, uuid)
+	ws, err := RunUseSession(ac, uuid)
 	if err != nil {
 		return "", err
 	}
+	return ws.Description, nil
+}
+
+// RunUseSession validates the work-session via the server, then stores it in config.
+func RunUseSession(ac *client.AlpaconClient, uuid string) (*wsapi.WorkSession, error) {
+	ws, err := wsapi.GetWorkSession(ac, uuid)
+	if err != nil {
+		return nil, err
+	}
 	if ws.Status != activeWorkSessionStatus {
-		return "", fmt.Errorf("work-session %s is in '%s' state and cannot be used", uuid, ws.Status)
+		return nil, fmt.Errorf("work-session %s is in '%s' state and cannot be used", uuid, ws.Status)
 	}
 	if err := config.SetActiveWorkSession(uuid); err != nil {
-		return "", err
+		return nil, err
 	}
-	return ws.Description, nil
+	return ws, nil
 }
 
 // RunUnset clears the active work-session for the current workspace.

--- a/cmd/worksession/worksession_use.go
+++ b/cmd/worksession/worksession_use.go
@@ -40,7 +40,7 @@ Pass --unset (with no SESSION_ID) to clear the active work-session.`,
 				if utils.OutputFormat == utils.OutputFormatJSON {
 					printWorkSessionMutationJSON(workSessionMutationOutput{
 						OK:                true,
-						Operation:         "use",
+						Operation:         "unset",
 						Message:           "No active work-session to unset.",
 						ActiveWorksession: nil,
 					})
@@ -55,7 +55,7 @@ Pass --unset (with no SESSION_ID) to clear the active work-session.`,
 			if utils.OutputFormat == utils.OutputFormatJSON {
 				printWorkSessionMutationJSON(workSessionMutationOutput{
 					OK:                true,
-					Operation:         "use",
+					Operation:         "unset",
 					Message:           "Active work-session cleared.",
 					ActiveWorksession: nil,
 				})

--- a/utils/error.go
+++ b/utils/error.go
@@ -28,8 +28,20 @@ type ErrorResponse struct {
 	Source string `json:"source"`
 }
 
+type codedError interface {
+	ErrorCode() string
+	ErrorSource() string
+}
+
 func ParseErrorResponse(err error) (string, string) {
 	for e := err; e != nil; e = errors.Unwrap(e) {
+		if coded, ok := e.(codedError); ok {
+			code, source := coded.ErrorCode(), coded.ErrorSource()
+			if code != "" || source != "" {
+				return code, source
+			}
+		}
+
 		errStr := e.Error()
 
 		// Try JSON format: {"code": "...", "source": "..."}

--- a/utils/output.go
+++ b/utils/output.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -20,6 +21,43 @@ const (
 // OutputFormat holds the value of the --output persistent flag.
 // Bound by cmd/root.go; read by PrintTable and PrintJson.
 var OutputFormat string
+
+type JSONErrorEnvelope[T any] struct {
+	OK          bool     `json:"ok"`
+	ExitCode    int      `json:"exit_code,omitempty"`
+	ErrorCode   string   `json:"error_code,omitempty"`
+	Message     string   `json:"message"`
+	Reason      string   `json:"reason,omitempty"`
+	Context     T        `json:"context,omitempty"`
+	NextActions []string `json:"next_actions,omitempty"`
+}
+
+func FormatJSON(value any) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(value); err != nil {
+		return "", err
+	}
+	return strings.TrimRight(buf.String(), "\n"), nil
+}
+
+func PrintJSONValue(w io.Writer, value any) error {
+	rendered, err := FormatJSON(value)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, rendered)
+	return err
+}
+
+func PrintJSONError[T any](w io.Writer, envelope JSONErrorEnvelope[T]) {
+	envelope.OK = false
+	if err := PrintJSONValue(w, envelope); err != nil {
+		_, _ = fmt.Fprintf(w, `{"ok":false,"error_code":%q}`+"\n", envelope.ErrorCode)
+	}
+}
 
 func PrintTable(slice any) {
 	s := reflect.ValueOf(slice)

--- a/utils/output_test.go
+++ b/utils/output_test.go
@@ -113,3 +113,32 @@ func TestPrintJson_TableOutput(t *testing.T) {
 	assert.Contains(t, got, "\"name\": \"alpha\"")
 	assert.Contains(t, got, "\"id\": 1")
 }
+
+func TestFormatJSON_DisablesHTMLEscaping(t *testing.T) {
+	got, err := FormatJSON(map[string]string{"next": `alpacon work-session use <ID>`})
+	assert.NoError(t, err)
+	assert.Contains(t, got, "<ID>")
+	assert.NotContains(t, got, "\\u003c")
+}
+
+func TestPrintJSONError(t *testing.T) {
+	var buf bytes.Buffer
+	PrintJSONError(&buf, JSONErrorEnvelope[map[string]string]{
+		ExitCode:  3,
+		ErrorCode: "work_session_required",
+		Message:   "command requires a work session",
+		Context: map[string]string{
+			"required_scope": "command",
+		},
+		NextActions: []string{"alpacon work-session use <ID>"},
+	})
+
+	assert.JSONEq(t, `{
+		"ok": false,
+		"exit_code": 3,
+		"error_code": "work_session_required",
+		"message": "command requires a work session",
+		"context": {"required_scope": "command"},
+		"next_actions": ["alpacon work-session use <ID>"]
+	}`, buf.String())
+}

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -1,22 +1,12 @@
 package utils
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 )
 
-type workSessionErrorJSON struct {
-	OK          bool                `json:"ok"`
-	ExitCode    int                 `json:"exit_code"`
-	ErrorCode   string              `json:"error_code"`
-	Message     string              `json:"message"`
-	Reason      string              `json:"reason"`
-	Context     workSessionErrorCtx `json:"context"`
-	NextActions []string            `json:"next_actions"`
-}
+type workSessionErrorJSON = JSONErrorEnvelope[workSessionErrorCtx]
 
 type workSessionErrorCtx struct {
 	AuthMethod         string   `json:"auth_method"`
@@ -50,7 +40,7 @@ func HandleWorkSessionError(err error, operation, serverName, authMethod, active
 		return
 	}
 	if OutputFormat == OutputFormatJSON {
-		fmt.Fprintln(os.Stderr, buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS))
+		PrintJSONError(os.Stderr, buildWorkSessionErrorEnvelope(code, operation, serverName, authMethod, activeWS))
 	} else {
 		fmt.Fprintln(os.Stderr, buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeWS))
 	}
@@ -84,11 +74,20 @@ func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeW
 }
 
 func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS string) string {
+	envelope := buildWorkSessionErrorEnvelope(code, operation, serverName, authMethod, activeWS)
+	rendered, err := FormatJSON(envelope)
+	if err != nil {
+		return `{"ok":false,"error_code":"` + code + `"}`
+	}
+	return rendered
+}
+
+func buildWorkSessionErrorEnvelope(code, operation, serverName, authMethod, activeWS string) workSessionErrorJSON {
 	var ws *string
 	if activeWS != "" {
 		ws = &activeWS
 	}
-	envelope := workSessionErrorJSON{
+	return workSessionErrorJSON{
 		OK:        false,
 		ExitCode:  ExitCodeWorkSessionDenied,
 		ErrorCode: code,
@@ -102,14 +101,6 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 		},
 		NextActions: workSessionNextActions(code, operation, serverName, activeWS),
 	}
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(envelope); err != nil {
-		return `{"ok":false,"error_code":"` + code + `"}`
-	}
-	return strings.TrimRight(buf.String(), "\n")
 }
 
 func targetServerList(serverName string) []string {

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -73,15 +73,6 @@ func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeW
 	return sb.String()
 }
 
-func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS string) string {
-	envelope := buildWorkSessionErrorEnvelope(code, operation, serverName, authMethod, activeWS)
-	rendered, err := FormatJSON(envelope)
-	if err != nil {
-		return `{"ok":false,"error_code":"` + code + `"}`
-	}
-	return rendered
-}
-
 func buildWorkSessionErrorEnvelope(code, operation, serverName, authMethod, activeWS string) workSessionErrorJSON {
 	var ws *string
 	if activeWS != "" {

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -96,7 +96,8 @@ func buildWorkSessionErrorEnvelope(code, operation, serverName, authMethod, acti
 
 func targetServerList(serverName string) []string {
 	if serverName == "" {
-		return nil
+		// Return an empty array (not nil) so the JSON field type stays a stable array.
+		return []string{}
 	}
 	return []string{serverName}
 }

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -75,10 +74,8 @@ func TestBuildWorkSessionJSON(t *testing.T) {
 
 	for _, code := range tests {
 		t.Run(code, func(t *testing.T) {
-			got := buildWorkSessionJSON(code, "command", "srv-1", "API token", "")
+			envelope := buildWorkSessionErrorEnvelope(code, "command", "srv-1", "API token", "")
 
-			var envelope workSessionErrorJSON
-			assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
 			assert.False(t, envelope.OK)
 			assert.Equal(t, ExitCodeWorkSessionDenied, envelope.ExitCode)
 			assert.Equal(t, code, envelope.ErrorCode)
@@ -92,10 +89,8 @@ func TestBuildWorkSessionJSON(t *testing.T) {
 }
 
 func TestBuildWorkSessionJSON_WithActiveWS(t *testing.T) {
-	got := buildWorkSessionJSON(WorkSessionExpired, "webftp", "srv-2", "Browser login", "abc-123-uuid")
+	envelope := buildWorkSessionErrorEnvelope(WorkSessionExpired, "webftp", "srv-2", "Browser login", "abc-123-uuid")
 
-	var envelope workSessionErrorJSON
-	assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
 	assert.NotNil(t, envelope.Context.CurrentWorksession)
 	assert.Equal(t, "abc-123-uuid", *envelope.Context.CurrentWorksession)
 	// Expired case: <ID> placeholder must be substituted with the known active UUID.
@@ -107,20 +102,16 @@ func TestBuildWorkSessionJSON_WithActiveWS(t *testing.T) {
 
 func TestBuildWorkSessionJSON_ExpiredWithoutActiveWS(t *testing.T) {
 	// When activeWS is unknown, the placeholder must remain.
-	got := buildWorkSessionJSON(WorkSessionExpired, "webftp", "srv-2", "Browser login", "")
+	envelope := buildWorkSessionErrorEnvelope(WorkSessionExpired, "webftp", "srv-2", "Browser login", "")
 
-	var envelope workSessionErrorJSON
-	assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
 	assert.Contains(t, envelope.NextActions, "alpacon work-session extend <ID>")
 }
 
 func TestBuildWorkSessionJSON_RequiredKeepsPlaceholder(t *testing.T) {
 	// For work_session_required, activeWS is unrelated to the suggested `use <ID>`,
 	// so the placeholder must NOT be substituted even when activeWS is known.
-	got := buildWorkSessionJSON(WorkSessionRequired, "command", "srv-1", "Browser login", "abc-123-uuid")
+	envelope := buildWorkSessionErrorEnvelope(WorkSessionRequired, "command", "srv-1", "Browser login", "abc-123-uuid")
 
-	var envelope workSessionErrorJSON
-	assert.NoError(t, json.Unmarshal([]byte(got), &envelope))
 	assert.Contains(t, envelope.NextActions, "alpacon work-session use <ID>")
 }
 

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -61,7 +61,7 @@ func TestBuildWorkSessionDiagnostic_APIToken(t *testing.T) {
 	assert.NotContains(t, got, "(interactive)")
 }
 
-func TestBuildWorkSessionJSON(t *testing.T) {
+func TestBuildWorkSessionErrorEnvelope(t *testing.T) {
 	tests := []string{
 		WorkSessionRequired,
 		WorkSessionNotActive,
@@ -88,7 +88,7 @@ func TestBuildWorkSessionJSON(t *testing.T) {
 	}
 }
 
-func TestBuildWorkSessionJSON_WithActiveWS(t *testing.T) {
+func TestBuildWorkSessionErrorEnvelope_WithActiveWS(t *testing.T) {
 	envelope := buildWorkSessionErrorEnvelope(WorkSessionExpired, "webftp", "srv-2", "Browser login", "abc-123-uuid")
 
 	assert.NotNil(t, envelope.Context.CurrentWorksession)
@@ -100,14 +100,14 @@ func TestBuildWorkSessionJSON_WithActiveWS(t *testing.T) {
 	}
 }
 
-func TestBuildWorkSessionJSON_ExpiredWithoutActiveWS(t *testing.T) {
+func TestBuildWorkSessionErrorEnvelope_ExpiredWithoutActiveWS(t *testing.T) {
 	// When activeWS is unknown, the placeholder must remain.
 	envelope := buildWorkSessionErrorEnvelope(WorkSessionExpired, "webftp", "srv-2", "Browser login", "")
 
 	assert.Contains(t, envelope.NextActions, "alpacon work-session extend <ID>")
 }
 
-func TestBuildWorkSessionJSON_RequiredKeepsPlaceholder(t *testing.T) {
+func TestBuildWorkSessionErrorEnvelope_RequiredKeepsPlaceholder(t *testing.T) {
 	// For work_session_required, activeWS is unrelated to the suggested `use <ID>`,
 	// so the placeholder must NOT be substituted even when activeWS is known.
 	envelope := buildWorkSessionErrorEnvelope(WorkSessionRequired, "command", "srv-1", "Browser login", "abc-123-uuid")


### PR DESCRIPTION
## Overview

Makes the WorkSession security gate machine-readable so AI agents and CI/CD pipelines can understand denials and self-recover. Human-facing output is preserved; this adds canonical JSON fields plus stable `error_code`/exit-code signals.

## Background

Until now the CLI only emitted human-readable output, so when an agent hit the gate it had to:
- guess the error type by **matching message strings** (brittle),
- with no machine-readable way to know *why* it was blocked or *what to do next*,
- and could not distinguish a gate denial from a generic error by exit code.

## What changed (before → after)

### 1. Preserve API error code/source — `client/client.go`, `utils/error.go`
- **before:** even when the server returned a code like `work_session_required`, the CLI flattened it into a human string and the code was lost.
- **after:** introduced an `apiError{message, code, source}` type so `parseAPIError` preserves the server's `code`/`source` end-to-end. A `codedError` interface short-circuits when code/source are present, and falls back to legacy string parsing otherwise (backward compatible).

### 2. Structured JSON error envelope — `utils/output.go`, `utils/worksession_error.go`
- **before:** gate denials were printed as plain text on stderr, and each domain hand-rolled its own marshaller.
- **after:** added a generic `JSONErrorEnvelope[T]` plus `FormatJSON`/`PrintJSONValue`/`PrintJSONError[T]`. Errors now share one shape — `{ok, exit_code, error_code, message, reason, context, next_actions}` — and the hand-rolled WorkSession marshaller was removed (less duplication). Falls back to `{"ok":false,"error_code":...}` if marshalling fails.

### 3. Structured output for WorkSession mutations — `cmd/worksession/worksession_output.go` (new), `create`/`use`/`extend`
- **before:** create/use/extend results were mostly human-readable messages, awkward to parse.
- **after:** `work_session_id`, `status`, `expires_at`, and `approval_request_id` are promoted to **top-level flat fields**, with the full object also nested under `work_session`. `pollForApproval` now returns the active session object.

### 4. WorkSession-aware whoami fields — `cmd/whoami.go`
- **before:** the auth method was only a human string (`"Browser login"`), so a machine couldn't tell whether a WorkSession was required or active.
- **after:** added canonical fields `auth_classification` (enum), `worksession_required_for_access`, and `active_worksession`. `MarshalJSON`/`normalized()` keep them in sync with the legacy keys (`auth_method`, `work_session_required`, `active_work_session`), so existing scripts are not broken.

### 5. Stable exit codes
- **before:** gate denials were mixed in with generic errors (exit 1).
- **after:** gate denial = `3` (`ExitCodeWorkSessionDenied`), success = `0`. `--output json` emits `[]` for empty results consistently.

## Tests

`client_test`, `whoami_test`, `worksession_output_test` (+307), `cmd/exec/worksession_command_test` (gate diagnostics, +134), `output_test`, `worksession_error_test`. Build passes (`go build -o alpacon .`).

## Compatibility

- whoami emits **both** legacy and canonical keys → non-breaking for existing consumers.
- Exit-code contract `0/1/2/3` preserved (see README "Exit codes").

**Size:** 8 commits · 15 files · +913 / −116
