### PR TITLE
feat(worksession): make the session workflow agent-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ $ alpacon work-session create \
     --purpose "describe the task" \
     --scope command,websh \
     --server <server> \
+    --expires-in 1h \
     --use --wait
 
 # 4. Operate within the session.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,10 @@ $ alpacon tunnel prod-k8s -l 6443 -r 6443 -- kubectl --server=https://127.0.0.1:
 
 ### Work sessions
 ```bash
-$ alpacon work-session ls
+$ alpacon work-session ls                          # my active sessions (default)
+$ alpacon work-session ls --status all             # my sessions in any status
+$ alpacon work-session ls --user all               # everyone's active sessions
+$ alpacon work-session ls --user all --status all  # all sessions
 $ alpacon work-session current
 $ alpacon work-session use <session-id>          # set active session
 $ alpacon work-session use --unset

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -13,13 +13,16 @@ import (
 
 const workSessionURL = "/api/work-sessions/sessions/"
 
-func GetWorkSessionList(ac *client.AlpaconClient, status, requesterType string) ([]WorkSessionAttributes, error) {
+func GetWorkSessionList(ac *client.AlpaconClient, status, requesterType, assignedUser string) ([]WorkSessionAttributes, error) {
 	params := map[string]string{}
 	if status != "" {
 		params["status"] = status
 	}
 	if requesterType != "" {
 		params["requester_type"] = requesterType
+	}
+	if assignedUser != "" {
+		params["assigned_user"] = assignedUser
 	}
 
 	sessions, err := api.FetchAllPages[WorkSession](ac, workSessionURL, params)

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -42,7 +42,7 @@ func TestGetWorkSessionList(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	list, err := GetWorkSessionList(newTestClient(ts), "", "")
+	list, err := GetWorkSessionList(newTestClient(ts), "", "", "")
 	assert.NoError(t, err)
 	assert.Len(t, list, 1)
 	assert.Equal(t, "ses-1", list[0].ID)
@@ -59,7 +59,19 @@ func TestGetWorkSessionList_StatusFilter(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := GetWorkSessionList(newTestClient(ts), "pending", "")
+	_, err := GetWorkSessionList(newTestClient(ts), "pending", "", "")
+	assert.NoError(t, err)
+}
+
+func TestGetWorkSessionList_AssignedUserFilter(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "6eaa827d-616a-4fa9-ad42-4fbb67bb007b", r.URL.Query().Get("assigned_user"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[WorkSession]{Count: 0, Results: nil})
+	}))
+	defer ts.Close()
+
+	_, err := GetWorkSessionList(newTestClient(ts), "", "", "6eaa827d-616a-4fa9-ad42-4fbb67bb007b")
 	assert.NoError(t, err)
 }
 
@@ -161,7 +173,7 @@ func TestGetWorkSessionList_RequesterTypeFilter(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := GetWorkSessionList(newTestClient(ts), "", "agent")
+	_, err := GetWorkSessionList(newTestClient(ts), "", "agent", "")
 	assert.NoError(t, err)
 }
 
@@ -176,7 +188,7 @@ func TestGetWorkSessionList_ScopesJoined(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	list, err := GetWorkSessionList(newTestClient(ts), "", "")
+	list, err := GetWorkSessionList(newTestClient(ts), "", "", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "command, websh, webftp", list[0].Scopes)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -100,33 +100,34 @@ func getUserPrivileges(isStaff, isSuperuser bool) string {
 func checkAuthStatus(statusCode int, body []byte) error {
 	switch statusCode {
 	case http.StatusUnauthorized:
-		if msg, code, source, ok := parseAuthStatusErrorPayload(body); ok {
-			return newAPIError(fmt.Sprintf("%s (run 'alpacon login' if your session has expired)", msg), code, source)
+		msg, code, source, ok := parseAuthStatusErrorPayload(body)
+		if !ok {
+			return newAPIError("authentication failed: please run 'alpacon login' again", code, source)
 		}
-		return errors.New("authentication failed: please run 'alpacon login' again")
+		return newAPIError(fmt.Sprintf("%s (run 'alpacon login' if your session has expired)", msg), code, source)
 	case http.StatusForbidden:
-		if msg, code, source, ok := parseAuthStatusErrorPayload(body); ok {
-			return newAPIError(msg, code, source)
+		msg, code, source, ok := parseAuthStatusErrorPayload(body)
+		if !ok {
+			return newAPIError("permission denied: you do not have the required privileges for this action", code, source)
 		}
-		return errors.New("permission denied: you do not have the required privileges for this action")
+		return newAPIError(msg, code, source)
 	}
 	return nil
 }
 
+// parseAuthStatusErrorPayload returns ok=true only with a clean "detail" message;
+// code/source are returned regardless so the WorkSession gate can route to exit 3.
 func parseAuthStatusErrorPayload(body []byte) (message string, code string, source string, ok bool) {
 	message, code, source, ok = parseAPIErrorPayload(body)
 	if !ok || message == "" {
-		return "", "", "", false
+		return "", code, source, false
 	}
-	// Require a non-empty "detail" so 401/403 responses surface a clean server
-	// message (while still preserving code/source) instead of the truncated
-	// raw-body fallback parseAPIErrorPayload returns when only code/source exist.
 	var parsed map[string]any
 	if err := json.Unmarshal(body, &parsed); err != nil {
-		return "", "", "", false
+		return "", code, source, false
 	}
 	if stringField(parsed, "detail") == "" {
-		return "", "", "", false
+		return "", code, source, false
 	}
 	return message, code, source, true
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -121,19 +121,22 @@ func TestSendRequest_403EmptyDetailFallsBackToGenericMessage(t *testing.T) {
 	assert.NotContains(t, err.Error(), "detail:")
 }
 
-func TestSendRequest_403CodeWithoutDetailFallsBackToGenericMessage(t *testing.T) {
+func TestSendRequest_403CodeWithoutDetailKeepsCodeSource(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"code": "some_code", "source": "command"}`))
+		_, _ = w.Write([]byte(`{"code": "work_session_required", "source": "command"}`))
 	}))
 	defer ts.Close()
 
 	ac := newTestClient(ts.URL)
 	_, err := ac.SendGetRequest("/api/test/")
-	// No "detail" -> must not leak the raw JSON body as the message.
+	// Detail-less denial: generic message, but code/source must survive for exit-3 routing.
 	assert.ErrorContains(t, err, "permission denied")
-	assert.NotContains(t, err.Error(), "some_code")
+	assert.NotContains(t, err.Error(), "work_session_required")
+	code, source := utils.ParseErrorResponse(err)
+	assert.Equal(t, utils.WorkSessionRequired, code)
+	assert.Equal(t, "command", source)
 }
 
 func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ Quick start (for humans and AI agents):
        --purpose "<what you're doing>" \    #   (prints a SESSION_ID)
        --scope command,websh \              #   (scopes: command, editor, sudo, tunnel, webftp, websh)
        --server <SERVER> \
+       --expires-in 1h \                    #   (required non-interactively; or --expires-at <RFC3339>)
        --use --wait
   3. alpacon exec <SERVER> -- <COMMAND>     # run work inside the session
   4. alpacon work-session complete <SESSION_ID>  # finish the session when done

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,10 +47,10 @@ Quick start (for humans and AI agents):
   2. alpacon work-session create \          # open + activate a scoped session
        --purpose "<what you're doing>" \    #   (prints a SESSION_ID)
        --scope command,websh \              #   (scopes: command, editor, sudo, tunnel, webftp, websh)
-       --server <server> \
+       --server <SERVER> \
        --use --wait
-  3. alpacon exec <server> -- <command>     # run work inside the session
-  4. alpacon work-session complete <id>     # finish the session when done
+  3. alpacon exec <SERVER> -- <COMMAND>     # run work inside the session
+  4. alpacon work-session complete <SESSION_ID>  # finish the session when done
 
 See 'alpacon work-session --help' for session lifecycle and error codes.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,34 +39,20 @@ var RootCmd = &cobra.Command{
 	Aliases: []string{"ac"},
 	Short:   "Command-line client for Alpacon, the AI-native PAM",
 	Long: `Alpacon CLI is the command-line client for Alpacon, the AI-native PAM.
-With Alpacon, humans, AI agents, and CI/CD pipelines reach and operate
-your entire fleet through a single identity—and every command they run
-is judged at runtime, recorded, and bounded by a scoped work session.
-If a credential leaks or an AI client is compromised, the damage is
-bounded by the session, not by what the credential could touch.
+Humans, AI agents, and CI/CD run commands—each judged, recorded, and bounded.
 
-Quick start (interactive auth):
+Quick start (for humans and AI agents):
 
-  1. alpacon                                # check current login + workspace
-                                            # (run 'alpacon login' or
-                                            #  'alpacon workspace switch' if
-                                            #  not logged in / wrong place)
-  2. alpacon whoami                         # confirm identity + work
-                                            # session requirement
-  3. alpacon work-session create \          # create + activate a session
-       --purpose "describe the task" \
-       --scope command,websh \
+  1. alpacon server ls                      # find the server to target
+  2. alpacon work-session create \          # open + activate a scoped session
+       --purpose "<what you're doing>" \    #   (prints a SESSION_ID)
+       --scope command,websh \              #   (scopes: command, editor, sudo, tunnel, webftp, websh)
        --server <server> \
        --use --wait
-  4. alpacon exec, websh, cp, tunnel        # operate within the session
+  3. alpacon exec <server> -- <command>     # run work inside the session
+  4. alpacon work-session complete <id>     # finish the session when done
 
-Token auth (CI/CD, API automation):
-
-  alpacon login -t <token>                  # work session not required
-  alpacon exec ...
-
-See 'alpacon work-session --help' for session lifecycle, gating, and
-common error codes.`,
+See 'alpacon work-session --help' for session lifecycle and error codes.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		switch utils.OutputFormat {
 		case utils.OutputFormatTable, utils.OutputFormatJSON:

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -9,6 +9,7 @@ import (
 var (
 	statusFilter    string
 	requesterFilter string
+	userFilter      string
 )
 
 var WorkSessionCmd = &cobra.Command{

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -188,14 +188,15 @@ session with 'alpacon work-session update <id> --sudo "<command>"'.`,
 		// the --wait branch below (or exit immediately when --wait is not set).
 		switch decideUseAction(session.Status, useAfterCreate) {
 		case useDecisionUseNow:
-			desc, err := RunUse(ac, session.ID)
+			// Re-fetch so the serialized JSON matches the --wait --use path.
+			activeSession, err := RunUseSession(ac, session.ID)
 			if err != nil {
 				utils.CliErrorWithExit("Work session created (%s) but failed to set as active: %s. Run 'alpacon work-session use %s' to retry.", session.ID, err, session.ID)
 			}
-			message := activeWorkSessionSetMessage("", session.ID, desc)
+			message := activeWorkSessionSetMessage("", activeSession.ID, activeSession.Description)
 			if utils.OutputFormat == utils.OutputFormatJSON {
-				active := session.ID
-				printWorkSessionMutationJSON(newWorkSessionMutationOutput("create", createSuccessMessage(session)+". "+message, session, &active))
+				active := activeSession.ID
+				printWorkSessionMutationJSON(newWorkSessionMutationOutput("create", createSuccessMessage(session)+". "+message, activeSession, &active))
 				return
 			}
 			utils.CliSuccess("%s", message)

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -52,6 +52,9 @@ var workSessionCreateCmd = &cobra.Command{
 	Short: "Create a new work session",
 	Long: `Create a new work session.
 
+Set the session lifetime with --expires-in (relative, e.g. 2h) or --expires-at
+(absolute RFC3339); one is required in non-interactive mode.
+
 Pass --use to set the new session as the workspace's active session, so subsequent
 exec/websh/cp/tunnel commands attach to it without --work-session. When approval is
 required, combine --use with --wait. The session is attached once it reaches the
@@ -63,11 +66,11 @@ running 'exec') can run those exact sudo commands without an interactive MFA
 prompt. The 'sudo' scope is added automatically, and the policies are submitted for
 approval together with the session. If a sudo command is later denied, add it to the
 session with 'alpacon work-session update <id> --sudo "<command>"'.`,
-	Example: `  alpacon work-session create --purpose "nginx fix" --scope command,websh --server web-01 --expires-in 2h
-  alpacon work-session create --purpose "deploy" --scope command --server web-01,db-01 --expires-at 2027-01-15T10:00:00Z --wait
-  alpacon work-session create --purpose "hotfix" --scope command --server web-01 --expires-in 1h --use
-  alpacon work-session create --purpose "deploy" --scope command --server web-01 --expires-in 2h --wait --use
-  alpacon work-session create --purpose "nginx hotfix" --server web-01 --expires-in 2h \
+	Example: `  alpacon work-session create --scope command,websh --server web-01 --expires-in 2h --purpose "nginx fix"
+  alpacon work-session create --scope command --server web-01,db-01 --expires-at 2027-01-15T10:00:00Z --purpose "deploy" --wait
+  alpacon work-session create --scope command --server web-01 --expires-in 1h --purpose "hotfix" --use
+  alpacon work-session create --scope command --server web-01 --expires-in 2h --purpose "deploy" --wait --use
+  alpacon work-session create --server web-01 --expires-in 2h --purpose "nginx hotfix" \
     --sudo "systemctl restart nginx,systemctl reload nginx" --sudo "tail -f /var/log/nginx/*.log"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		purpose = strings.TrimSpace(purpose)
@@ -380,7 +383,7 @@ func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) erro
 }
 
 func init() {
-	workSessionCreateCmd.Flags().StringVar(&purpose, "purpose", "", "Session purpose")
+	workSessionCreateCmd.Flags().StringVar(&purpose, "purpose", "", "Session purpose (required in non-interactive mode)")
 	workSessionCreateCmd.Flags().StringSliceVar(&createScopes, "scope", nil, "Scopes to request. Valid: command, editor, sudo, tunnel, webftp, websh (repeatable; comma-separated values also accepted)")
 	workSessionCreateCmd.Flags().StringSliceVar(&createServers, "server", nil, "Target server names (repeatable; comma-separated values also accepted)")
 	workSessionCreateCmd.Flags().StringVar(&expiresIn, "expires-in", "", "Session duration (e.g. 1h, 2h, 4h)")

--- a/cmd/worksession/worksession_list.go
+++ b/cmd/worksession/worksession_list.go
@@ -1,12 +1,38 @@
 package worksession
 
 import (
+	"strings"
+
+	"github.com/alpacax/alpacon-cli/api/iam"
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
+
+// resolveStatusFilter maps the --status flag to the API value. "all"
+// (case-insensitive) clears the filter; any other value passes through.
+func resolveStatusFilter(status string) string {
+	if strings.EqualFold(status, "all") {
+		return ""
+	}
+	return status
+}
+
+// resolveAssignedUser maps the --user flag to the assigned_user API value.
+// "all" (case-insensitive) lists everyone; empty resolves to the current user
+// via getCurrentUserID; any other value (a uuid) passes through.
+func resolveAssignedUser(user string, getCurrentUserID func() (string, error)) (string, error) {
+	switch {
+	case strings.EqualFold(user, "all"):
+		return "", nil
+	case user == "":
+		return getCurrentUserID()
+	default:
+		return user, nil
+	}
+}
 
 // MarkActive decorates the row whose ID matches activeUUID with a "*" marker
 // in its Active column. No-op when activeUUID is empty or no row matches.
@@ -26,9 +52,12 @@ var workSessionListCmd = &cobra.Command{
 	Use:     "ls",
 	Aliases: []string{"list"},
 	Short:   "List work sessions",
-	Example: `  alpacon work-session ls
-  alpacon work-session ls --status active
-  alpacon work-session ls --requester-type agent`,
+	Example: `  alpacon work-session ls                          # my active sessions (default)
+  alpacon work-session ls --status all             # my sessions in any status
+  alpacon work-session ls --user all               # everyone's active sessions
+  alpacon work-session ls --user all --status all  # all sessions
+  alpacon work-session ls --requester-type agent
+  alpacon work-session ls --user 1a2b3c4d-... --status active`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if requesterFilter != "" && requesterFilter != "user" && requesterFilter != "agent" {
 			utils.CliErrorWithExit("Invalid --requester-type %q: must be \"user\" or \"agent\".", requesterFilter)
@@ -39,7 +68,20 @@ var workSessionListCmd = &cobra.Command{
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		sessions, err := wsapi.GetWorkSessionList(ac, statusFilter, requesterFilter)
+		status := resolveStatusFilter(statusFilter)
+
+		assignedUser, err := resolveAssignedUser(userFilter, func() (string, error) {
+			currentUser, err := iam.GetCurrentUser(ac)
+			if err != nil {
+				return "", err
+			}
+			return currentUser.ID, nil
+		})
+		if err != nil {
+			utils.CliErrorWithExit("Failed to resolve current user: %s.", err)
+		}
+
+		sessions, err := wsapi.GetWorkSessionList(ac, status, requesterFilter, assignedUser)
 		if err != nil {
 			utils.CliErrorWithExit("Failed to retrieve work sessions: %s.", err)
 		}
@@ -53,6 +95,7 @@ var workSessionListCmd = &cobra.Command{
 }
 
 func init() {
-	workSessionListCmd.Flags().StringVar(&statusFilter, "status", "", "Filter by status (pending, approved, active, completed, rejected, expired, revoked)")
+	workSessionListCmd.Flags().StringVar(&statusFilter, "status", "active", "Filter by status (pending, approved, active, completed, rejected, expired, revoked); use \"all\" for any status")
 	workSessionListCmd.Flags().StringVar(&requesterFilter, "requester-type", "", "Filter by requester type (user, agent)")
+	workSessionListCmd.Flags().StringVar(&userFilter, "user", "", "Filter by assigned user: default is self, \"all\" for everyone, or a user uuid")
 }

--- a/cmd/worksession/worksession_list.go
+++ b/cmd/worksession/worksession_list.go
@@ -57,7 +57,7 @@ var workSessionListCmd = &cobra.Command{
   alpacon work-session ls --user all               # everyone's active sessions
   alpacon work-session ls --user all --status all  # all sessions
   alpacon work-session ls --requester-type agent
-  alpacon work-session ls --user 1a2b3c4d-... --status active`,
+  alpacon work-session ls --user <USER_ID> --status active`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if requesterFilter != "" && requesterFilter != "user" && requesterFilter != "agent" {
 			utils.CliErrorWithExit("Invalid --requester-type %q: must be \"user\" or \"agent\".", requesterFilter)

--- a/cmd/worksession/worksession_list.go
+++ b/cmd/worksession/worksession_list.go
@@ -14,6 +14,7 @@ import (
 // resolveStatusFilter maps the --status flag to the API value. "all"
 // (case-insensitive) clears the filter; any other value passes through.
 func resolveStatusFilter(status string) string {
+	status = strings.TrimSpace(status)
 	if strings.EqualFold(status, "all") {
 		return ""
 	}
@@ -24,6 +25,7 @@ func resolveStatusFilter(status string) string {
 // "all" (case-insensitive) lists everyone; empty resolves to the current user
 // via getCurrentUserID; any other value (a uuid) passes through.
 func resolveAssignedUser(user string, getCurrentUserID func() (string, error)) (string, error) {
+	user = strings.TrimSpace(user)
 	switch {
 	case strings.EqualFold(user, "all"):
 		return "", nil

--- a/cmd/worksession/worksession_list_filter_test.go
+++ b/cmd/worksession/worksession_list_filter_test.go
@@ -1,0 +1,70 @@
+package worksession
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveStatusFilter(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"all clears filter", "all", ""},
+		{"all is case-insensitive", "ALL", ""},
+		{"active passes through", "active", "active"},
+		{"comma multi-value passes through", "active,completed", "active,completed"},
+		{"empty passes through", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveStatusFilter(tt.input))
+		})
+	}
+}
+
+func TestResolveAssignedUser(t *testing.T) {
+	const myID = "6eaa827d-616a-4fa9-ad42-4fbb67bb007b"
+
+	t.Run("all lists everyone without resolving current user", func(t *testing.T) {
+		calls := 0
+		got, err := resolveAssignedUser("all", func() (string, error) { calls++; return myID, nil })
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+		assert.Equal(t, 0, calls, "current user must not be resolved for --user all")
+	})
+
+	t.Run("all is case-insensitive", func(t *testing.T) {
+		calls := 0
+		got, err := resolveAssignedUser("ALL", func() (string, error) { calls++; return myID, nil })
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+		assert.Equal(t, 0, calls)
+	})
+
+	t.Run("empty resolves to current user", func(t *testing.T) {
+		calls := 0
+		got, err := resolveAssignedUser("", func() (string, error) { calls++; return myID, nil })
+		require.NoError(t, err)
+		assert.Equal(t, myID, got)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("uuid passes through without resolving current user", func(t *testing.T) {
+		calls := 0
+		got, err := resolveAssignedUser(myID, func() (string, error) { calls++; return "other", nil })
+		require.NoError(t, err)
+		assert.Equal(t, myID, got)
+		assert.Equal(t, 0, calls)
+	})
+
+	t.Run("current user resolution error propagates", func(t *testing.T) {
+		got, err := resolveAssignedUser("", func() (string, error) { return "", errors.New("boom") })
+		require.Error(t, err)
+		assert.Equal(t, "", got)
+	})
+}

--- a/cmd/worksession/worksession_list_filter_test.go
+++ b/cmd/worksession/worksession_list_filter_test.go
@@ -19,6 +19,9 @@ func TestResolveStatusFilter(t *testing.T) {
 		{"active passes through", "active", "active"},
 		{"comma multi-value passes through", "active,completed", "active,completed"},
 		{"empty passes through", "", ""},
+		{"surrounding whitespace trimmed", " active ", "active"},
+		{"whitespace around all still clears", " all ", ""},
+		{"whitespace-only becomes empty", "   ", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -60,6 +63,20 @@ func TestResolveAssignedUser(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, myID, got)
 		assert.Equal(t, 0, calls)
+	})
+
+	t.Run("surrounding whitespace trimmed off uuid", func(t *testing.T) {
+		got, err := resolveAssignedUser("  "+myID+"  ", func() (string, error) { return "other", nil })
+		require.NoError(t, err)
+		assert.Equal(t, myID, got)
+	})
+
+	t.Run("whitespace-only resolves to current user", func(t *testing.T) {
+		calls := 0
+		got, err := resolveAssignedUser("   ", func() (string, error) { calls++; return myID, nil })
+		require.NoError(t, err)
+		assert.Equal(t, myID, got)
+		assert.Equal(t, 1, calls, "blank input must be treated as empty (self)")
 	})
 
 	t.Run("current user resolution error propagates", func(t *testing.T) {

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -104,16 +104,18 @@ func targetServerList(serverName string) []string {
 
 func workSessionNextActions(code, operation, serverName, activeWS string) []string {
 	createCmd := fmt.Sprintf(
-		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>"`,
+		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>" --use`,
 		operation, serverName,
 	)
+	// createOrReuse leads with create-and-attach, then the reuse path.
+	createOrReuse := []string{
+		createCmd + "  # create a new session and attach it",
+		"alpacon work-session ls --status active  # or reuse an existing active session",
+		"alpacon work-session use <ID>",
+	}
 	switch code {
 	case WorkSessionRequired:
-		return []string{
-			"alpacon work-session ls --status active",
-			"alpacon work-session use <ID>",
-			createCmd,
-		}
+		return createOrReuse
 	case WorkSessionNotActive:
 		return []string{"alpacon work-session current"}
 	case WorkSessionExpired:
@@ -125,10 +127,7 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	case WorkSessionAssigneeMismatch:
 		return []string{"alpacon work-session use <ID>"}
 	case WorkSessionNotUsable:
-		return []string{
-			"alpacon work-session ls",
-			createCmd,
-		}
+		return createOrReuse
 	default: // scope_not_allowed, server_not_allowed
 		return []string{createCmd}
 	}

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -103,9 +103,14 @@ func targetServerList(serverName string) []string {
 }
 
 func workSessionNextActions(code, operation, serverName, activeWS string) []string {
+	serverArg := serverName
+	if serverArg == "" {
+		// Some call sites have no target server (e.g. exec logs); keep the suggestion runnable.
+		serverArg = "<SERVER>"
+	}
 	createCmd := fmt.Sprintf(
 		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>" --use`,
-		operation, serverName,
+		operation, serverArg,
 	)
 	// createOrReuse leads with create-and-attach, then the reuse path.
 	createOrReuse := []string{

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -65,7 +65,7 @@ func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeW
 	}
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "%s: %s requires an active WorkSession on this authentication.\n", Red("Error"), operation)
+	fmt.Fprintf(&sb, "%s: the %s operation requires an active WorkSession on this authentication.\n", Red("Error"), operation)
 	fmt.Fprintln(&sb)
 	fmt.Fprintf(&sb, "  %-14s: %s\n", "auth", authDisplay)
 	fmt.Fprintf(&sb, "  %-14s: %s\n", "reason", reason)
@@ -92,7 +92,7 @@ func buildWorkSessionJSON(code, operation, serverName, authMethod, activeWS stri
 		OK:        false,
 		ExitCode:  ExitCodeWorkSessionDenied,
 		ErrorCode: code,
-		Message:   fmt.Sprintf("%s requires an active WorkSession on this authentication.", operation),
+		Message:   fmt.Sprintf("the %s operation requires an active WorkSession on this authentication.", operation),
 		Reason:    workSessionReasonMap[code],
 		Context: workSessionErrorCtx{
 			AuthMethod:         authMethod,
@@ -121,7 +121,7 @@ func targetServerList(serverName string) []string {
 
 func workSessionNextActions(code, operation, serverName, activeWS string) []string {
 	createCmd := fmt.Sprintf(
-		`alpacon work-session create --scope %s --server %s --purpose "<intent>"`,
+		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>"`,
 		operation, serverName,
 	)
 	switch code {

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,18 +30,19 @@ func TestIsWorkSessionCode(t *testing.T) {
 
 func TestBuildWorkSessionDiagnostic(t *testing.T) {
 	tests := []struct {
-		code       string
-		wantReason string
-		wantNext   string
-		hasCreate  bool // suggests 'work-session create', which must carry an expiry flag
+		code          string
+		wantReason    string
+		wantNext      string
+		hasCreate     bool // suggests 'create --use', which must carry an expiry flag
+		reuseVsCreate bool // distinguishes reuse (use) vs create-and-attach paths
 	}{
-		{WorkSessionRequired, "no WorkSession selected", "work-session ls", true},
-		{WorkSessionNotActive, "not yet active", "work-session current", false},
-		{WorkSessionExpired, "has expired", "work-session extend", true},
-		{WorkSessionScopeNotAllowed, "does not include this scope", "work-session create", true},
-		{WorkSessionServerNotAllowed, "target server is not in this session", "work-session create", true},
-		{WorkSessionAssigneeMismatch, "assigned to another principal", "work-session use", false},
-		{WorkSessionNotUsable, "no longer usable", "work-session create", true},
+		{WorkSessionRequired, "no WorkSession selected", "work-session ls", true, true},
+		{WorkSessionNotActive, "not yet active", "work-session current", false, false},
+		{WorkSessionExpired, "has expired", "work-session extend", true, false},
+		{WorkSessionScopeNotAllowed, "does not include this scope", "work-session create", true, false},
+		{WorkSessionServerNotAllowed, "target server is not in this session", "work-session create", true, false},
+		{WorkSessionAssigneeMismatch, "assigned to another principal", "work-session use", false, false},
+		{WorkSessionNotUsable, "no longer usable", "work-session create", true, true},
 	}
 
 	for _, tt := range tests {
@@ -55,6 +57,12 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 			assert.Contains(t, got, "Note:")
 			if tt.hasCreate {
 				assert.Contains(t, got, "--expires-in")
+				assert.Contains(t, got, "--use")
+			}
+			if tt.reuseVsCreate {
+				assert.Contains(t, got, "alpacon work-session use <ID>")
+				assert.Contains(t, got, "reuse an existing")
+				assert.Contains(t, got, "create a new")
 			}
 		})
 	}
@@ -118,7 +126,8 @@ func TestBuildWorkSessionErrorEnvelope_RequiredKeepsPlaceholder(t *testing.T) {
 	// so the placeholder must NOT be substituted even when activeWS is known.
 	envelope := buildWorkSessionErrorEnvelope(WorkSessionRequired, "command", "srv-1", "Browser login", "abc-123-uuid")
 
-	assert.Contains(t, envelope.NextActions, "alpacon work-session use <ID>")
+	// The use action carries an inline comment, so match as a substring.
+	assert.Contains(t, strings.Join(envelope.NextActions, "\n"), "alpacon work-session use <ID>")
 }
 
 func TestHandleWorkSessionError_NoOp(t *testing.T) {

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -33,25 +33,30 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 		code       string
 		wantReason string
 		wantNext   string
+		hasCreate  bool // suggests 'work-session create', which must carry an expiry flag
 	}{
-		{WorkSessionRequired, "no WorkSession selected", "work-session ls"},
-		{WorkSessionNotActive, "not yet active", "work-session current"},
-		{WorkSessionExpired, "has expired", "work-session extend"},
-		{WorkSessionScopeNotAllowed, "does not include this scope", "work-session create"},
-		{WorkSessionServerNotAllowed, "target server is not in this session", "work-session create"},
-		{WorkSessionAssigneeMismatch, "assigned to another principal", "work-session use"},
-		{WorkSessionNotUsable, "no longer usable", "work-session create"},
+		{WorkSessionRequired, "no WorkSession selected", "work-session ls", true},
+		{WorkSessionNotActive, "not yet active", "work-session current", false},
+		{WorkSessionExpired, "has expired", "work-session extend", true},
+		{WorkSessionScopeNotAllowed, "does not include this scope", "work-session create", true},
+		{WorkSessionServerNotAllowed, "target server is not in this session", "work-session create", true},
+		{WorkSessionAssigneeMismatch, "assigned to another principal", "work-session use", false},
+		{WorkSessionNotUsable, "no longer usable", "work-session create", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.code, func(t *testing.T) {
 			got := buildWorkSessionDiagnostic(tt.code, "websh", "prod-1", "Browser login", "")
+			assert.Contains(t, got, "the websh operation requires an active WorkSession")
 			assert.Contains(t, got, tt.wantReason)
 			assert.Contains(t, got, tt.wantNext)
 			assert.Contains(t, got, "required scope")
 			assert.Contains(t, got, "prod-1")
 			assert.Contains(t, got, "Browser login (interactive)")
 			assert.Contains(t, got, "Note:")
+			if tt.hasCreate {
+				assert.Contains(t, got, "--expires-in")
+			}
 		})
 	}
 }
@@ -82,6 +87,7 @@ func TestBuildWorkSessionJSON(t *testing.T) {
 			assert.False(t, envelope.OK)
 			assert.Equal(t, ExitCodeWorkSessionDenied, envelope.ExitCode)
 			assert.Equal(t, code, envelope.ErrorCode)
+			assert.Equal(t, "the command operation requires an active WorkSession on this authentication.", envelope.Message)
 			assert.Equal(t, workSessionReasonMap[code], envelope.Reason)
 			assert.Equal(t, "command", envelope.Context.RequiredScope)
 			assert.Equal(t, []string{"srv-1"}, envelope.Context.TargetServers)


### PR DESCRIPTION
## Summary

Make the work-session workflow something both humans and AI agents (Claude Code, Copilot, etc.) can follow straight from `--help`, without guessing. This tunes `work-session ls` defaults/filters to real usage, turns gate-denial output into runnable commands, and rebuilds the root quick start into a closed loop where each step's data feeds the next. It also fixes a client error-handling bug so a gate denial still routes to exit 3 even when the server omits `detail`.

## Changes

**1. `work-session ls` — add user filter, default to "my active sessions"** (`ead6f3e`)
- New `--user` flag: default is self, `all` lists everyone, a UUID targets a specific user (mapped to the `assigned_user` API param)
- `--status` now defaults to `active`; the shared `all` sentinel clears a filter
- Matches alpacon-web's default behavior (assigned_user=self, status=active)

**2. Turn gate-denial guidance into runnable commands** (`59c4336`, `409fae5`)
- Lead with a "create a new session and attach it" path, and distinguish the "reuse an existing active session" path
- Embed flags that actually work (`--expires-in 1h`, `--use`) in the suggested commands

**3. `work-session create` — surface session-lifetime options** (`698e92b`)
- Document `--expires-in` (relative) / `--expires-at` (absolute, RFC3339); note one is required in non-interactive mode
- Reorder the Example to `--scope -> --server -> --expires-in -> --purpose -> --use`

**4. Rebuild the root quick start to be agent-first** (`4064be6`)
- A closed loop: `server ls -> work-session create -> exec -> complete`, where each step's output feeds the next
- Replace the non-runnable pseudo-command (`exec, websh, cp, tunnel` list) with a real `exec <server> -- <command>`
- Compress the intro to two lines; drop the token-auth block

**5. (fix) Preserve error code/source on detail-less 401/403** (`e56d094`)
- Before: when the response had no `detail`, the message fell back to the generic text *and* dropped `code`/`source`, so a gate denial could no longer route to exit 3
- After: only the human-facing message falls back; `code`/`source` are preserved regardless of `detail`

**6. (refactor) Consistent JSON serialization in `create --use`** (`4e88f80`)
- The UseNow branch serialized the create-time object; align it with the `--wait --use` path by serializing the re-fetched session

## Motivation

When an AI agent reads only `--help` to drive the work-session flow, pseudo-commands, non-existent subcommands, and blanks it has to guess at become failure points. Every piece of guidance is now copy-paste runnable, and the machine-readable error contract (exit 3) no longer depends on whether the server includes a `detail` field.

## Testing

- `go build` / `go vet ./...` pass
- `go test ./...` all pass (including new/folded tests in `client` and `cmd/worksession`)
- New: `worksession_list_filter_test.go` (filter resolution); `TestSendRequest_403CodeWithoutDetailKeepsCodeSource` (code/source preservation)
