### PR TITLE
Enhance login with --workspace/--region flags

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -260,7 +260,8 @@ func isCloudDirectURL(workspaceURL string) bool {
 	if err != nil {
 		return false
 	}
-	host := strings.ToLower(parsed.Hostname())
+	// Normalize for case-insensitive hostnames and the trailing-dot FQDN form.
+	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
 	return host == defaultBaseDomain || strings.HasSuffix(host, "."+defaultBaseDomain)
 }
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -72,6 +72,14 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
   ALPACON_NO_BROWSER=1 alpacon login`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		// Trim cloud flag values so whitespace-only input can't bypass
+		// validateCloudFlags or assemble a broken URL like https://demo. .alpacon.io.
+		var blank bool
+		workspaceFlag, regionFlag, blank = normalizeCloudFlags(workspaceFlag, regionFlag)
+		if blank {
+			utils.CliErrorWithExit("--workspace and --region cannot be blank")
+		}
+
 		if len(args) > 0 && (workspaceFlag != "" || regionFlag != "") {
 			utils.CliErrorWithExit("Cannot combine a HOST argument with --workspace/--region. Use a HOST for self-hosted, or --workspace/--region for Alpacon Cloud")
 		}
@@ -234,6 +242,15 @@ func cloudRegionsHint() string {
 // buildCloudWorkspaceURL assembles an Alpacon Cloud workspace URL.
 func buildCloudWorkspaceURL(workspace, region string) string {
 	return fmt.Sprintf("https://%s.%s.%s", workspace, region, defaultBaseDomain)
+}
+
+// normalizeCloudFlags trims flag values and reports whether the user supplied
+// only blank (whitespace-only) values, which must be rejected rather than
+// silently treated as if no flags were passed.
+func normalizeCloudFlags(workspace, region string) (w, r string, blank bool) {
+	w, r = strings.TrimSpace(workspace), strings.TrimSpace(region)
+	blank = (workspace != "" || region != "") && w == "" && r == ""
+	return w, r, blank
 }
 
 // validateCloudFlags rejects the case where exactly one of workspace/region is set.

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -18,9 +18,8 @@ import (
 
 const defaultBaseDomain = "alpacon.io"
 
-// knownCloudRegions lists the Alpacon Cloud regions shown as a hint when a
-// user omits --region. Source of truth: 10-alpacon-web src/constants/constants.ts
-// and 06-account settings.py. Update on CLI release when a region is added.
+// knownCloudRegions are the Alpacon Cloud regions shown when --region is omitted.
+// Source: 10-alpacon-web constants.ts, 06-account settings.py. Update on release.
 var knownCloudRegions = []string{"us1", "ap1"}
 
 var (
@@ -86,12 +85,12 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 			baseDomain = utils.ExtractBaseDomain(workspaceURL)
 		} else if workspaceFlag != "" || regionFlag != "" {
 			// Alpacon Cloud mode via flags (non-interactive)
-			if msg := validateCloudFlags(workspaceFlag, regionFlag); msg != "" {
-				utils.CliErrorWithExit("%s", msg)
+			if err := validateCloudFlags(workspaceFlag, regionFlag); err != nil {
+				utils.CliErrorWithExit("%s", err.Error())
 			}
 			workspaceName = workspaceFlag
 			baseDomain = defaultBaseDomain
-			workspaceURL = fmt.Sprintf("https://%s.%s.%s", workspaceFlag, regionFlag, defaultBaseDomain)
+			workspaceURL = buildCloudWorkspaceURL(workspaceFlag, regionFlag)
 		} else {
 			// No args, no flags — try saved config for re-login
 			cfg, err := config.LoadConfig()
@@ -111,7 +110,7 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 					knownCloudRegions[0],
 				)
 				baseDomain = defaultBaseDomain
-				workspaceURL = fmt.Sprintf("https://%s.%s.%s", workspaceName, region, defaultBaseDomain)
+				workspaceURL = buildCloudWorkspaceURL(workspaceName, region)
 			}
 		}
 
@@ -224,34 +223,34 @@ func promptForCredentials(workspaceURL, username, password string) (string, stri
 	return workspaceURL, username, password
 }
 
-// cloudRegionsHint renders the known regions as a comma-separated hint.
 func cloudRegionsHint() string {
 	return strings.Join(knownCloudRegions, ", ")
 }
 
-// validateCloudFlags returns a user-facing error message when exactly one of
-// workspace/region is provided. An empty string means the input is valid
-// (both set, or both empty).
-func validateCloudFlags(workspace, region string) string {
+// buildCloudWorkspaceURL assembles an Alpacon Cloud workspace URL.
+func buildCloudWorkspaceURL(workspace, region string) string {
+	return fmt.Sprintf("https://%s.%s.%s", workspace, region, defaultBaseDomain)
+}
+
+// validateCloudFlags rejects the case where exactly one of workspace/region is set.
+func validateCloudFlags(workspace, region string) error {
 	if workspace != "" && region == "" {
-		return fmt.Sprintf(
+		return fmt.Errorf(
 			"--region is required for Alpacon Cloud.\nAvailable regions: %s\nTry: alpacon login --workspace %s --region %s",
 			cloudRegionsHint(), workspace, knownCloudRegions[0],
 		)
 	}
 	if region != "" && workspace == "" {
-		return fmt.Sprintf(
+		return fmt.Errorf(
 			"--workspace is required for Alpacon Cloud.\nTry: alpacon login --workspace <name> --region %s",
 			region,
 		)
 	}
-	return ""
+	return nil
 }
 
-// isCloudDirectURL reports whether a host-mode workspace URL points at the
-// Alpacon Cloud base domain. Such direct URLs are deprecated in favor of
-// --workspace/--region. Matches both subdomain forms (myws.us1.alpacon.io)
-// and the bare base domain (alpacon.io).
+// isCloudDirectURL reports whether a host-mode URL targets the Alpacon Cloud base
+// domain (alpacon.io or a subdomain). Such direct URLs are deprecated.
 func isCloudDirectURL(workspaceURL string) bool {
 	parsed, err := url.Parse(workspaceURL)
 	if err != nil {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -72,6 +72,10 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
   ALPACON_NO_BROWSER=1 alpacon login`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 && (workspaceFlag != "" || regionFlag != "") {
+			utils.CliErrorWithExit("Cannot combine a HOST argument with --workspace/--region. Use a HOST for self-hosted, or --workspace/--region for Alpacon Cloud")
+		}
+
 		var workspaceURL, workspaceName, baseDomain string
 
 		if len(args) > 0 {
@@ -273,7 +277,7 @@ func rejectURLWithPath(host string) {
 		return
 	}
 	if p := strings.TrimSuffix(parsed.Path, "/"); p != "" {
-		utils.CliErrorWithExit("URL paths are not supported. Use 'alpacon login --workspace <name> --region <region>' instead")
+		utils.CliErrorWithExit("URL paths are not supported. For Alpacon Cloud use 'alpacon login --workspace <name> --region <region>'; for self-hosted pass the host without a path (e.g. 'alpacon login alpacon.example.com')")
 	}
 }
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -18,6 +18,11 @@ import (
 
 const defaultBaseDomain = "alpacon.io"
 
+// knownCloudRegions lists the Alpacon Cloud regions shown as a hint when a
+// user omits --region. Source of truth: 10-alpacon-web src/constants/constants.ts
+// and 06-account settings.py. Update on CLI release when a region is added.
+var knownCloudRegions = []string{"us1", "ap1"}
+
 var (
 	insecure      bool
 	noBrowser     bool
@@ -48,17 +53,17 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
   # Alpacon Cloud login (non-interactive, for CI/CD or AI agents)
   alpacon login --workspace myworkspace --region us1
 
+  # Alpacon Cloud login with an API token
+  alpacon login --workspace myworkspace --region us1 -t <api-token>
+
   # Self-hosted
   alpacon login alpacon.example.com
 
-  # Direct API URL
-  alpacon login myworkspace.us1.alpacon.io
+  # Self-hosted with an API token
+  alpacon login alpacon.example.com -t <api-token>
 
-  # API token login
-  alpacon login myworkspace.us1.alpacon.io -t <api-token>
-
-  # Username and password
-  alpacon login myworkspace.us1.alpacon.io -u admin -p mypassword
+  # Self-hosted with username and password
+  alpacon login alpacon.example.com -u admin -p mypassword
 
   # Self-signed certificates
   alpacon login alpacon.example.com --insecure
@@ -71,13 +76,19 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 		var workspaceURL, workspaceName, baseDomain string
 
 		if len(args) > 0 {
-			// Host mode: self-hosted or direct API URL
+			// Host mode: self-hosted only. Cloud direct URLs are deprecated.
 			rejectURLWithPath(args[0])
 			workspaceURL = formatHostURL(args[0])
+			if isCloudDirectURL(workspaceURL) {
+				utils.CliErrorWithExit("Direct URLs are not supported for Alpacon Cloud. Use 'alpacon login --workspace <name> --region <region>' instead")
+			}
 			workspaceName = utils.ExtractWorkspaceName(workspaceURL)
 			baseDomain = utils.ExtractBaseDomain(workspaceURL)
 		} else if workspaceFlag != "" || regionFlag != "" {
 			// Alpacon Cloud mode via flags (non-interactive)
+			if msg := validateCloudFlags(workspaceFlag, regionFlag); msg != "" {
+				utils.CliErrorWithExit("%s", msg)
+			}
 			workspaceName = workspaceFlag
 			baseDomain = defaultBaseDomain
 			workspaceURL = fmt.Sprintf("https://%s.%s.%s", workspaceFlag, regionFlag, defaultBaseDomain)
@@ -94,8 +105,11 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 				utils.CliInfo("Using saved workspace: %s", workspaceURL)
 			} else {
 				// Interactive Alpacon Cloud prompts
-				workspaceName = utils.PromptForRequiredInput("Workspace: ")
-				region := utils.PromptForInputWithDefault("Region (default: us1): ", "us1")
+				workspaceName = utils.PromptForRequiredInput("Workspace name: ")
+				region := utils.PromptForInputWithDefault(
+					fmt.Sprintf("Region [%s] (%s): ", knownCloudRegions[0], cloudRegionsHint()),
+					knownCloudRegions[0],
+				)
 				baseDomain = defaultBaseDomain
 				workspaceURL = fmt.Sprintf("https://%s.%s.%s", workspaceName, region, defaultBaseDomain)
 			}
@@ -188,7 +202,6 @@ func init() {
 	loginCmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Do not open the browser automatically")
 	loginCmd.Flags().StringVar(&workspaceFlag, "workspace", "", "Workspace name for Alpacon Cloud login")
 	loginCmd.Flags().StringVar(&regionFlag, "region", "", "Region for Alpacon Cloud login (e.g., us1, ap1)")
-	loginCmd.MarkFlagsRequiredTogether("workspace", "region")
 }
 
 func promptForCredentials(workspaceURL, username, password string) (string, string, string) {
@@ -209,6 +222,43 @@ func promptForCredentials(workspaceURL, username, password string) (string, stri
 	}
 
 	return workspaceURL, username, password
+}
+
+// cloudRegionsHint renders the known regions as a comma-separated hint.
+func cloudRegionsHint() string {
+	return strings.Join(knownCloudRegions, ", ")
+}
+
+// validateCloudFlags returns a user-facing error message when exactly one of
+// workspace/region is provided. An empty string means the input is valid
+// (both set, or both empty).
+func validateCloudFlags(workspace, region string) string {
+	if workspace != "" && region == "" {
+		return fmt.Sprintf(
+			"--region is required for Alpacon Cloud.\nAvailable regions: %s\nTry: alpacon login --workspace %s --region %s",
+			cloudRegionsHint(), workspace, knownCloudRegions[0],
+		)
+	}
+	if region != "" && workspace == "" {
+		return fmt.Sprintf(
+			"--workspace is required for Alpacon Cloud.\nTry: alpacon login --workspace <name> --region %s",
+			region,
+		)
+	}
+	return ""
+}
+
+// isCloudDirectURL reports whether a host-mode workspace URL points at the
+// Alpacon Cloud base domain. Such direct URLs are deprecated in favor of
+// --workspace/--region. Matches both subdomain forms (myws.us1.alpacon.io)
+// and the bare base domain (alpacon.io).
+func isCloudDirectURL(workspaceURL string) bool {
+	parsed, err := url.Parse(workspaceURL)
+	if err != nil {
+		return false
+	}
+	host := parsed.Hostname()
+	return host == defaultBaseDomain || strings.HasSuffix(host, "."+defaultBaseDomain)
 }
 
 // rejectURLWithPath exits with a migration hint if the host argument contains a path.

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -72,38 +73,12 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
   ALPACON_NO_BROWSER=1 alpacon login`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		// Trim cloud flag values so whitespace-only input can't bypass
-		// validateCloudFlags or assemble a broken URL like https://demo. .alpacon.io.
-		var blank bool
-		workspaceFlag, regionFlag, blank = normalizeCloudFlags(workspaceFlag, regionFlag)
-		if blank {
-			utils.CliErrorWithExit("--workspace/--region cannot be blank")
+		workspaceURL, workspaceName, baseDomain, ok, err := resolveLoginTarget(args, workspaceFlag, regionFlag)
+		if err != nil {
+			utils.CliErrorWithExit("%s", err.Error())
 		}
 
-		if len(args) > 0 && (workspaceFlag != "" || regionFlag != "") {
-			utils.CliErrorWithExit("Cannot combine a HOST argument with --workspace/--region. Use a HOST for self-hosted, or --workspace/--region for Alpacon Cloud")
-		}
-
-		var workspaceURL, workspaceName, baseDomain string
-
-		if len(args) > 0 {
-			// Host mode: self-hosted only. Cloud direct URLs are deprecated.
-			rejectURLWithPath(args[0])
-			workspaceURL = formatHostURL(args[0])
-			if isCloudDirectURL(workspaceURL) {
-				utils.CliErrorWithExit("Direct URLs are not supported for Alpacon Cloud. Use 'alpacon login --workspace <name> --region <region>' instead")
-			}
-			workspaceName = utils.ExtractWorkspaceName(workspaceURL)
-			baseDomain = utils.ExtractBaseDomain(workspaceURL)
-		} else if workspaceFlag != "" || regionFlag != "" {
-			// Alpacon Cloud mode via flags (non-interactive)
-			if err := validateCloudFlags(workspaceFlag, regionFlag); err != nil {
-				utils.CliErrorWithExit("%s", err.Error())
-			}
-			workspaceName = workspaceFlag
-			baseDomain = defaultBaseDomain
-			workspaceURL = buildCloudWorkspaceURL(workspaceFlag, regionFlag)
-		} else {
+		if !ok {
 			// No args, no flags — try saved config for re-login
 			cfg, err := config.LoadConfig()
 			if err == nil && cfg.WorkspaceURL != "" {
@@ -253,6 +228,43 @@ func normalizeCloudFlags(workspace, region string) (w, r string, blank bool) {
 	return w, r, blank
 }
 
+// resolveLoginTarget resolves the non-interactive login target from the HOST
+// argument and the cloud --workspace/--region flags, applying all combination
+// guards. ok is false when neither a HOST nor cloud flags were supplied, so the
+// caller falls back to saved config or interactive prompts.
+func resolveLoginTarget(args []string, workspace, region string) (workspaceURL, workspaceName, baseDomain string, ok bool, err error) {
+	// Trim cloud flag values so whitespace-only input is rejected up front
+	// instead of slipping past validation or building a malformed URL.
+	workspace, region, blank := normalizeCloudFlags(workspace, region)
+	if blank {
+		return "", "", "", false, errors.New("--workspace/--region cannot be blank")
+	}
+	if len(args) > 0 && (workspace != "" || region != "") {
+		return "", "", "", false, errors.New("cannot combine a HOST argument with --workspace/--region. Use a HOST for self-hosted, or --workspace/--region for Alpacon Cloud")
+	}
+
+	switch {
+	case len(args) > 0:
+		// Host mode: self-hosted only. Cloud direct URLs are deprecated.
+		if err := checkURLPath(args[0]); err != nil {
+			return "", "", "", false, err
+		}
+		workspaceURL = formatHostURL(args[0])
+		if isCloudDirectURL(workspaceURL) {
+			return "", "", "", false, errors.New("direct URLs are not supported for Alpacon Cloud. Use 'alpacon login --workspace <name> --region <region>' instead")
+		}
+		return workspaceURL, utils.ExtractWorkspaceName(workspaceURL), utils.ExtractBaseDomain(workspaceURL), true, nil
+	case workspace != "" || region != "":
+		// Alpacon Cloud mode via flags (non-interactive)
+		if err := validateCloudFlags(workspace, region); err != nil {
+			return "", "", "", false, err
+		}
+		return buildCloudWorkspaceURL(workspace, region), workspace, defaultBaseDomain, true, nil
+	default:
+		return "", "", "", false, nil
+	}
+}
+
 // validateCloudFlags rejects the case where exactly one of workspace/region is set.
 func validateCloudFlags(workspace, region string) error {
 	if workspace != "" && region == "" {
@@ -282,21 +294,22 @@ func isCloudDirectURL(workspaceURL string) bool {
 	return host == defaultBaseDomain || strings.HasSuffix(host, "."+defaultBaseDomain)
 }
 
-// rejectURLWithPath exits with a migration hint if the host argument contains a path.
+// checkURLPath returns a migration-hint error if the host argument contains a path.
 // This catches the legacy alpacon.io/workspace format that is no longer supported.
 // TODO: remove once the new workspace/region flow is well-established.
-func rejectURLWithPath(host string) {
+func checkURLPath(host string) error {
 	raw := host
 	if !strings.Contains(raw, "://") {
 		raw = "https://" + raw
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil {
-		return
+		return nil
 	}
 	if p := strings.TrimSuffix(parsed.Path, "/"); p != "" {
-		utils.CliErrorWithExit("URL paths are not supported. For Alpacon Cloud use 'alpacon login --workspace <name> --region <region>'; for self-hosted pass the host without a path (e.g. 'alpacon login alpacon.example.com')")
+		return errors.New("URL paths are not supported. For Alpacon Cloud use 'alpacon login --workspace <name> --region <region>'; for self-hosted pass the host without a path (e.g. 'alpacon login alpacon.example.com')")
 	}
+	return nil
 }
 
 // formatHostURL normalizes a host argument into a full URL.

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -77,7 +77,7 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 		var blank bool
 		workspaceFlag, regionFlag, blank = normalizeCloudFlags(workspaceFlag, regionFlag)
 		if blank {
-			utils.CliErrorWithExit("--workspace and --region cannot be blank")
+			utils.CliErrorWithExit("--workspace/--region cannot be blank")
 		}
 
 		if len(args) > 0 && (workspaceFlag != "" || regionFlag != "") {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -260,7 +260,7 @@ func isCloudDirectURL(workspaceURL string) bool {
 	if err != nil {
 		return false
 	}
-	host := parsed.Hostname()
+	host := strings.ToLower(parsed.Hostname())
 	return host == defaultBaseDomain || strings.HasSuffix(host, "."+defaultBaseDomain)
 }
 

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -91,3 +91,72 @@ func TestBuildCloudWorkspaceURL(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCloudFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		workspace string
+		region    string
+		contains  []string
+		empty     bool
+	}{
+		{
+			name:      "both set is valid",
+			workspace: "demo",
+			region:    "us1",
+			empty:     true,
+		},
+		{
+			name:      "both empty is valid",
+			workspace: "",
+			region:    "",
+			empty:     true,
+		},
+		{
+			name:      "workspace without region",
+			workspace: "demo",
+			region:    "",
+			contains:  []string{"--region is required", "us1, ap1", "alpacon login --workspace demo --region us1"},
+		},
+		{
+			name:      "region without workspace",
+			workspace: "",
+			region:    "ap1",
+			contains:  []string{"--workspace is required", "--region ap1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateCloudFlags(tt.workspace, tt.region)
+			if tt.empty {
+				assert.Empty(t, result)
+				return
+			}
+			for _, sub := range tt.contains {
+				assert.Contains(t, result, sub)
+			}
+		})
+	}
+}
+
+func TestIsCloudDirectURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{name: "cloud subdomain", url: "https://demo.us1.alpacon.io", expected: true},
+		{name: "cloud subdomain with port", url: "https://demo.us1.alpacon.io:8443", expected: true},
+		{name: "cloud region subdomain", url: "https://foo.alpacon.io", expected: true},
+		{name: "cloud base domain", url: "https://alpacon.io", expected: true},
+		{name: "self-hosted domain", url: "https://alpacon.example.com", expected: false},
+		{name: "localhost", url: "http://localhost:8000", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isCloudDirectURL(tt.url))
+		})
+	}
+}

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -146,6 +146,7 @@ func TestIsCloudDirectURL(t *testing.T) {
 		expected bool
 	}{
 		{name: "cloud subdomain", url: "https://demo.us1.alpacon.io", expected: true},
+		{name: "mixed-case cloud subdomain", url: "https://DeMo.us1.AlPaCoN.iO", expected: true},
 		{name: "cloud subdomain with port", url: "https://demo.us1.alpacon.io:8443", expected: true},
 		{name: "cloud region subdomain", url: "https://foo.alpacon.io", expected: true},
 		{name: "cloud base domain", url: "https://alpacon.io", expected: true},

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -147,6 +147,8 @@ func TestIsCloudDirectURL(t *testing.T) {
 	}{
 		{name: "cloud subdomain", url: "https://demo.us1.alpacon.io", expected: true},
 		{name: "mixed-case cloud subdomain", url: "https://DeMo.us1.AlPaCoN.iO", expected: true},
+		{name: "cloud base domain with trailing dot", url: "https://alpacon.io.", expected: true},
+		{name: "cloud subdomain with trailing dot", url: "https://demo.us1.alpacon.io.", expected: true},
 		{name: "cloud subdomain with port", url: "https://demo.us1.alpacon.io:8443", expected: true},
 		{name: "cloud region subdomain", url: "https://foo.alpacon.io", expected: true},
 		{name: "cloud base domain", url: "https://alpacon.io", expected: true},

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,7 +85,7 @@ func TestBuildCloudWorkspaceURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := fmt.Sprintf("https://%s.%s.%s", tt.workspace, tt.region, defaultBaseDomain)
+			result := buildCloudWorkspaceURL(tt.workspace, tt.region)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -98,19 +97,19 @@ func TestValidateCloudFlags(t *testing.T) {
 		workspace string
 		region    string
 		contains  []string
-		empty     bool
+		valid     bool
 	}{
 		{
 			name:      "both set is valid",
 			workspace: "demo",
 			region:    "us1",
-			empty:     true,
+			valid:     true,
 		},
 		{
 			name:      "both empty is valid",
 			workspace: "",
 			region:    "",
-			empty:     true,
+			valid:     true,
 		},
 		{
 			name:      "workspace without region",
@@ -128,13 +127,13 @@ func TestValidateCloudFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := validateCloudFlags(tt.workspace, tt.region)
-			if tt.empty {
-				assert.Empty(t, result)
+			err := validateCloudFlags(tt.workspace, tt.region)
+			if tt.valid {
+				assert.NoError(t, err)
 				return
 			}
 			for _, sub := range tt.contains {
-				assert.Contains(t, result, sub)
+				assert.ErrorContains(t, err, sub)
 			}
 		})
 	}

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -117,6 +117,58 @@ func TestNormalizeCloudFlags(t *testing.T) {
 	}
 }
 
+func TestResolveLoginTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		workspace  string
+		region     string
+		wantOK     bool
+		wantURL    string
+		wantName   string
+		wantDomain string
+		wantErrSub string
+	}{
+		{name: "self-hosted host", args: []string{"alpacon.example.com"}, wantOK: true, wantURL: "https://alpacon.example.com", wantName: "alpacon", wantDomain: "example.com"},
+		{name: "cloud flags", workspace: "demo", region: "us1", wantOK: true, wantURL: "https://demo.us1.alpacon.io", wantName: "demo", wantDomain: "alpacon.io"},
+		{name: "no args no flags falls back", wantOK: false},
+		{name: "host plus workspace flag", args: []string{"alpacon.example.com"}, workspace: "demo", wantErrSub: "cannot combine a HOST"},
+		{name: "host plus region flag", args: []string{"alpacon.example.com"}, region: "us1", wantErrSub: "cannot combine a HOST"},
+		// Blank guard fires before the combine guard, even when a HOST is present.
+		{name: "host plus blank flag is blank not combine", args: []string{"alpacon.example.com"}, workspace: " ", wantErrSub: "cannot be blank"},
+		{name: "blank both flags", workspace: " ", region: " ", wantErrSub: "cannot be blank"},
+		{name: "blank region only", region: " ", wantErrSub: "cannot be blank"},
+		{name: "workspace without region", workspace: "demo", wantErrSub: "--region is required"},
+		{name: "region without workspace", region: "us1", wantErrSub: "--workspace is required"},
+		{name: "host with path", args: []string{"alpacon.io/demo"}, wantErrSub: "URL paths are not supported"},
+		{name: "cloud direct url rejected", args: []string{"demo.us1.alpacon.io"}, wantErrSub: "direct URLs are not supported"},
+		// Path check runs before the cloud-direct check, so a cloud URL with a path reports the path error.
+		{name: "cloud direct url with path reports path error", args: []string{"demo.us1.alpacon.io/foo"}, wantErrSub: "URL paths are not supported"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, name, domain, ok, err := resolveLoginTarget(tt.args, tt.workspace, tt.region)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				assert.False(t, ok)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantURL, url)
+			}
+			if tt.wantName != "" {
+				assert.Equal(t, tt.wantName, name)
+			}
+			if tt.wantDomain != "" {
+				assert.Equal(t, tt.wantDomain, domain)
+			}
+		})
+	}
+}
+
 func TestValidateCloudFlags(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -91,6 +91,32 @@ func TestBuildCloudWorkspaceURL(t *testing.T) {
 	}
 }
 
+func TestNormalizeCloudFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspace     string
+		region        string
+		wantWorkspace string
+		wantRegion    string
+		wantBlank     bool
+	}{
+		{name: "trims surrounding spaces", workspace: " demo ", region: " us1 ", wantWorkspace: "demo", wantRegion: "us1"},
+		{name: "no flags is not blank", workspace: "", region: "", wantWorkspace: "", wantRegion: ""},
+		{name: "whitespace-only both is blank", workspace: " ", region: "  ", wantBlank: true},
+		{name: "whitespace-only region only is blank", workspace: "", region: " ", wantBlank: true},
+		{name: "valid workspace with blank region is not blank", workspace: "demo", region: " ", wantWorkspace: "demo", wantRegion: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, r, blank := normalizeCloudFlags(tt.workspace, tt.region)
+			assert.Equal(t, tt.wantWorkspace, w)
+			assert.Equal(t, tt.wantRegion, r)
+			assert.Equal(t, tt.wantBlank, blank)
+		})
+	}
+}
+
 func TestValidateCloudFlags(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

Reduce friction in `alpacon login` for Alpacon Cloud, where the web console URL (`alpacon.io/demo`) exposes the workspace name but never the region—yet login requires one. There is no pre-auth public API to look the region up, so this change improves discoverability instead and consolidates the cloud login path onto `--workspace`/`--region`.

## Changes

- **Region hint** — add a hardcoded `knownCloudRegions = {us1, ap1}` (source: alpacon-web `constants.ts`, account `settings.py`) surfaced in prompts and error messages.
- **Friendlier flag validation** — replace `MarkFlagsRequiredTogether` with `validateCloudFlags`, which returns an actionable, copy-pasteable hint listing available regions when exactly one of `--workspace`/`--region` is given. Validation runs *before* URL assembly to avoid building a broken `https://demo..alpacon.io`.
- **Deprecate cloud direct URLs** — `isCloudDirectURL` rejects `*.alpacon.io` / bare `alpacon.io` in host mode and points users to `--workspace`/`--region`. Self-hosted domains and `localhost` are unaffected.
- **Clearer interactive prompts** — `Workspace name:` and `Region [us1] (us1, ap1):` expose the region candidates.
- **Help/examples** — drop cloud direct-URL examples in favor of flags / self-hosted forms.

## Known limitation

The hardcoded list answers "which regions exist," not "which region *my* workspace is in"—that requires a post-auth token claim (account-level login), which is out of scope here.

## Test plan

- `go build ./...` — clean
- `go vet ./cmd/` — clean
- `go test ./cmd/...` — pass (new table-driven tests: `validateCloudFlags`, `isCloudDirectURL`, `buildCloudWorkspaceURL`)