### PR TITLE
fix: align CLI websh sudo to the SudoGrant/verify contract

### DIFF
--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -15,13 +15,16 @@ import (
 )
 
 const (
-	sudoApproveURL = "/api/approvals/sudo-policies/self-approve/"
+	// sudoVerifyURLFmt is the sudo-grant MFA verify endpoint; the grant ID is
+	// substituted into the path. Replaces the removed self-approve route.
+	sudoVerifyURLFmt = "/api/sudo/grants/%s/verify/"
 
 	// mfaPollingInterval is how often we check if MFA is completed.
 	mfaPollingInterval = 500 * time.Millisecond
 
 	// mfaPollingTimeout is the maximum time to wait for MFA completion.
-	// Server expires the approval request after 30s, but we give extra buffer.
+	// The server expires the pending sudo grant after a short window; we keep
+	// extra buffer over that so a slow browser MFA does not race the expiry.
 	mfaPollingTimeout = 60 * time.Second
 
 	// reconnectBaseDelay is the initial delay for WebSocket reconnection.
@@ -34,26 +37,21 @@ const (
 // sudoMFAEvent represents the MFA request payload from the event WebSocket.
 type sudoMFAEvent struct {
 	Payload struct {
-		Type              string `json:"type"`
-		Query             string `json:"query"`
-		ApprovalRequestID string `json:"approval_request_id"`
-		MfaURL            string `json:"mfa_url"`
-		Command           string `json:"command"`
-		SessionID         string `json:"session_id"`
+		Type        string `json:"type"`
+		Query       string `json:"query"`
+		SudoGrantID string `json:"sudo_grant_id"`
+		MfaURL      string `json:"mfa_url"`
+		Command     string `json:"command"`
+		SessionID   string `json:"session_id"`
 	} `json:"payload"`
-}
-
-// selfApproveRequest is sent to approve a sudo request after MFA.
-type selfApproveRequest struct {
-	ApprovalRequestID string `json:"approval_request_id"`
 }
 
 // SudoListener listens for sudo MFA events on the event WebSocket
 // and handles the browser-based MFA flow.
 //
 // The AlpaconClient (ac) is shared with the terminal WebSocket goroutines.
-// http.Client is concurrency-safe. Token refresh and self-approve are serialized
-// by mfaMu so only one MFA flow runs at a time.
+// http.Client is concurrency-safe. Token refresh and grant verification are
+// serialized by mfaMu so only one MFA flow runs at a time.
 type SudoListener struct {
 	ac           *client.AlpaconClient
 	serverName   string
@@ -231,15 +229,15 @@ func (sl *SudoListener) handleSudoMFA(event sudoMFAEvent) {
 	default:
 	}
 
-	approvalID := event.Payload.ApprovalRequestID
-	if approvalID == "" {
+	grantID := event.Payload.SudoGrantID
+	if grantID == "" {
 		return
 	}
 
 	// Fast path: if MFA is already completed (e.g., recent sudo in another
 	// terminal), skip the browser and approve immediately.
 	if err := sl.ac.RefreshToken(); err == nil {
-		if err := sl.selfApprove(approvalID); err == nil {
+		if err := sl.verifySudoGrant(grantID); err == nil {
 			return
 		}
 	}
@@ -270,7 +268,7 @@ func (sl *SudoListener) handleSudoMFA(event sudoMFAEvent) {
 		return
 	}
 
-	if err := sl.selfApprove(approvalID); err != nil {
+	if err := sl.verifySudoGrant(grantID); err != nil {
 		fmt.Fprintf(os.Stderr, "\r\n\033[31mSudo approval failed: %s\033[0m\r\n", err)
 		return
 	}
@@ -299,14 +297,12 @@ func (sl *SudoListener) pollMFACompletion() bool {
 	}
 }
 
-func (sl *SudoListener) selfApprove(approvalRequestID string) error {
-	req := &selfApproveRequest{
-		ApprovalRequestID: approvalRequestID,
-	}
+func (sl *SudoListener) verifySudoGrant(grantID string) error {
+	url := fmt.Sprintf(sudoVerifyURLFmt, grantID)
 
-	_, err := sl.ac.SendPostRequest(sudoApproveURL, req)
+	_, err := sl.ac.SendPostRequest(url, struct{}{})
 	if err != nil {
-		return fmt.Errorf("failed to self-approve sudo request: %w", err)
+		return fmt.Errorf("failed to verify sudo grant: %w", err)
 	}
 
 	return nil

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -231,6 +232,7 @@ func (sl *SudoListener) handleSudoMFA(event sudoMFAEvent) {
 
 	grantID := event.Payload.SudoGrantID
 	if grantID == "" {
+		fmt.Fprintf(os.Stderr, "\r\n\033[31mSudo MFA event is missing a grant ID; cannot verify. This likely indicates a server/CLI version mismatch.\033[0m\r\n")
 		return
 	}
 
@@ -269,7 +271,7 @@ func (sl *SudoListener) handleSudoMFA(event sudoMFAEvent) {
 	}
 
 	if err := sl.verifySudoGrant(grantID); err != nil {
-		fmt.Fprintf(os.Stderr, "\r\n\033[31mSudo approval failed: %s\033[0m\r\n", err)
+		fmt.Fprintf(os.Stderr, "\r\n\033[31mSudo verification failed: %s\033[0m\r\n", err)
 		return
 	}
 }
@@ -298,9 +300,11 @@ func (sl *SudoListener) pollMFACompletion() bool {
 }
 
 func (sl *SudoListener) verifySudoGrant(grantID string) error {
-	url := fmt.Sprintf(sudoVerifyURLFmt, grantID)
+	// PathEscape the server-issued grant ID so a stray '/' cannot redirect
+	// the request to an unintended endpoint.
+	endpoint := fmt.Sprintf(sudoVerifyURLFmt, url.PathEscape(grantID))
 
-	_, err := sl.ac.SendPostRequest(url, struct{}{})
+	_, err := sl.ac.SendPostRequest(endpoint, struct{}{})
 	if err != nil {
 		return fmt.Errorf("failed to verify sudo grant: %w", err)
 	}

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -241,6 +242,11 @@ func TestSudoListener_VerifySudoGrant_Success(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Contains(t, r.URL.Path, "/api/sudo/grants/grant-123/verify/")
+
+		// Verify carries no payload — the server resolves MFA from the
+		// MFACompletion record, so the body must stay empty.
+		body, _ := io.ReadAll(r.Body)
+		assert.JSONEq(t, "{}", string(body))
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -19,7 +19,7 @@ func TestSudoMFAEvent_JSONRoundTrip(t *testing.T) {
 	payload := sudoMFAEvent{}
 	payload.Payload.Type = "auth"
 	payload.Payload.Query = "mfa_request"
-	payload.Payload.ApprovalRequestID = "test-approval-id"
+	payload.Payload.SudoGrantID = "test-grant-id"
 	payload.Payload.MfaURL = "https://auth.alpacon.io/mfa?token=abc"
 	payload.Payload.Command = "sudo systemctl restart nginx"
 	payload.Payload.SessionID = "test-session-id"
@@ -32,7 +32,7 @@ func TestSudoMFAEvent_JSONRoundTrip(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "auth", parsed.Payload.Type)
 	assert.Equal(t, "mfa_request", parsed.Payload.Query)
-	assert.Equal(t, "test-approval-id", parsed.Payload.ApprovalRequestID)
+	assert.Equal(t, "test-grant-id", parsed.Payload.SudoGrantID)
 	assert.Equal(t, "https://auth.alpacon.io/mfa?token=abc", parsed.Payload.MfaURL)
 }
 
@@ -237,15 +237,10 @@ func TestSudoListener_WaitConnected_Shutdown(t *testing.T) {
 	assert.Less(t, elapsed, 1*time.Second, "should exit quickly on shutdown")
 }
 
-func TestSudoListener_SelfApprove_Success(t *testing.T) {
+func TestSudoListener_VerifySudoGrant_Success(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Contains(t, r.URL.Path, "sudo-policies/self-approve")
-
-		var req selfApproveRequest
-		err := json.NewDecoder(r.Body).Decode(&req)
-		assert.NoError(t, err)
-		assert.Equal(t, "approval-123", req.ApprovalRequestID)
+		assert.Contains(t, r.URL.Path, "/api/sudo/grants/grant-123/verify/")
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -263,11 +258,11 @@ func TestSudoListener_SelfApprove_Success(t *testing.T) {
 		connected: make(chan struct{}),
 	}
 
-	err := sl.selfApprove("approval-123")
+	err := sl.verifySudoGrant("grant-123")
 	assert.NoError(t, err)
 }
 
-func TestSudoListener_SelfApprove_ServerError(t *testing.T) {
+func TestSudoListener_VerifySudoGrant_ServerError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
@@ -283,7 +278,7 @@ func TestSudoListener_SelfApprove_ServerError(t *testing.T) {
 		connected: make(chan struct{}),
 	}
 
-	err := sl.selfApprove("approval-123")
+	err := sl.verifySudoGrant("grant-123")
 	assert.Error(t, err)
 }
 

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -245,7 +245,8 @@ func TestSudoListener_VerifySudoGrant_Success(t *testing.T) {
 
 		// Verify carries no payload — the server resolves MFA from the
 		// MFACompletion record, so the body must stay empty.
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
 		assert.JSONEq(t, "{}", string(body))
 
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Problem (#209)

Running `sudo` in a CLI Websh session did nothing—the MFA browser never opened and no error was printed.

The server's sudo redesign replaced the `ApprovalRequest` self-approve flow with a `SudoGrant` + `verify` model, but the CLI was never updated:
- the `mfa_request` event field `approval_request_id` became `sudo_grant_id`
- the action endpoint `/api/approvals/sudo-policies/self-approve/` became `/api/sudo/grants/{id}/verify/`

The CLI still read the now-always-empty `approval_request_id` and bailed before opening the browser, so the entire flow was dead.

## Change

Re-align `api/event/sudolistener.go` to the current contract:
- read `sudo_grant_id` from the `mfa_request` event
- POST to `/api/sudo/grants/{grantID}/verify/` with an empty body
- rename `selfApprove` → `verifySudoGrant` and drop the removed self-approve request struct

The verify body is intentionally empty: the CLI's browser MFA exchange (`location=cli`) writes an `MFACompletion` row on the regional server, so the server's `verify` permission (`IsMFACompletedOrStepUpToken`) passes via its DB fallback. No `mfa_token` needs to be forwarded—that step-up-token path is web-only.

## Verification

- Security + quality review, cross-checked against the server `verify` contract:
  - empty-body verify confirmed to pass via the `MFACompletion` DB fallback (no `mfa_token` required)
  - the CLI user JWT satisfies `HasTokenScope.for_resource('sudo_grant')`—full user JWTs bypass the scoped-token check, so the contract change introduces no 403 risk
  - URL routing matches the server's `/api/sudo/grants/{pk}/verify/` action
  - fast path unchanged: `RefreshToken()` then `verifySudoGrant`; on a non-recent MFA the server returns 403 and the flow falls through cleanly to the browser
- Tests updated (`sudolistener_test.go`): success asserts the new verify path; the error test asserts 403 → error. All old symbols (`selfApprove`, `selfApproveRequest`, `sudoApproveURL`, `ApprovalRequestID`) are removed with no dangling references.
- No Go toolchain available locally, so `go build` / `golangci-lint` / `gofmt` run in CI.

Closes #209