### PR TITLE
refactor(cli): remove work-session announcement and websh [y/n] prompt

### DIFF
--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -71,7 +71,7 @@ redirections, or '&&' will not work.`,
 			utils.CliErrorWithExit("%s", err)
 		}
 
-		workSessionID := worksession.ResolveAndAnnounce(flagWorkSession)
+		workSessionID := worksession.ResolveOrExit(flagWorkSession)
 		authMethod := config.ResolveAuthMethod()
 
 		alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -95,7 +95,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			utils.OutputFormat = parsed.OutputFormat
 		}
 
-		workSessionID := worksession.ResolveAndAnnounce(parsed.WorkSessionID)
+		workSessionID := worksession.ResolveOrExit(parsed.WorkSessionID)
 
 		authMethod := config.ResolveAuthMethod()
 

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -101,7 +101,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 
 		// Resolve and announce after argument/path validation so stderr stays
 		// clean on early usage errors.
-		workSessionID := worksession.ResolveAndAnnounce(flagWorkSession)
+		workSessionID := worksession.ResolveOrExit(flagWorkSession)
 
 		authMethod := config.ResolveAuthMethod()
 

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -99,8 +99,8 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			return
 		}
 
-		// Resolve and announce after argument/path validation so stderr stays
-		// clean on early usage errors.
+		// Resolve after argument/path validation so resolution errors don't
+		// mask early usage errors.
 		workSessionID := worksession.ResolveOrExit(flagWorkSession)
 
 		authMethod := config.ResolveAuthMethod()

--- a/cmd/tunnel/tunnel.go
+++ b/cmd/tunnel/tunnel.go
@@ -133,7 +133,7 @@ func validateTunnelArgs(cmd *cobra.Command, args []string) error {
 
 func runTunnel(cmd *cobra.Command, args []string) {
 	// Write resolved value back so handleTunnelStartError's retry reuses the same UUID.
-	tunnelFlags.workSessionID = worksession.ResolveAndAnnounce(tunnelFlags.workSessionID)
+	tunnelFlags.workSessionID = worksession.ResolveOrExit(tunnelFlags.workSessionID)
 
 	var sigChan <-chan os.Signal
 	if cmd.ArgsLenAtDash() < 0 {

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -224,12 +224,6 @@ Note: All flags must be placed before the server name.
 		}
 
 		if len(commandArgs) > 0 {
-			if len(commandArgs) > 1 {
-				utils.CliWarning("Command without quotes may cause unexpected behavior. Consider wrapping the command in quotes.")
-				if !utils.CommandConfirm() {
-					return
-				}
-			}
 			command := execCmd.ShellJoin(commandArgs)
 			result, err := execCmd.RunCommandWithRetry(alpaconClient, serverName, command, username, groupname, env, workSessionID)
 			utils.HandleWorkSessionError(err, "command", serverName, authMethod, workSessionID)

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -214,7 +214,7 @@ Note: All flags must be placed before the server name.
 			utils.OutputFormat = parsed.OutputFormat
 		}
 
-		workSessionID := worksession.ResolveAndAnnounce(parsed.WorkSessionID)
+		workSessionID := worksession.ResolveOrExit(parsed.WorkSessionID)
 
 		authMethod := config.ResolveAuthMethod()
 

--- a/cmd/worksession/resolve.go
+++ b/cmd/worksession/resolve.go
@@ -1,7 +1,6 @@
 package worksession
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/alpacax/alpacon-cli/config"
@@ -23,21 +22,11 @@ func Resolve(flagValue string) (string, error) {
 	return config.GetActiveWorkSession()
 }
 
-// AnnounceIfActive prints "Using work-session <uuid>" to stderr when uuid is non-empty.
-// Stderr keeps stdout clean for --output json.
-func AnnounceIfActive(uuid string) {
-	if uuid == "" {
-		return
-	}
-	fmt.Fprintf(os.Stderr, "Using work-session %s\n", uuid)
-}
-
-// ResolveAndAnnounce resolves the work-session UUID, announces it, and exits on error.
-func ResolveAndAnnounce(flagValue string) string {
+// ResolveOrExit resolves the work-session UUID and exits on error.
+func ResolveOrExit(flagValue string) string {
 	uuid, err := Resolve(flagValue)
 	if err != nil {
 		utils.CliErrorWithExit("%s", err)
 	}
-	AnnounceIfActive(uuid)
 	return uuid
 }

--- a/cmd/worksession/resolve_test.go
+++ b/cmd/worksession/resolve_test.go
@@ -1,9 +1,6 @@
 package worksession_test
 
 import (
-	"bytes"
-	"io"
-	"os"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
@@ -44,32 +41,4 @@ func TestResolve_Priority(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
-}
-
-func TestAnnounceIfActive_PrintsToStderr(t *testing.T) {
-	r, w, _ := os.Pipe()
-	origStderr := os.Stderr
-	os.Stderr = w
-	defer func() { os.Stderr = origStderr }()
-
-	worksession.AnnounceIfActive("uuid-x")
-	_ = w.Close()
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-
-	assert.Contains(t, buf.String(), "Using work-session uuid-x")
-}
-
-func TestAnnounceIfActive_SilentWhenEmpty(t *testing.T) {
-	r, w, _ := os.Pipe()
-	origStderr := os.Stderr
-	os.Stderr = w
-	defer func() { os.Stderr = origStderr }()
-
-	worksession.AnnounceIfActive("")
-	_ = w.Close()
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-
-	assert.Equal(t, "", buf.String())
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"archive/zip"
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -536,29 +535,6 @@ func CreateAndEditTempFile(data []byte) (string, error) {
 func SplitPath(path string) (string, string) {
 	parts := strings.SplitN(path, ":", 2)
 	return parts[0], parts[1]
-}
-
-// CommandConfirm prompts the user for confirmation to continue executing a command.
-// It returns true if the user enters "y" or "yes" (case-insensitive), and false otherwise.
-func CommandConfirm() bool {
-	if IsInteractiveShell() {
-		fmt.Fprint(os.Stderr, "Do you want to continue executing the command? [y/n]: ")
-		reader := bufio.NewReader(os.Stdin)
-		input, err := reader.ReadString('\n')
-		if err != nil {
-			CliErrorWithExit("Failed to read user input: %s", err)
-			return false
-		}
-
-		input = strings.TrimSpace(strings.ToLower(input))
-		if input != "y" && input != "yes" {
-			CliInfo("Command execution cancelled.")
-			return false
-		}
-		return true
-	} else {
-		return true
-	}
 }
 
 // IsInteractiveShell checks if the current program is running in an interactive terminal.


### PR DESCRIPTION
## Summary

Two CLI output noise removals based on teammate feedback.

## Changes

### 1. Remove `Using work-session <uuid>` stderr output (dc0c96f)

- Printed on every run of work-session-aware commands (`exec`, `websh`, `cp`, `tunnel`, `edit`), adding noise to the output
- Deleted the `AnnounceIfActive` function and renamed `ResolveAndAnnounce` → `ResolveOrExit`
- Work-session resolution priority (flag > `ALPACON_WORK_SESSION` env > config) is unchanged

### 2. Remove the `[y/n]` confirmation prompt for unquoted websh commands (efa0460)

- Passing multiple unquoted arguments like `websh server echo hello` required confirmation every time, which was inconvenient
- Now executes immediately without confirmation, matching exec behavior
- Quoting guidance remains in the help text (`Long`)
- Deleted `utils.CommandConfirm`, whose only caller was websh

## Behavior changes

| Before | After |
|---|---|
| `alpacon exec ...` prints `Using work-session <uuid>` to stderr | No output |
| `alpacon websh server docker ps` asks `[y/n]` before running | Runs immediately |

## Test plan

- [x] `go build ./...` / `go vet ./...`
- [x] `go test -race ./...` passes
- [x] CI (Build and Test, Lint) passes

Close #181 