### PR TITLE
fix(client): don't mislabel coded 401s as authentication failures

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -95,24 +95,56 @@ func getUserPrivileges(isStaff, isSuperuser bool) string {
 	return "general"
 }
 
-// checkAuthStatus prefers the server-provided detail so policy denials are
-// not masked as stale-token failures.
+// checkAuthStatus prefers the server-provided reason and only suggests
+// re-login for a bare authentication failure—never for a coded condition such
+// as MFA-required or a policy denial, which re-login does not resolve. The
+// error code is always preserved on the returned error so downstream handlers
+// (MFA flow, WorkSession gate) can still route on it.
 func checkAuthStatus(statusCode int, body []byte) error {
-	switch statusCode {
-	case http.StatusUnauthorized:
-		msg, code, source, ok := parseAuthStatusErrorPayload(body)
-		if !ok {
-			return newAPIError("authentication failed: please run 'alpacon login' again", code, source)
-		}
-		return newAPIError(fmt.Sprintf("%s (run 'alpacon login' if your session has expired)", msg), code, source)
-	case http.StatusForbidden:
-		msg, code, source, ok := parseAuthStatusErrorPayload(body)
-		if !ok {
-			return newAPIError("permission denied: you do not have the required privileges for this action", code, source)
-		}
-		return newAPIError(msg, code, source)
+	if statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden {
+		return nil
 	}
-	return nil
+	detail, code, source, hasDetail := parseAuthStatusErrorPayload(body)
+	return newAPIError(authStatusMessage(statusCode, code, detail, hasDetail), code, source)
+}
+
+// authStatusMessage renders the user-facing message for a 401/403. It prefers
+// the server's human detail; absent that, a known structured code maps to a
+// clear message. A code-less 401 is the only case that suggests re-login—an
+// authenticated user who merely needs MFA, or who hit a policy denial, must not
+// be told to log in again.
+func authStatusMessage(statusCode int, code, detail string, hasDetail bool) string {
+	if hasDetail {
+		if statusCode == http.StatusUnauthorized && code == "" {
+			return fmt.Sprintf("%s (run 'alpacon login' if your session has expired)", detail)
+		}
+		return detail
+	}
+	if msg, ok := authStatusCodeMessage(code); ok {
+		return msg
+	}
+	if statusCode == http.StatusUnauthorized {
+		if code == "" {
+			return "authentication failed: please run 'alpacon login' again"
+		}
+		// A coded 401 is a deliberate server decision, not a stale token; do not
+		// mislabel it as an authentication failure or suggest re-login.
+		// Deliberately information-light: do not interpolate the raw code into the
+		// message—callers read it via ErrorCode(), and embedding it would break the
+		// no-raw-code contract that TestSendRequest_403CodeWithoutDetailKeepsCodeSource guards.
+		return "request denied by server"
+	}
+	return "permission denied: you do not have the required privileges for this action"
+}
+
+// authStatusCodeMessage maps structured server codes that arrive on a 401/403
+// without a human detail to a clear, actionable message.
+func authStatusCodeMessage(code string) (string, bool) {
+	switch code {
+	case utils.AuthMFARequired:
+		return "multi-factor authentication required—complete MFA to continue", true
+	}
+	return "", false
 }
 
 // parseAuthStatusErrorPayload returns ok=true only with a clean "detail" message;

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -139,6 +139,68 @@ func TestSendRequest_403CodeWithoutDetailKeepsCodeSource(t *testing.T) {
 	assert.Equal(t, "command", source)
 }
 
+func TestSendRequest_401MFARequiredCodeNoReLoginHint(t *testing.T) {
+	// Accessing root / a system account requires MFA: the server returns 401
+	// with {"code": "auth_mfa_required"} and no detail string. This must not be
+	// mislabeled as an authentication failure or suggest re-login—the user is
+	// authenticated and only needs MFA. The code must survive for the MFA flow.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code": "auth_mfa_required", "source": "websh"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	assert.ErrorContains(t, err, "multi-factor authentication")
+	assert.NotContains(t, err.Error(), "authentication failed")
+	assert.NotContains(t, err.Error(), "alpacon login")
+
+	code, source := utils.ParseErrorResponse(err)
+	assert.Equal(t, utils.AuthMFARequired, code)
+	assert.Equal(t, "websh", source)
+}
+
+func TestSendRequest_401MFARequiredPrefersServerDetail(t *testing.T) {
+	// When the server also provides a human detail, surface it—still without a
+	// re-login hint, since a coded 401 is not a stale token.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code": "auth_mfa_required", "source": "websh", "detail": "MFA required to access root"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	assert.ErrorContains(t, err, "MFA required to access root")
+	assert.NotContains(t, err.Error(), "alpacon login")
+
+	code, _ := utils.ParseErrorResponse(err)
+	assert.Equal(t, utils.AuthMFARequired, code)
+}
+
+func TestSendRequest_401CodedDenialNotMislabeledAsAuthFailure(t *testing.T) {
+	// Any coded 401 without a detail must not become "authentication failed" /
+	// re-login; the code is preserved for downstream handling.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code": "some_policy_denial", "source": "command"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	assert.NotContains(t, err.Error(), "authentication failed")
+	assert.NotContains(t, err.Error(), "alpacon login")
+
+	code, source := utils.ParseErrorResponse(err)
+	assert.Equal(t, "some_policy_denial", code)
+	assert.Equal(t, "command", source)
+}
+
 func TestLoadCurrentUser_PopulatesFieldsAndCaches(t *testing.T) {
 	callCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Problem

Accessing `root` (or a system account) from the CLI when MFA is required returns **HTTP 401** from the server with body `{"code": "auth_mfa_required", "source": "..."}` — a structured `code`, **no `detail` string**. `checkAuthStatus` rendered *any* 401-without-detail as the hardcoded:

> authentication failed: please run 'alpacon login' again

So an authenticated user who merely needed MFA (or hit a policy denial) was told their login was bad — and **AI agents driving the CLI re-logged in pointlessly**. The real cause is authorization/MFA, not authentication.

## Fix

`checkAuthStatus` now delegates to a pure `authStatusMessage(statusCode, code, detail, hasDetail)`:

- A **known structured code** maps to a clear message (`auth_mfa_required` → "multi-factor authentication required—complete MFA to continue").
- The **re-login hint is dropped for any coded 401** — a deliberate server decision is not a stale token.
- A **code-less 401** is still the only case that suggests `alpacon login`.
- Unknown coded denials get a generic message **without echoing the raw code** (preserves the contract `TestSendRequest_403CodeWithoutDetailKeepsCodeSource` guards).
- The error **`code` is always preserved** on the returned error, so the downstream MFA flow (`HandleCommonErrors` → `ParseErrorResponse` → `ErrorCode()`) and the WorkSession exit-3 gate still route on it — message wording does not affect routing.

## Tests

- All existing 401/403 auth-status tests pass unchanged (verified the full truth table).
- Added: coded-401 MFA (no re-login hint, code preserved), coded-401 MFA with detail (detail wins, no hint), non-MFA coded-401 (not mislabeled, code preserved).
- `go build ./...`, `go vet`, `go test -race ./...` all green locally (go1.25.10).

## Review

Quality + security reviewed (subagent): APPROVED, 0 blockers / 0 important / 2 nits (one taken — annotated the information-light path against future raw-code interpolation).

## Dependencies & deploy order

This is one of a set of PRs that resolve the sudo problems end-to-end:

| PR | Repo | Depends on | Deploy |
|---|---|---|---|
| **this (PR-A)** | alpacon-cli | — | **anytime, independent** |
| PR-T0 sid-binding | alpamon | — | anytime |
| PR-P user-scoped presence | alpacon-server | — | anytime (flagged) |
| PR-X gate separation + exec unblock | server + cli | PR-P (runtime: PR-T0) | after PR-P **and** PR-T0 |

**PR-A has no dependencies and can merge/deploy immediately** — it is a pure client-side message fix with no server or protocol change.