### PR TITLE
feat(exec): actionable hints for the new exec-sudo denial codes

### DIFF
--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -13,7 +13,7 @@ import (
 	"github.com/alpacax/alpacon-cli/utils"
 )
 
-// sudoDenialHints map a non-interactive sudo denial code to actionable
+// sudoDenialHints maps a non-interactive sudo denial code to actionable
 // guidance. Codes are kept in sync with alpacon-server utils/error_codes.py.
 //
 // The form is UPPERCASE because alpacon_approval.c only passes [A-Z0-9_] codes
@@ -48,7 +48,10 @@ var sudoDenialHints = []struct {
 // non-interactive sudo denial. Returns "" when no such denial is present.
 func sudoDenialHint(output string) string {
 	for _, h := range sudoDenialHints {
-		if strings.Contains(output, h.code) {
+		// Match the parenthesized denial token "(CODE)"—the form
+		// alpacon_approval.c emits—not the bare code, so a command that merely
+		// prints the code string in its own output is not a false positive.
+		if strings.Contains(output, "("+h.code+")") {
 			return fmt.Sprintf("%s %s", utils.Yellow("Hint:"), h.guidance)
 		}
 	}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -13,30 +13,46 @@ import (
 	"github.com/alpacax/alpacon-cli/utils"
 )
 
-// sudoNoWorksessionPolicyCode is the server error code surfaced in command
-// output when a non-interactive sudo is denied for lack of a matching
-// MFA-bypass policy in the work session. Kept in sync with
-// alpacon-server utils/error_codes.py ErrorCode.SUDO_NO_WORKSESSION_POLICY.
+// sudoDenialHints map a non-interactive sudo denial code to actionable
+// guidance. Codes are kept in sync with alpacon-server utils/error_codes.py.
 //
-// The form is UPPERCASE because alpacon_approval.c only passes [A-Z0-9_]
-// codes through its sanitizer into the user-facing denial message; lowercase
-// values are dropped, so this is the form that actually reaches stderr as
-// "Permission denied (SUDO_NO_WORKSESSION_POLICY)".
-const sudoNoWorksessionPolicyCode = "SUDO_NO_WORKSESSION_POLICY"
+// The form is UPPERCASE because alpacon_approval.c only passes [A-Z0-9_] codes
+// through its sanitizer into the user-facing denial message (lowercase values
+// are dropped), so this is the form that reaches stderr as
+// "Permission denied (<CODE>)". Each hint stays at the denial *category* level
+// (what to do)—the server never sends the risk score or reasoning to a client.
+var sudoDenialHints = []struct {
+	code, guidance string
+}{
+	{
+		"SUDO_NO_WORKSESSION_POLICY",
+		"sudo was denied: this command is not covered by an MFA-bypass policy in your work session.\n" +
+			"Add it and re-run (omit SESSION_ID to use the active session):\n" +
+			"  alpacon work-session update [SESSION_ID] --sudo \"<command>\"\n",
+	},
+	{
+		"SUDO_PRESENCE_REQUIRED",
+		"sudo needs a recent MFA: complete a step-up, then re-run the command.\n",
+	},
+	{
+		"SUDO_APPROVAL_REQUIRED",
+		"sudo needs approval: an approval request was created. Re-run after a reviewer approves it.\n",
+	},
+	{
+		"SUDO_RISK_DENIED",
+		"sudo was denied by runtime risk assessment; this command is not permitted in this work session.\n",
+	},
+}
 
 // sudoDenialHint returns actionable guidance when the command output shows a
-// non-interactive sudo denial, telling the caller how to authorize the command
-// via their work session. Returns "" when no such denial is present.
+// non-interactive sudo denial. Returns "" when no such denial is present.
 func sudoDenialHint(output string) string {
-	if !strings.Contains(output, sudoNoWorksessionPolicyCode) {
-		return ""
+	for _, h := range sudoDenialHints {
+		if strings.Contains(output, h.code) {
+			return fmt.Sprintf("%s %s", utils.Yellow("Hint:"), h.guidance)
+		}
 	}
-	return fmt.Sprintf(
-		"%s sudo was denied: this command is not covered by an MFA-bypass policy in your work session.\n"+
-			"Add it and re-run (omit SESSION_ID to use the active session):\n"+
-			"  alpacon work-session update [SESSION_ID] --sudo \"<command>\"\n",
-		utils.Yellow("Hint:"),
-	)
+	return ""
 }
 
 // RunCommandWithRetry executes a remote command with MFA and username-required

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -13,14 +13,21 @@ import (
 	"github.com/alpacax/alpacon-cli/utils"
 )
 
+// sudoDenialLinePrefix is the exact terminal-facing denial line emitted by
+// alpacon_approval.c via g_plugin_printf ("Alpacon denied this sudo command
+// (CODE)."). The other "Permission denied (CODE)" form is assigned to *errstr,
+// which only reaches the audit log—not the invoking terminal—so it must not be
+// matched. Anchoring on this full prefix (not a bare "(CODE)") stops a command
+// whose own output prints "(SUDO_RISK_DENIED)" from forging a hint.
+const sudoDenialLinePrefix = "Alpacon denied this sudo command"
+
 // sudoDenialHints maps a non-interactive sudo denial code to actionable
 // guidance. Codes are kept in sync with alpacon-server utils/error_codes.py.
 //
-// The form is UPPERCASE because alpacon_approval.c only passes [A-Z0-9_] codes
-// through its sanitizer into the user-facing denial message (lowercase values
-// are dropped), so this is the form that reaches stderr as
-// "Permission denied (<CODE>)". Each hint stays at the denial *category* level
-// (what to do)—the server never sends the risk score or reasoning to a client.
+// The codes are UPPERCASE because alpacon_approval.c only passes [A-Z0-9_]
+// codes through its sanitizer into the user-facing denial line (lowercase
+// values are dropped). Each hint stays at the denial *category* level (what to
+// do)—the server never sends the risk score or reasoning to a client.
 var sudoDenialHints = []struct {
 	code, guidance string
 }{
@@ -48,10 +55,10 @@ var sudoDenialHints = []struct {
 // non-interactive sudo denial. Returns "" when no such denial is present.
 func sudoDenialHint(output string) string {
 	for _, h := range sudoDenialHints {
-		// Match the parenthesized denial token "(CODE)"—the form
-		// alpacon_approval.c emits—not the bare code, so a command that merely
-		// prints the code string in its own output is not a false positive.
-		if strings.Contains(output, "("+h.code+")") {
+		// Anchor on the plugin's full denial line, not a bare "(CODE)" token,
+		// so a command whose own output prints "(SUDO_RISK_DENIED)" cannot forge
+		// a hint on a command that actually succeeded.
+		if strings.Contains(output, sudoDenialLinePrefix+" ("+h.code+")") {
 			return fmt.Sprintf("%s %s", utils.Yellow("Hint:"), h.guidance)
 		}
 	}

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -43,4 +43,10 @@ func TestSudoDenialHint(t *testing.T) {
 		assert.Empty(t, sudoDenialHint("ok\n"))
 		assert.Empty(t, sudoDenialHint(""))
 	})
+
+	t.Run("bare code in command output is not a false positive", func(t *testing.T) {
+		// A command that merely prints the code (no "(CODE)" denial token)
+		// must not trigger a hint.
+		assert.Empty(t, sudoDenialHint("echo SUDO_RISK_DENIED\nSUDO_RISK_DENIED\n"))
+	})
 }

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSudoDenialHint(t *testing.T) {
 	t.Run("returns guidance when denial code present", func(t *testing.T) {
-		out := "sudo: Permission denied (SUDO_NO_WORKSESSION_POLICY)\n"
+		out := "Alpacon denied this sudo command (SUDO_NO_WORKSESSION_POLICY).\n"
 		hint := sudoDenialHint(out)
 		assert.NotEmpty(t, hint)
 		assert.True(t, strings.Contains(hint, "work-session update"),
@@ -17,21 +17,21 @@ func TestSudoDenialHint(t *testing.T) {
 	})
 
 	t.Run("presence-required points to a step-up", func(t *testing.T) {
-		hint := sudoDenialHint("sudo: Permission denied (SUDO_PRESENCE_REQUIRED)\n")
+		hint := sudoDenialHint("Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED).\n")
 		assert.NotEmpty(t, hint)
 		assert.True(t, strings.Contains(hint, "step-up"),
 			"hint should tell the user to step up MFA")
 	})
 
 	t.Run("approval-required points to re-running after approval", func(t *testing.T) {
-		hint := sudoDenialHint("sudo: Permission denied (SUDO_APPROVAL_REQUIRED)\n")
+		hint := sudoDenialHint("Alpacon denied this sudo command (SUDO_APPROVAL_REQUIRED).\n")
 		assert.NotEmpty(t, hint)
 		assert.True(t, strings.Contains(hint, "approv"),
 			"hint should mention the approval request")
 	})
 
 	t.Run("risk-denied is a terminal denial", func(t *testing.T) {
-		hint := sudoDenialHint("sudo: Permission denied (SUDO_RISK_DENIED)\n")
+		hint := sudoDenialHint("Alpacon denied this sudo command (SUDO_RISK_DENIED).\n")
 		assert.NotEmpty(t, hint)
 		assert.True(t, strings.Contains(hint, "risk"),
 			"hint should name the risk assessment")
@@ -45,8 +45,14 @@ func TestSudoDenialHint(t *testing.T) {
 	})
 
 	t.Run("bare code in command output is not a false positive", func(t *testing.T) {
-		// A command that merely prints the code (no "(CODE)" denial token)
-		// must not trigger a hint.
+		// A command that merely prints the code (no denial line) must not
+		// trigger a hint.
 		assert.Empty(t, sudoDenialHint("echo SUDO_RISK_DENIED\nSUDO_RISK_DENIED\n"))
+	})
+
+	t.Run("forged parenthesized token is not a false positive", func(t *testing.T) {
+		// A command whose own output prints the parenthesized token, without the
+		// plugin's denial line, must not forge a hint (the command succeeded).
+		assert.Empty(t, sudoDenialHint("echo \"(SUDO_RISK_DENIED)\"\n(SUDO_RISK_DENIED)\n"))
 	})
 }

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -16,6 +16,29 @@ func TestSudoDenialHint(t *testing.T) {
 			"hint should point to the work-session update command")
 	})
 
+	t.Run("presence-required points to a step-up", func(t *testing.T) {
+		hint := sudoDenialHint("sudo: Permission denied (SUDO_PRESENCE_REQUIRED)\n")
+		assert.NotEmpty(t, hint)
+		assert.True(t, strings.Contains(hint, "step-up"),
+			"hint should tell the user to step up MFA")
+	})
+
+	t.Run("approval-required points to re-running after approval", func(t *testing.T) {
+		hint := sudoDenialHint("sudo: Permission denied (SUDO_APPROVAL_REQUIRED)\n")
+		assert.NotEmpty(t, hint)
+		assert.True(t, strings.Contains(hint, "approv"),
+			"hint should mention the approval request")
+	})
+
+	t.Run("risk-denied is a terminal denial", func(t *testing.T) {
+		hint := sudoDenialHint("sudo: Permission denied (SUDO_RISK_DENIED)\n")
+		assert.NotEmpty(t, hint)
+		assert.True(t, strings.Contains(hint, "risk"),
+			"hint should name the risk assessment")
+		// Disclosure: never echo a score/reasoning, only the category.
+		assert.False(t, strings.Contains(hint, "score"))
+	})
+
 	t.Run("empty when no denial code", func(t *testing.T) {
 		assert.Empty(t, sudoDenialHint("ok\n"))
 		assert.Empty(t, sudoDenialHint(""))


### PR DESCRIPTION
## What

When a non-interactive `alpacon exec server sudo …` is denied on the host, the denial code reaches the CLI embedded in the command output (alpacon_approval.c prints `Permission denied (<CODE>)`). The CLI already turns `SUDO_NO_WORKSESSION_POLICY` into a hint; this extends `sudoDenialHint` (now table-driven) to the three codes the server's exec-sudo risk gate (PR-X, `alpacon-server`) adds:

| Code | Hint |
|---|---|
| `SUDO_PRESENCE_REQUIRED` | complete a step-up, then re-run |
| `SUDO_APPROVAL_REQUIRED` | an approval request was created; re-run after a reviewer approves it |
| `SUDO_RISK_DENIED` | denied by runtime risk assessment; not permitted in this work session |

## Security / disclosure

Hints stay at the **denial category** level (which gate fired + what to do). The server never sends the risk **score**, factors, or reasoning to a client — those go to the audit log server-side. A test asserts the risk-denied hint never echoes a `score`.

## Tests

`TestSudoDenialHint` extended for all three new codes + the existing two cases; `go build`, `go vet`, `go test -race ./cmd/exec` green.

## Dependencies

Pairs with **PR-X** (`alpacon-server`, `feat/sudo-gate-and-exec`) which emits these codes. This PR is a pure client-side hint addition (string match), so it compiles/merges independently; it only produces the new hints end-to-end once PR-X is deployed in `EXEC_SUDO_MODE=enforce`. A sibling MCP change surfaces the same codes to agents.