### PR TITLE
feat(exec): interactive MFA step-up for sudo presence denials

### DIFF
--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -99,6 +99,11 @@ func StepUpForSudo(ac *client.AlpaconClient, serverName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get the MFA step-up link: %w", err)
 	}
+	// GetMFALink can return an empty URL without an error on a malformed
+	// response; fail fast rather than print a blank link and poll until timeout.
+	if stepUpURL == "" {
+		return fmt.Errorf("server returned an empty MFA step-up link")
+	}
 
 	fmt.Fprintf(os.Stderr, "\nsudo needs a recent MFA to proceed. Open this link to verify:\n%s\n", stepUpURL)
 	fmt.Fprintf(os.Stderr, "Press Enter to open it in your browser, or open the link manually.\n")

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -1,9 +1,11 @@
 package mfa
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/client"
@@ -14,6 +16,12 @@ import (
 const (
 	mfaURL           = "/api/auth0/mfa"
 	mfaCompletionURL = "/api/auth0/mfa/completion/"
+
+	// stepUpPollInterval and stepUpTimeout bound the StepUpForSudo wait. They
+	// mirror the websh sudo listener (api/event/sudolistener.go) so the step-up
+	// feel is consistent across the two terminals.
+	stepUpPollInterval = 500 * time.Millisecond
+	stepUpTimeout      = 60 * time.Second
 )
 
 type mfaResponse struct {
@@ -71,6 +79,70 @@ func GetMFALinkForSudo(ac *client.AlpaconClient, serverName string) (string, err
 	}
 
 	return GetMFALink(ac, serverID, cfg.WorkspaceName)
+}
+
+// StepUpForSudo runs an interactive MFA step-up for an exec-sudo presence denial
+// (SUDO_PRESENCE_REQUIRED). It prints the verification link, opens the browser
+// when the user presses Enter, and polls until the server records the MFA
+// completion. It returns nil once presence is fresh, or an error on timeout.
+//
+// The Enter prompt opens the browser as a convenience but never gates progress:
+// the poll runs regardless, so a user who opens the link manually still
+// completes, and an absent human or a misconfigured agent always terminates at
+// the bounded timeout rather than wedging the command. Callers should still gate
+// this on an interactive terminal, since scripts, CI, and AI agents never
+// receive a presence denial in the first place.
+func StepUpForSudo(ac *client.AlpaconClient, serverName string) error {
+	// Use the CLI-scoped sudo MFA URL (location=cli) so the mfa-success page
+	// notifies the backend, letting CheckMFACompletion observe completion.
+	stepUpURL, err := GetMFALinkForSudo(ac, serverName)
+	if err != nil {
+		return fmt.Errorf("failed to get the MFA step-up link: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "\nsudo needs a recent MFA to proceed. Open this link to verify:\n%s\n", stepUpURL)
+	fmt.Fprintf(os.Stderr, "Press Enter to open it in your browser, or open the link manually.\n")
+
+	// Open the browser on Enter without blocking the poll. EOF or a closed stdin
+	// simply skips the auto-open; it never aborts the flow. The goroutine ends at
+	// process exit if Enter is never pressed.
+	go func() {
+		if _, rerr := bufio.NewReader(os.Stdin).ReadString('\n'); rerr == nil {
+			utils.OpenBrowser(stepUpURL)
+		}
+	}()
+
+	spinner := utils.NewSpinner("Waiting for MFA verification...")
+	spinner.Start()
+
+	// Mirror the websh sudo listener: a precise deadline plus a fixed-interval
+	// ticker (api/event/sudolistener.go).
+	deadline := time.After(stepUpTimeout)
+	ticker := time.NewTicker(stepUpPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			spinner.Stop()
+			return fmt.Errorf("MFA step-up timed out after %v", stepUpTimeout)
+		case <-ticker.C:
+			completed, cerr := CheckMFACompletion(ac)
+			if cerr != nil || !completed {
+				// Non-fatal: the endpoint may lag the browser; keep polling.
+				continue
+			}
+			spinner.Stop()
+			// Refresh the token so the server sees the updated MFA state on
+			// retry, mirroring the websh sudo listener.
+			if rerr := ac.RefreshToken(); rerr != nil {
+				return fmt.Errorf(
+					"failed to refresh token after MFA; run 'alpacon login' to re-authenticate: %w",
+					rerr,
+				)
+			}
+			return nil
+		}
+	}
 }
 
 // GetWorkspaceSecurityMFALink returns an MFA URL for workspace security settings.

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -103,11 +103,20 @@ func StepUpForSudo(ac *client.AlpaconClient, serverName string) error {
 	fmt.Fprintf(os.Stderr, "\nsudo needs a recent MFA to proceed. Open this link to verify:\n%s\n", stepUpURL)
 	fmt.Fprintf(os.Stderr, "Press Enter to open it in your browser, or open the link manually.\n")
 
-	// Open the browser on Enter without blocking the poll. EOF or a closed stdin
-	// simply skips the auto-open; it never aborts the flow. The goroutine ends at
-	// process exit if Enter is never pressed.
+	// Open the browser on Enter without blocking the poll. The done guard makes a
+	// late Enter—pressed after the step-up already completed or timed out—a no-op,
+	// so the browser never opens unexpectedly later in the command flow. EOF or a
+	// closed stdin simply skips the auto-open; it never aborts the flow. The
+	// goroutine ends at process exit if Enter is never pressed.
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
-		if _, rerr := bufio.NewReader(os.Stdin).ReadString('\n'); rerr == nil {
+		if _, rerr := bufio.NewReader(os.Stdin).ReadString('\n'); rerr != nil {
+			return
+		}
+		select {
+		case <-done:
+		default:
 			utils.OpenBrowser(stepUpURL)
 		}
 	}()

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -148,7 +148,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			return
 		}
 
-		result, err := RunCommandWithRetry(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
+		result, err := RunExecWithPresenceStepUp(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
 		utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
 		HandleCommandResult(result, err)
 	},

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -88,7 +88,13 @@ func hasSudoPresenceDenial(output string) bool {
 // keeps its own sudo MFA flow.
 func RunExecWithPresenceStepUp(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (string, error) {
 	result, err := RunCommandWithRetry(ac, serverName, command, username, groupname, env, workSessionID)
-	if !hasSudoPresenceDenial(result) {
+	// A real presence denial makes sudo exit non-zero, so it always surfaces as a
+	// RemoteCommandError carrying the denial line. Require that error as well as
+	// the line match: a command that merely prints the line and SUCCEEDS
+	// (err == nil) must not trigger a step-up and a re-run of a side-effecting
+	// command.
+	var remoteErr *event.RemoteCommandError
+	if !errors.As(err, &remoteErr) || !hasSudoPresenceDenial(result) {
 		return result, err
 	}
 

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -51,18 +51,65 @@ var sudoDenialHints = []struct {
 	},
 }
 
+// denialCodePresent reports whether output contains the plugin's terminal denial
+// line for the given code. It anchors on the full "Alpacon denied this sudo
+// command (CODE)" line, never a bare "(CODE)" token, so a command whose own
+// output prints the token cannot forge a match on a command that succeeded.
+// Both sudoDenialHint and hasSudoPresenceDenial route through here so the
+// anchoring logic lives in one place.
+func denialCodePresent(output, code string) bool {
+	return strings.Contains(output, sudoDenialLinePrefix+" ("+code+")")
+}
+
 // sudoDenialHint returns actionable guidance when the command output shows a
 // non-interactive sudo denial. Returns "" when no such denial is present.
 func sudoDenialHint(output string) string {
 	for _, h := range sudoDenialHints {
-		// Anchor on the plugin's full denial line, not a bare "(CODE)" token,
-		// so a command whose own output prints "(SUDO_RISK_DENIED)" cannot forge
-		// a hint on a command that actually succeeded.
-		if strings.Contains(output, sudoDenialLinePrefix+" ("+h.code+")") {
+		if denialCodePresent(output, h.code) {
 			return fmt.Sprintf("%s %s", utils.Yellow("Hint:"), h.guidance)
 		}
 	}
 	return ""
+}
+
+// hasSudoPresenceDenial reports whether output carries the non-interactive sudo
+// presence denial (SUDO_PRESENCE_REQUIRED), the only denial the CLI can resolve
+// in-flow via an MFA step-up.
+func hasSudoPresenceDenial(output string) bool {
+	return denialCodePresent(output, "SUDO_PRESENCE_REQUIRED")
+}
+
+// RunExecWithPresenceStepUp runs a command via RunCommandWithRetry and, when it
+// is denied for a missing recent MFA (SUDO_PRESENCE_REQUIRED) on an interactive
+// terminal, offers an MFA step-up and retries once. Non-interactive callers
+// (scripts, CI, AI agents) fall through unchanged so HandleCommandResult prints
+// the static denial hint; non-interactive humans additionally get the
+// verification link they can complete out of band. Only exec uses this; websh
+// keeps its own sudo MFA flow.
+func RunExecWithPresenceStepUp(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (string, error) {
+	result, err := RunCommandWithRetry(ac, serverName, command, username, groupname, env, workSessionID)
+	if !hasSudoPresenceDenial(result) {
+		return result, err
+	}
+
+	if !utils.IsInteractiveShell() {
+		// Non-interactive: surface the verification link so a human reading the
+		// logs can complete MFA out of band, then re-run. We cannot prompt or
+		// open a browser here.
+		if url, linkErr := mfa.GetMFALinkForSudo(ac, serverName); linkErr == nil && url != "" {
+			utils.CliInfo("MFA verification link (open in a browser):\n  %s", url)
+		}
+		return result, err
+	}
+
+	if stepErr := mfa.StepUpForSudo(ac, serverName); stepErr != nil {
+		utils.CliWarning("MFA step-up did not complete: %s", stepErr)
+		return result, err
+	}
+
+	// Presence is fresh—retry once. Any remaining denial falls through to the
+	// static hint in HandleCommandResult.
+	return RunCommandWithRetry(ac, serverName, command, username, groupname, env, workSessionID)
 }
 
 // RunCommandWithRetry executes a remote command with MFA and username-required

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -53,12 +53,13 @@ var sudoDenialHints = []struct {
 
 // denialCodePresent reports whether output contains the plugin's terminal denial
 // line for the given code. It anchors on the full "Alpacon denied this sudo
-// command (CODE)" line, never a bare "(CODE)" token, so a command whose own
-// output prints the token cannot forge a match on a command that succeeded.
-// Both sudoDenialHint and hasSudoPresenceDenial route through here so the
-// anchoring logic lives in one place.
+// command (CODE)." line—including the trailing period the plugin emits—never a
+// bare "(CODE)" token, so a command whose own output prints the token cannot
+// forge a match on a command that succeeded. Both sudoDenialHint and
+// hasSudoPresenceDenial route through here so the anchoring logic lives in one
+// place.
 func denialCodePresent(output, code string) bool {
-	return strings.Contains(output, sudoDenialLinePrefix+" ("+code+")")
+	return strings.Contains(output, sudoDenialLinePrefix+" ("+code+").")
 }
 
 // sudoDenialHint returns actionable guidance when the command output shows a

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -89,4 +89,11 @@ func TestHasSudoPresenceDenial(t *testing.T) {
 			"reading config...\nApplying changes\n"+
 				"Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED).\n"))
 	})
+
+	t.Run("denial line without the trailing period does not match", func(t *testing.T) {
+		// The matcher anchors on the plugin's exact line, which ends in a period.
+		// A line that stops at ")" is not the plugin's output and must not match.
+		assert.False(t, hasSudoPresenceDenial(
+			"Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED)\n"))
+	})
 }

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -56,3 +56,37 @@ func TestSudoDenialHint(t *testing.T) {
 		assert.Empty(t, sudoDenialHint("echo \"(SUDO_RISK_DENIED)\"\n(SUDO_RISK_DENIED)\n"))
 	})
 }
+
+func TestHasSudoPresenceDenial(t *testing.T) {
+	t.Run("true on the real presence denial line", func(t *testing.T) {
+		assert.True(t, hasSudoPresenceDenial(
+			"Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED).\n"))
+	})
+
+	t.Run("false for other denial codes", func(t *testing.T) {
+		assert.False(t, hasSudoPresenceDenial(
+			"Alpacon denied this sudo command (SUDO_RISK_DENIED).\n"))
+		assert.False(t, hasSudoPresenceDenial(
+			"Alpacon denied this sudo command (SUDO_APPROVAL_REQUIRED).\n"))
+	})
+
+	t.Run("false on clean output", func(t *testing.T) {
+		assert.False(t, hasSudoPresenceDenial("ok\n"))
+		assert.False(t, hasSudoPresenceDenial(""))
+	})
+
+	t.Run("forged parenthesized token does not trigger a step-up", func(t *testing.T) {
+		// A command whose own output prints the bare token, without the plugin's
+		// denial line, must not be mistaken for a presence denial.
+		assert.False(t, hasSudoPresenceDenial(
+			"echo \"(SUDO_PRESENCE_REQUIRED)\"\n(SUDO_PRESENCE_REQUIRED)\n"))
+	})
+
+	t.Run("true when the denial line is buried in real command output", func(t *testing.T) {
+		// The denial line may be preceded by legitimate stdout; the detector
+		// must still fire.
+		assert.True(t, hasSudoPresenceDenial(
+			"reading config...\nApplying changes\n"+
+				"Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED).\n"))
+	})
+}


### PR DESCRIPTION
## Summary

Adds an in-flow MFA step-up for exec sudo **presence** denials. When the server's exec-sudo risk gate denies a command for a missing recent MFA presence (`SUDO_PRESENCE_REQUIRED`), an interactive terminal now gets a step-up — print the verification link, open the browser on Enter, poll for completion, then retry the command once — instead of only a static hint. This closes the websh-vs-exec asymmetry: websh already had interactive sudo MFA (the grant-bound `SudoListener`); exec did not.

## Behavior

| Caller | TTY | CLI behavior |
|---|---|---|
| Human, interactive | yes | print link → Enter opens browser → poll completion → auto-retry once |
| Human, script/CI | no | print link (non-interactively) + static denial hint; never blocks |
| AI agent | n/a | server never sends `SUDO_PRESENCE_REQUIRED` to agent-mode (it gets HITL), so this path is never reached |

## Design notes (shaped by review)

- **Non-blocking Enter.** The Enter keypress only opens the browser, inside a goroutine; the bounded poll (`time.After` + ticker, mirroring `api/event/sudolistener.go`) runs regardless. So a manually opened link still completes, an absent human or a misconfigured TTY-bearing agent always terminates at the 60s timeout instead of wedging the command, and a stdin EOF simply skips the auto-open (no process exit).
- **Forge-proof detection.** `denialCodePresent` (now shared by `sudoDenialHint` and `hasSudoPresenceDenial`) anchors on the plugin's full terminal line `Alpacon denied this sudo command (CODE)`, never a bare `(CODE)` token, so a command that prints the code in its own stdout cannot forge a step-up.
- **websh untouched.** The new `RunExecWithPresenceStepUp` wrapper is exec-only; websh keeps its grant-bound `SudoListener` flow. `RunCommandWithRetry` / `HandleCommandResult` are unchanged.
- **Disclosure.** New messages stay at the denial-category level (the link + "sudo needs a recent MFA"); no risk score or risk factors are surfaced.

## Dependencies / deploy order

- **CLI-only — no server or MCP change.** Depends only on the server denial code `SUDO_PRESENCE_REQUIRED`, which already ships. Backward-compatible: the CLI only reacts to a code the server already defines, so it can be released independently and runs against any current server.
- The step-up path activates only when the server's exec-sudo risk gate actually requires presence (`EXEC_SUDO_MODE=enforce` + `ALPACON_AI_ENABLED` + a risk band that demands presence). With the gate inert, this code is dormant.
- Server invariant relied on: agent-mode sessions get HITL, not presence denials. The CLI degrades gracefully even if that were ever violated — bounded timeout, no hang, no bypass.

## Tests

- `TestHasSudoPresenceDenial`: real line → true; other denial codes → false; clean/empty output → false; forged bare-token → false; denial line buried in real command output → true.
- Existing `TestSudoDenialHint` unchanged — the shared-matcher refactor preserves the exact anchor string.
- `go build`, `go vet`, `go test -race ./cmd/exec/... ./api/mfa/...`, and `gofmt` all clean.

## Review

Per-change quality + security review and an integration-flow security/operation review were both run. The integration review flagged the original blocking Enter prompt as a wedge risk for TTY-bearing agents / absent humans (CHANGES_REQUIRED); it was redesigned to the non-blocking goroutine + bounded poll above, and a focused re-review returned APPROVED.
