### PR TITLE
fix(login): re-allow Alpacon Cloud direct URLs as a deprecated host arg

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -70,7 +70,10 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 
   # Headless environment only (no browser available)
   alpacon login --no-browser
-  ALPACON_NO_BROWSER=1 alpacon login`,
+  ALPACON_NO_BROWSER=1 alpacon login
+
+  # Alpacon Cloud via direct URL with an API token (deprecated; prefer --workspace/--region)
+  alpacon login myworkspace.us1.alpacon.io -t <api-token>`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		workspaceURL, workspaceName, baseDomain, ok, err := resolveLoginTarget(args, workspaceFlag, regionFlag)
@@ -245,14 +248,11 @@ func resolveLoginTarget(args []string, workspace, region string) (workspaceURL, 
 
 	switch {
 	case len(args) > 0:
-		// Host mode: self-hosted only. Cloud direct URLs are deprecated.
+		// Host mode: self-hosted, plus deprecated Alpacon Cloud direct URLs (backward compat).
 		if err := checkURLPath(args[0]); err != nil {
 			return "", "", "", false, err
 		}
 		workspaceURL = formatHostURL(args[0])
-		if isCloudDirectURL(workspaceURL) {
-			return "", "", "", false, errors.New("direct URLs are not supported for Alpacon Cloud. Use 'alpacon login --workspace <name> --region <region>' instead")
-		}
 		return workspaceURL, utils.ExtractWorkspaceName(workspaceURL), utils.ExtractBaseDomain(workspaceURL), true, nil
 	case workspace != "" || region != "":
 		// Alpacon Cloud mode via flags (non-interactive)
@@ -280,18 +280,6 @@ func validateCloudFlags(workspace, region string) error {
 		)
 	}
 	return nil
-}
-
-// isCloudDirectURL reports whether a host-mode URL targets the Alpacon Cloud base
-// domain (alpacon.io or a subdomain). Such direct URLs are deprecated.
-func isCloudDirectURL(workspaceURL string) bool {
-	parsed, err := url.Parse(workspaceURL)
-	if err != nil {
-		return false
-	}
-	// Normalize for case-insensitive hostnames and the trailing-dot FQDN form.
-	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
-	return host == defaultBaseDomain || strings.HasSuffix(host, "."+defaultBaseDomain)
 }
 
 // checkURLPath returns a migration-hint error if the host argument contains a path.

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -141,8 +141,8 @@ func TestResolveLoginTarget(t *testing.T) {
 		{name: "workspace without region", workspace: "demo", wantErrSub: "--region is required"},
 		{name: "region without workspace", region: "us1", wantErrSub: "--workspace is required"},
 		{name: "host with path", args: []string{"alpacon.io/demo"}, wantErrSub: "URL paths are not supported"},
-		{name: "cloud direct url rejected", args: []string{"demo.us1.alpacon.io"}, wantErrSub: "direct URLs are not supported"},
-		// Path check runs before the cloud-direct check, so a cloud URL with a path reports the path error.
+		{name: "cloud direct url accepted", args: []string{"demo.us1.alpacon.io"}, wantOK: true, wantURL: "https://demo.us1.alpacon.io", wantName: "demo", wantDomain: "alpacon.io"},
+		// Path check runs first, so a cloud URL with a path reports the path error.
 		{name: "cloud direct url with path reports path error", args: []string{"demo.us1.alpacon.io/foo"}, wantErrSub: "URL paths are not supported"},
 	}
 
@@ -213,30 +213,6 @@ func TestValidateCloudFlags(t *testing.T) {
 			for _, sub := range tt.contains {
 				assert.ErrorContains(t, err, sub)
 			}
-		})
-	}
-}
-
-func TestIsCloudDirectURL(t *testing.T) {
-	tests := []struct {
-		name     string
-		url      string
-		expected bool
-	}{
-		{name: "cloud subdomain", url: "https://demo.us1.alpacon.io", expected: true},
-		{name: "mixed-case cloud subdomain", url: "https://DeMo.us1.AlPaCoN.iO", expected: true},
-		{name: "cloud base domain with trailing dot", url: "https://alpacon.io.", expected: true},
-		{name: "cloud subdomain with trailing dot", url: "https://demo.us1.alpacon.io.", expected: true},
-		{name: "cloud subdomain with port", url: "https://demo.us1.alpacon.io:8443", expected: true},
-		{name: "cloud region subdomain", url: "https://foo.alpacon.io", expected: true},
-		{name: "cloud base domain", url: "https://alpacon.io", expected: true},
-		{name: "self-hosted domain", url: "https://alpacon.example.com", expected: false},
-		{name: "localhost", url: "http://localhost:8000", expected: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isCloudDirectURL(tt.url))
 		})
 	}
 }


### PR DESCRIPTION
## Why

v1.7.0 started hard-rejecting Alpacon Cloud direct URLs (`*.alpacon.io`) when passed
as the HOST argument to `alpacon login`. However, the three official GitHub Actions
(alpacon-common-action, alpacon-websh-action, alpacon-cp-action) all log in with:

    alpacon login "${{ inputs.workspace-url }}" -t "${{ inputs.api-token }}"

For Cloud users, `workspace-url` is a Cloud direct URL such as
`https://myworkspace.us1.alpacon.io`. So the moment those actions install the latest
CLI, login breaks with `login failed` on every Alpacon Cloud workspace. This restores
the path.

## Changes

- Accept Cloud direct URLs again in host mode. They resolve to the same target as
  `--workspace/--region`, and the behavior/credential flow is identical to a
  self-hosted host argument.
- The form stays **deprecated** — surfaced only as a single bottom help example,
  framed as the CI/CD + API-token use case.
- Path-style URLs are still rejected (`checkURLPath` runs first).
- Remove the now-unused `isCloudDirectURL` helper and its test.

## Help-text design intent

A Cloud direct URL technically also works on the OAuth (interactive Auth0 login) path,
but the help text **intentionally does not mention it for the OAuth case** — it is shown
only under the API-token (CI/CD) example.

- Fewer login permutations for an AI agent to reason about — interactive/Cloud login is
  steered consistently to plain `alpacon login` or `--workspace/--region`.
- Less human confusion — exposing the deprecated direct URL in an interactive example
  would blur it against the recommended `--workspace/--region` path.
- As a result the direct URL is documented in exactly one context: backward compatibility
  for existing CI/CD scripts.

## Verification

- `go build ./...`, `go vet ./cmd/` pass
- `go test -race ./...` passes (notably `TestResolveLoginTarget`, `TestFormatHostURL`,
  `TestValidateCloudFlags`)
  - new case: `demo.us1.alpacon.io` → accepted as `https://demo.us1.alpacon.io`
    (name=demo, domain=alpacon.io)
  - `demo.us1.alpacon.io/foo` → rejected with the path error (path check runs first)
- Regression check: self-hosted host / `--workspace --region` / empty-arg re-login paths
  are all unaffected
- Action path verified end-to-end: `alpacon login <cloud-url> -t <token>` resolves through
  host mode, and because `token != ""` the OAuth device-code branch is skipped and the
  API-token branch (`LoginAndSaveCredentials`) runs — exactly what the three actions need

## Impact

- alpacon-common-action / websh-action / cp-action: auto-recover after the 1.7.1 release
  (no action code changes needed)

## Release

This is intended to ship as a **v1.7.1 patch release** right after merge.
**If this should NOT be released yet, please leave a comment** — otherwise the tag
(`v1.7.1`) will be pushed once merged.
