### PR TITLE
feat: implement ADR 0015 out-of-band approval surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Run `alpacon --help` for the full list, or `alpacon <command> --help` for detail
 | `1`  | General error (network failure, server error, etc.) |
 | `2`  | Usage error (invalid flags or arguments) |
 | `3`  | WorkSession gate denied—the active session does not authorize this action |
+| `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. Re-run after approval, or pass `--wait` to block. Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Run `alpacon --help` for the full list, or `alpacon <command> --help` for detail
 | `1`  | General error (network failure, server error, etc.) |
 | `2`  | Usage error (invalid flags or arguments) |
 | `3`  | WorkSession gate denied—the active session does not authorize this action |
-| `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. Re-run after approval, or pass `--wait` to block. Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending |
+| `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. For `exec`, re-run the command after approval (or pass `--wait` on the original command to block); for `work-session create` the session already exists—after approval attach it with `alpacon work-session use <id>` (or pass `--wait` on the original create to block). Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending |
 
 ## Contributing
 

--- a/cmd/approval/approval.go
+++ b/cmd/approval/approval.go
@@ -13,22 +13,21 @@ var ApprovalCmd = &cobra.Command{
 	Long: `Approval requests are created when actions require administrator
 review—work session creation, sudo policy grants, IAM username
 conflicts, and service token issuance all generate requests that
-a superuser must approve or reject before the action proceeds.
+a human must approve or reject before the action proceeds.
 
-Subcommands for reviewers (superuser only):
-  ls        List pending approval requests
+Approving and rejecting happen out of band in the Alpacon console
+(web) or Slack, not the CLI. The CLI is an execution and request
+surface only; use it to create requests and track their status.
+
+Subcommands for tracking:
+  ls        List approval requests (--my for your own)
   describe  Show details of a request
-  approve   Approve a pending request
-  reject    Reject a pending request
-
-Subcommands for requesters:
-  ls --my   List your own pending requests
   cancel    Cancel a pending request you submitted`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon approval ls', 'alpacon approval describe', 'alpacon approval approve', 'alpacon approval reject', or 'alpacon approval cancel'. Run 'alpacon approval --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon approval ls', 'alpacon approval describe', or 'alpacon approval cancel'. Approve and reject happen in the Alpacon console (web). Run 'alpacon approval --help' for more information")
 	},
 }
 

--- a/cmd/approval/approval_approve.go
+++ b/cmd/approval/approval_approve.go
@@ -1,55 +1,34 @@
 package approval
 
 import (
-	approvalapi "github.com/alpacax/alpacon-cli/api/approval"
-	"github.com/alpacax/alpacon-cli/api/server"
-	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
 
-var (
-	approveScopes  []string
-	approveServers []string
-)
+// approveRejectExcludedMessage explains why the CLI no longer performs approve or
+// reject. ADR 0015 makes the CLI an execution/request surface only: approval
+// happens out of band in the Alpacon console (web/Slack), and the server now
+// refuses (HTTP 403) any approve/reject coming from the CLI credential channel.
+// The subcommands remain registered so the message is discoverable and existing
+// scripts get an actionable, intentional exit instead of an "unknown command".
+const approveRejectExcludedMessage = "Approvals must be done in the Alpacon console (web), not the CLI. " +
+	"The CLI is an execution and request surface only; approve and reject happen out of band. " +
+	"Use 'alpacon approval ls' to track a request's status."
 
 var approvalApproveCmd = &cobra.Command{
 	Use:   "approve REQUEST_ID",
-	Short: "Approve a pending approval request",
-	Long: `Approve a pending approval request. Superuser only.
+	Short: "Approve a request (moved to the Alpacon console)",
+	Long: `Approving requests has moved to the Alpacon console (web).
 
-For work_session requests, use --scope and --server to narrow
-the granted access at approval time. Omitting these flags
-approves the request exactly as submitted.`,
-	Args: cobra.ExactArgs(1),
-	Example: `  alpacon approval approve apr-abc123
-  alpacon approval approve apr-abc123 --scope command --scope websh
-  alpacon approval approve apr-abc123 --scope command,websh --server web-01`,
+The CLI is an execution and request surface only; a human approves or rejects
+out of band in the web console or Slack. The server rejects approve/reject from
+the CLI credential channel. Use 'alpacon approval ls' to track status.`,
+	Args: cobra.ArbitraryArgs,
+	Example: `  # Approve in the Alpacon console (web), then track status here:
+  alpacon approval ls --status approved`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ac, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		req := approvalapi.ApproveOptions{
-			AdjustedScopes: utils.CompactStrings(approveScopes),
-		}
-
-		serverIDs, err := server.ResolveServerNames(ac, approveServers)
-		if err != nil {
-			utils.CliErrorWithExit("Failed to resolve server names: %s.", err)
-		}
-		req.AdjustedServers = serverIDs
-
-		if err := approvalapi.ApproveRequest(ac, args[0], req); err != nil {
-			utils.CliErrorWithExit("Failed to approve request: %s.", err)
-		}
-
-		utils.CliSuccess("Approval request %s approved.", args[0])
+		// Exit non-zero so a script that expected the approval to happen does not
+		// mistake this for success—the CLI must never pretend to approve.
+		utils.CliErrorWithExit("%s", approveRejectExcludedMessage)
 	},
-}
-
-func init() {
-	approvalApproveCmd.Flags().StringSliceVar(&approveScopes, "scope", nil, "Adjust granted scopes (work_session only; repeatable or comma-separated)")
-	approvalApproveCmd.Flags().StringSliceVar(&approveServers, "server", nil, "Adjust target servers by name (work_session only; repeatable or comma-separated)")
 }

--- a/cmd/approval/approval_reject.go
+++ b/cmd/approval/approval_reject.go
@@ -1,28 +1,24 @@
 package approval
 
 import (
-	approvalapi "github.com/alpacax/alpacon-cli/api/approval"
-	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
 
 var approvalRejectCmd = &cobra.Command{
-	Use:     "reject REQUEST_ID",
-	Short:   "Reject a pending approval request",
-	Long:    "Reject a pending approval request. Superuser only.",
-	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon approval reject apr-abc123`,
+	Use:   "reject REQUEST_ID",
+	Short: "Reject a request (moved to the Alpacon console)",
+	Long: `Rejecting requests has moved to the Alpacon console (web).
+
+The CLI is an execution and request surface only; a human approves or rejects
+out of band in the web console or Slack. The server rejects approve/reject from
+the CLI credential channel. Use 'alpacon approval ls' to track status.`,
+	Args: cobra.ArbitraryArgs,
+	Example: `  # Reject in the Alpacon console (web), then track status here:
+  alpacon approval ls --status rejected`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ac, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		if err := approvalapi.RejectRequest(ac, args[0]); err != nil {
-			utils.CliErrorWithExit("Failed to reject request: %s.", err)
-		}
-
-		utils.CliSuccess("Approval request %s rejected.", args[0])
+		// Exit non-zero so a script that expected the reject to happen does not
+		// mistake this for success—the CLI must never pretend to reject.
+		utils.CliErrorWithExit("%s", approveRejectExcludedMessage)
 	},
 }

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/api/iam"
@@ -41,9 +42,15 @@ Flags:
   --detach                      Submit the command and return immediately without
                                 waiting for completion. Prints the job ID to stdout.
                                 Use 'alpacon exec logs JOB_ID' to retrieve the result.
+  --wait                        When a sudo command needs human approval, block and
+                                re-attempt until a reviewer approves it in the Alpacon
+                                console (web), or the wait times out.
 
 Exit code 3 indicates a WorkSession gate denial; run with --output json to
 parse a machine-readable diagnostic on stderr.
+Exit code 4 indicates the sudo command is pending human approval (approve it in
+the Alpacon console, then re-run, or pass --wait to block); --output json emits
+{"status":"pending_approval", ...} on stdout.
 Requires an active WorkSession when using Browser login (Auth0); Token auth (API token or Service token) bypasses this requirement.`,
 	Example: `  # Simple command execution
   alpacon exec prod-docker docker ps
@@ -148,8 +155,33 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			return
 		}
 
-		result, err := RunExecWithPresenceStepUp(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
+		result, err := RunExecWithApprovalWait(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID, parsed.Wait)
 		utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
+		// A sudo command pending human approval (SUDO_APPROVAL_REQUIRED) that we did
+		// not --wait on emits a machine-readable pending signal and exits before the
+		// normal result handling treats the denial as a plain failure.
+		if HandlePendingApproval(result, err, reRunHint(parsed)) {
+			return
+		}
 		HandleCommandResult(result, err)
 	},
+}
+
+// reRunHint reconstructs the exec invocation (server, optional user/group, and
+// command) so the pending-approval message can tell a human exactly what to
+// re-run once the request is approved. It uses -- before the command so remote
+// flags are never re-parsed as alpacon flags.
+func reRunHint(parsed RemoteExecArgs) string {
+	parts := []string{"alpacon exec"}
+	if parsed.Username != "" {
+		parts = append(parts, "-u "+parsed.Username)
+	}
+	if parsed.Groupname != "" {
+		parts = append(parts, "-g "+parsed.Groupname)
+	}
+	if parsed.WorkSessionID != "" {
+		parts = append(parts, "--work-session "+parsed.WorkSessionID)
+	}
+	parts = append(parts, parsed.Server, "--", parsed.Command)
+	return strings.Join(parts, " ")
 }

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -113,6 +113,12 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 		}
 	}
 
+	if detach && wait {
+		return RemoteExecArgs{
+			Err: "--wait and --detach cannot be combined; --detach returns immediately and would ignore --wait",
+		}
+	}
+
 	// Parse SSH-like user@host syntax
 	if server != "" && strings.Contains(server, "@") && !strings.Contains(server, ":") {
 		sshTarget := utils.ParseSSHTarget(server)

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -15,6 +15,7 @@ type RemoteExecArgs struct {
 	Server        string
 	Command       string
 	Detach        bool
+	Wait          bool
 	ShowHelp      bool
 	Err           string
 }
@@ -35,8 +36,9 @@ type RemoteExecArgs struct {
 func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 	var (
 		username, groupname, workSessionID, outputFormat, server string
-		commandParts                                              []string
-		detach                                                    bool
+		commandParts                                             []string
+		detach                                                   bool
+		wait                                                     bool
 	)
 
 	for i := 0; i < len(args); i++ {
@@ -100,6 +102,10 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 			detach = true
 		case strings.HasPrefix(arg, "--detach="):
 			return RemoteExecArgs{Err: "--detach does not accept a value; use --detach alone"}
+		case arg == "--wait":
+			wait = true
+		case strings.HasPrefix(arg, "--wait="):
+			return RemoteExecArgs{Err: "--wait does not accept a value; use --wait alone"}
 		case strings.HasPrefix(arg, "-"):
 			return RemoteExecArgs{Err: "unknown flag: " + arg}
 		default:
@@ -124,6 +130,7 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 		Server:        server,
 		Command:       ShellJoin(commandParts),
 		Detach:        detach,
+		Wait:          wait,
 	}
 }
 

--- a/cmd/exec/pending_approval_test.go
+++ b/cmd/exec/pending_approval_test.go
@@ -1,0 +1,96 @@
+package exec
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	osexec "os/exec"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// approvalDenialResult is the plugin's exact terminal denial line for a sudo
+// command that needs human approval.
+const approvalDenialResult = "Alpacon denied this sudo command (SUDO_APPROVAL_REQUIRED).\n"
+
+// newApprovalDenialServer returns a test server that resolves one server and
+// always answers an exec command with a SUDO_APPROVAL_REQUIRED denial
+// (success=false + the plugin denial line), so the command stays pending.
+func newApprovalDenialServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-1","name":"prod"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/events/commands/":
+			_, _ = fmt.Fprintf(w, `[{"id":"cmd-1"}]`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/events/commands/cmd-1/":
+			resp := map[string]any{
+				"id":          "cmd-1",
+				"status":      "completed",
+				"success":     false,
+				"exit_code":   1,
+				"result":      approvalDenialResult,
+				"error_phase": nil,
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestExecPendingApprovalExits4WithJSONSignal(t *testing.T) {
+	ts := newApprovalDenialServer()
+	defer ts.Close()
+
+	home := t.TempDir()
+	writeExecCommandTestConfig(t, home, ts.URL)
+
+	helper := osexec.Command(
+		os.Args[0],
+		"-test.run=^TestExecCommandWorkSessionGateHelperProcess$",
+		"--",
+		"exec-worksession-helper",
+		"--output",
+		"json",
+		"prod",
+		"--",
+		"sudo",
+		"reboot",
+	)
+	helper.Env = append(os.Environ(),
+		"GO_WANT_EXEC_WORKSESSION_HELPER=1",
+		"ALPACON_WORK_SESSION=",
+		"HOME="+home,
+	)
+	var stdout, stderr bytes.Buffer
+	helper.Stdout = &stdout
+	helper.Stderr = &stderr
+
+	err := helper.Run()
+	require.Error(t, err)
+	var exitErr *osexec.ExitError
+	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	assert.Equal(t, utils.ExitCodePendingApproval, exitErr.ExitCode(), "pending approval must exit 4")
+
+	var got struct {
+		OK          bool     `json:"ok"`
+		Status      string   `json:"status"`
+		ExitCode    int      `json:"exit_code"`
+		NextActions []string `json:"next_actions"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got), "stdout: %s", stdout.String())
+	assert.False(t, got.OK)
+	assert.Equal(t, utils.PendingApprovalStatus, got.Status)
+	assert.Equal(t, utils.ExitCodePendingApproval, got.ExitCode)
+	require.NotEmpty(t, got.NextActions)
+	assert.Equal(t, "alpacon exec prod -- sudo reboot", got.NextActions[0], "re-run hint should reconstruct the invocation")
+}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -187,7 +187,9 @@ func RunExecWithApprovalWait(ac *client.AlpaconClient, serverName, command, user
 			// pending-approval signal and exit code.
 			return result, err
 		case <-ticker.C:
-			result, err = RunCommandWithRetry(ac, serverName, command, username, groupname, env, workSessionID)
+			// Re-attempt via the presence-aware path so a step-up still fires if
+			// the approved command then needs fresh MFA (SUDO_PRESENCE_REQUIRED).
+			result, err = RunExecWithPresenceStepUp(ac, serverName, command, username, groupname, env, workSessionID)
 			if isApprovalDenial(result, err) {
 				// Still pending—keep waiting.
 				continue

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -5,12 +5,24 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/api/mfa"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
+)
+
+const (
+	// approvalWaitPollInterval and approvalWaitTimeout bound the --wait poll for a
+	// SUDO_APPROVAL_REQUIRED denial. The interval is slower than the MFA step-up
+	// poll (api/mfa/mfa.go) because each tick re-submits and re-runs the remote
+	// command, and a human approving out of band in the console works on a
+	// seconds-to-minutes timescale, not sub-second. The 3-minute ceiling mirrors
+	// maxRetryDuration in utils/error_handler.go so the two waits feel consistent.
+	approvalWaitPollInterval = 5 * time.Second
+	approvalWaitTimeout      = 3 * time.Minute
 )
 
 // sudoDenialLinePrefix is the exact terminal-facing denial line emitted by
@@ -80,6 +92,16 @@ func hasSudoPresenceDenial(output string) bool {
 	return denialCodePresent(output, "SUDO_PRESENCE_REQUIRED")
 }
 
+// hasSudoApprovalDenial reports whether output carries the sudo approval-required
+// denial (SUDO_APPROVAL_REQUIRED): a human must approve the request out of band
+// in the Alpacon console before the command can run. Like the other detectors it
+// anchors on the plugin's exact terminal denial line via denialCodePresent, so a
+// command that merely prints the token in its own output cannot forge a pending
+// signal or wedge --wait into an indefinite re-run loop.
+func hasSudoApprovalDenial(output string) bool {
+	return denialCodePresent(output, "SUDO_APPROVAL_REQUIRED")
+}
+
 // RunExecWithPresenceStepUp runs a command via RunCommandWithRetry and, when it
 // is denied for a missing recent MFA (SUDO_PRESENCE_REQUIRED) on an interactive
 // terminal, offers an MFA step-up and retries once. Non-interactive callers
@@ -117,6 +139,84 @@ func RunExecWithPresenceStepUp(ac *client.AlpaconClient, serverName, command, us
 	// Presence is fresh—retry once. Any remaining denial falls through to the
 	// static hint in HandleCommandResult.
 	return RunCommandWithRetry(ac, serverName, command, username, groupname, env, workSessionID)
+}
+
+// isApprovalDenial reports whether (result, err) is a SUDO_APPROVAL_REQUIRED
+// denial: the command exited non-zero (a real denial always surfaces as a
+// RemoteCommandError) AND the plugin's exact approval denial line is present.
+// Requiring both guards against a command that merely prints the token but
+// succeeds (err == nil) being mistaken for a pending approval.
+func isApprovalDenial(result string, err error) bool {
+	var remoteErr *event.RemoteCommandError
+	return errors.As(err, &remoteErr) && hasSudoApprovalDenial(result)
+}
+
+// RunExecWithApprovalWait runs a command via RunExecWithPresenceStepUp and, when
+// it is denied pending human approval (SUDO_APPROVAL_REQUIRED) and wait is set,
+// blocks and re-attempts the command on a fixed interval until a reviewer
+// approves it out of band (the re-run then succeeds or hits a different,
+// terminal denial), or the bounded timeout elapses. When wait is false, or the
+// denial is anything other than SUDO_APPROVAL_REQUIRED, it returns the first
+// (result, err) unchanged so the caller's pending/denial handling runs.
+//
+// Re-attempting the command is the only poll available here: the plugin's denial
+// line carries the denial code but no approval request id, and this credential
+// channel has no approval-status endpoint to query (ADR 0015 moves approval out
+// of band). Re-running is side-effect-safe: a sudo command pending approval is
+// denied by the server and never executes, so each poll tick is a no-op denial
+// until a reviewer approves, at which point the command runs exactly once. The
+// poll mirrors the MFA step-up structure (api/mfa/mfa.go): a spinner, a
+// fixed-interval ticker, and a precise deadline.
+func RunExecWithApprovalWait(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, wait bool) (string, error) {
+	result, err := RunExecWithPresenceStepUp(ac, serverName, command, username, groupname, env, workSessionID)
+	if !wait || !isApprovalDenial(result, err) {
+		return result, err
+	}
+
+	spinner := utils.NewSpinner("Waiting for approval in the Alpacon console...")
+	spinner.Start()
+
+	deadline := time.After(approvalWaitTimeout)
+	ticker := time.NewTicker(approvalWaitPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			spinner.Stop()
+			// Return the last pending denial so the caller emits the standard
+			// pending-approval signal and exit code.
+			return result, err
+		case <-ticker.C:
+			result, err = RunCommandWithRetry(ac, serverName, command, username, groupname, env, workSessionID)
+			if isApprovalDenial(result, err) {
+				// Still pending—keep waiting.
+				continue
+			}
+			spinner.Stop()
+			return result, err
+		}
+	}
+}
+
+// HandlePendingApproval emits the structured pending-approval feedback for an
+// exec sudo command that was denied SUDO_APPROVAL_REQUIRED and not waited on,
+// then exits with ExitCodePendingApproval. It reports true when it handled the
+// (result, err); the caller skips its normal result handling on true. The exec
+// denial line carries no approval request id, so the machine signal omits it.
+// reRunHint is the exact command the caller invoked, so a human can copy-paste
+// it once the request is approved.
+func HandlePendingApproval(result string, err error, reRunHint string) bool {
+	if !isApprovalDenial(result, err) {
+		return false
+	}
+	utils.PrintPendingApproval(
+		"Approval required—a human must approve this sudo command in the Alpacon console (web). "+
+			"Re-run after approval, or use --wait to block until it is approved.",
+		"", // the exec sudo denial line carries no approval request id
+		reRunHint,
+	)
+	os.Exit(utils.ExitCodePendingApproval)
+	return true
 }
 
 // RunCommandWithRetry executes a remote command with MFA and username-required

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -176,12 +176,13 @@ func RunExecWithApprovalWait(ac *client.AlpaconClient, serverName, command, user
 	spinner := utils.NewSpinner("Waiting for approval in the Alpacon console...")
 	spinner.Start()
 
-	deadline := time.After(approvalWaitTimeout)
+	timer := time.NewTimer(approvalWaitTimeout)
+	defer timer.Stop()
 	ticker := time.NewTicker(approvalWaitPollInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-deadline:
+		case <-timer.C:
 			spinner.Stop()
 			// Return the last pending denial so the caller emits the standard
 			// pending-approval signal and exit code.

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -1,9 +1,12 @@
 package exec
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -95,5 +98,77 @@ func TestHasSudoPresenceDenial(t *testing.T) {
 		// A line that stops at ")" is not the plugin's output and must not match.
 		assert.False(t, hasSudoPresenceDenial(
 			"Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED)\n"))
+	})
+}
+
+func TestHasSudoApprovalDenial(t *testing.T) {
+	t.Run("true on the real approval denial line", func(t *testing.T) {
+		assert.True(t, hasSudoApprovalDenial(
+			"Alpacon denied this sudo command (SUDO_APPROVAL_REQUIRED).\n"))
+	})
+
+	t.Run("false for other denial codes", func(t *testing.T) {
+		assert.False(t, hasSudoApprovalDenial(
+			"Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED).\n"))
+		assert.False(t, hasSudoApprovalDenial(
+			"Alpacon denied this sudo command (SUDO_RISK_DENIED).\n"))
+	})
+
+	t.Run("forged parenthesized token does not trigger a pending signal", func(t *testing.T) {
+		// A command whose own output prints the token, without the plugin's denial
+		// line, must not be mistaken for a pending approval.
+		assert.False(t, hasSudoApprovalDenial(
+			"echo \"(SUDO_APPROVAL_REQUIRED)\"\n(SUDO_APPROVAL_REQUIRED)\n"))
+	})
+
+	t.Run("false on clean output", func(t *testing.T) {
+		assert.False(t, hasSudoApprovalDenial("ok\n"))
+		assert.False(t, hasSudoApprovalDenial(""))
+	})
+}
+
+func TestIsApprovalDenial(t *testing.T) {
+	const denialLine = "Alpacon denied this sudo command (SUDO_APPROVAL_REQUIRED).\n"
+
+	t.Run("true when the denial line accompanies a non-zero exit", func(t *testing.T) {
+		assert.True(t, isApprovalDenial(denialLine, &event.RemoteCommandError{ExitCode: 1, Output: denialLine}))
+	})
+
+	t.Run("true through a wrapped RemoteCommandError", func(t *testing.T) {
+		wrapped := fmt.Errorf("failed to execute command: %w", &event.RemoteCommandError{ExitCode: 1})
+		assert.True(t, isApprovalDenial(denialLine, wrapped))
+	})
+
+	t.Run("false when the command printed the line but succeeded", func(t *testing.T) {
+		// err == nil means the command did not actually get denied; a command that
+		// merely echoes the denial line must not be treated as pending.
+		assert.False(t, isApprovalDenial(denialLine, nil))
+	})
+
+	t.Run("false for a non-approval denial", func(t *testing.T) {
+		out := "Alpacon denied this sudo command (SUDO_RISK_DENIED).\n"
+		assert.False(t, isApprovalDenial(out, &event.RemoteCommandError{ExitCode: 1, Output: out}))
+	})
+
+	t.Run("false for a plain error without the denial line", func(t *testing.T) {
+		assert.False(t, isApprovalDenial("boom\n", errors.New("nope")))
+	})
+}
+
+func TestReRunHint(t *testing.T) {
+	t.Run("minimal: server and command only", func(t *testing.T) {
+		got := reRunHint(RemoteExecArgs{Server: "web-01", Command: "sudo reboot"})
+		assert.Equal(t, "alpacon exec web-01 -- sudo reboot", got)
+	})
+
+	t.Run("includes user, group, and work-session", func(t *testing.T) {
+		got := reRunHint(RemoteExecArgs{
+			Username:      "root",
+			Groupname:     "docker",
+			WorkSessionID: "ses-1",
+			Server:        "web-01",
+			Command:       "sudo reboot",
+		})
+		assert.Equal(t, "alpacon exec -u root -g docker --work-session ses-1 web-01 -- sudo reboot", got)
 	})
 }

--- a/cmd/worksession/worksession_approve.go
+++ b/cmd/worksession/worksession_approve.go
@@ -1,56 +1,34 @@
 package worksession
 
 import (
-	"github.com/alpacax/alpacon-cli/api/server"
-	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
-	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
 
-var (
-	approveScopes  []string
-	approveServers []string
-)
+// approveRejectExcludedMessage explains why the CLI no longer approves or rejects
+// work sessions. ADR 0015 makes the CLI an execution/request surface only:
+// approval happens out of band in the Alpacon console (web/Slack), and the server
+// now refuses (HTTP 403) approve/reject from the CLI credential channel. The
+// subcommands stay registered so the message is discoverable and existing scripts
+// get an intentional, actionable exit instead of an "unknown command".
+const approveRejectExcludedMessage = "Approvals must be done in the Alpacon console (web), not the CLI. " +
+	"The CLI is an execution and request surface only; approve and reject happen out of band. " +
+	"Use 'alpacon work-session ls' to track a session's status."
 
 var workSessionApproveCmd = &cobra.Command{
 	Use:   "approve SESSION_ID",
-	Short: "Approve a pending work session",
-	Long: `Approve a pending work session. Superuser only.
+	Short: "Approve a session (moved to the Alpacon console)",
+	Long: `Approving work sessions has moved to the Alpacon console (web).
 
-Without flags, approves the session as originally requested.
-Use --scope and --server to narrow down the granted access at approval time.`,
-	Args: cobra.ExactArgs(1),
-	Example: `  alpacon work-session approve ses-abc123
-  alpacon work-session approve ses-abc123 --scope command --scope websh
-  alpacon work-session approve ses-abc123 --scope command,websh --server web-01`,
+The CLI is an execution and request surface only; a human approves or rejects
+out of band in the web console or Slack. The server rejects approve/reject from
+the CLI credential channel. Use 'alpacon work-session ls' to track status.`,
+	Args: cobra.ArbitraryArgs,
+	Example: `  # Approve in the Alpacon console (web), then track status here:
+  alpacon work-session ls --status active`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ac, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		req := wsapi.WorkSessionApproveRequest{
-			AdjustedScopes: utils.CompactStrings(approveScopes),
-		}
-
-		if len(approveServers) > 0 {
-			serverIDs, err := server.ResolveServerNames(ac, approveServers)
-			if err != nil {
-				utils.CliErrorWithExit("%s.", err)
-			}
-			req.AdjustedServers = serverIDs
-		}
-
-		if err := wsapi.ApproveWorkSession(ac, args[0], req); err != nil {
-			utils.CliErrorWithExit("Failed to approve work session: %s.", err)
-		}
-
-		utils.CliSuccess("Work session %s approved.", args[0])
+		// Exit non-zero so a script that expected the approval to happen does not
+		// mistake this for success—the CLI must never pretend to approve.
+		utils.CliErrorWithExit("%s", approveRejectExcludedMessage)
 	},
-}
-
-func init() {
-	workSessionApproveCmd.Flags().StringSliceVar(&approveScopes, "scope", nil, "Adjust granted scopes (repeatable; comma-separated values also accepted)")
-	workSessionApproveCmd.Flags().StringSliceVar(&approveServers, "server", nil, "Adjust target servers by name (repeatable; comma-separated values also accepted)")
 }

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -3,6 +3,7 @@ package worksession
 import (
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -217,6 +218,20 @@ session with 'alpacon work-session update <id> --sudo "<command>"'.`,
 		}
 
 		if !waitApproval {
+			// A session that lands pending needs a human to approve it out of band
+			// (ADR 0015). Emit the structured pending-approval signal and exit with
+			// ExitCodePendingApproval so a machine consumer (AI agent, CI) can branch
+			// on "wait or check later" instead of treating the pending create as a
+			// success. Other statuses (e.g. auto-approved) keep the existing success
+			// output and exit 0.
+			if session.Status == pendingWorkSessionStatus {
+				utils.PrintPendingApproval(
+					fmt.Sprintf("Approval required—work session %s is pending. A human must approve it in the Alpacon console (web).", session.ID),
+					session.ApprovalRequestID,
+					fmt.Sprintf("alpacon work-session use %s  # after approval", session.ID),
+				)
+				os.Exit(utils.ExitCodePendingApproval)
+			}
 			if utils.OutputFormat == utils.OutputFormatJSON {
 				printWorkSessionMutationJSON(newWorkSessionMutationOutput("create", createSuccessMessage(session), session, nil))
 			}

--- a/cmd/worksession/worksession_reject.go
+++ b/cmd/worksession/worksession_reject.go
@@ -1,28 +1,24 @@
 package worksession
 
 import (
-	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
-	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
 
 var workSessionRejectCmd = &cobra.Command{
-	Use:     "reject SESSION_ID",
-	Short:   "Reject a pending work session",
-	Long:    "Reject a pending work session. Superuser only.",
-	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon work-session reject ses-abc123`,
+	Use:   "reject SESSION_ID",
+	Short: "Reject a session (moved to the Alpacon console)",
+	Long: `Rejecting work sessions has moved to the Alpacon console (web).
+
+The CLI is an execution and request surface only; a human approves or rejects
+out of band in the web console or Slack. The server rejects approve/reject from
+the CLI credential channel. Use 'alpacon work-session ls' to track status.`,
+	Args: cobra.ArbitraryArgs,
+	Example: `  # Reject in the Alpacon console (web), then track status here:
+  alpacon work-session ls --status rejected`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ac, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		if err := wsapi.RejectWorkSession(ac, args[0]); err != nil {
-			utils.CliErrorWithExit("Failed to reject work session: %s.", err)
-		}
-
-		utils.CliSuccess("Work session %s rejected.", args[0])
+		// Exit non-zero so a script that expected the reject to happen does not
+		// mistake this for success—the CLI must never pretend to reject.
+		utils.CliErrorWithExit("%s", approveRejectExcludedMessage)
 	},
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -21,6 +21,19 @@ const (
 
 	// ExitCodeWorkSessionDenied is the process exit code for WorkSession gate refusals.
 	ExitCodeWorkSessionDenied = 3
+
+	// ExitCodePendingApproval is the process exit code for an action that landed
+	// pending human approval (a sudo HITL SUDO_APPROVAL_REQUIRED denial, or a work
+	// session created in the pending state) and was not waited on with --wait.
+	// It is distinct from ExitCodeWorkSessionDenied (3): the action was not
+	// refused, it is awaiting an out-of-band approve/reject in the Alpacon console
+	// (web/Slack). Scripts and AI agents branch on it to "wait or check later"
+	// rather than treat it as a hard failure.
+	ExitCodePendingApproval = 4
+
+	// PendingApprovalStatus is the stable machine-readable status string emitted
+	// under --output json when an action is pending human approval.
+	PendingApprovalStatus = "pending_approval"
 )
 
 type ErrorResponse struct {

--- a/utils/pending_approval.go
+++ b/utils/pending_approval.go
@@ -1,0 +1,70 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+// pendingApprovalCtx is the machine-readable context for a pending-approval
+// signal. RequestID is the approval request to track; it is omitted when the
+// originating surface cannot surface one (e.g. the exec sudo denial line carries
+// only the denial code, never a request id).
+type pendingApprovalCtx struct {
+	RequestID string `json:"request_id,omitempty"`
+}
+
+// pendingApprovalJSON is the JSON envelope printed under --output json for a
+// pending-approval signal. Status is always PendingApprovalStatus, so a machine
+// consumer can match on a single stable field without parsing prose.
+type pendingApprovalJSON struct {
+	OK          bool               `json:"ok"`
+	Status      string             `json:"status"`
+	ExitCode    int                `json:"exit_code"`
+	Message     string             `json:"message"`
+	RequestID   string             `json:"request_id,omitempty"`
+	Context     pendingApprovalCtx `json:"context"`
+	NextActions []string           `json:"next_actions,omitempty"`
+}
+
+// pendingApprovalNextActions lists the actionable follow-ups for a human reading
+// the message. reRunHint is the surface-specific way to retry (re-run the
+// command, or attach the session); it leads, then the generic console pointer.
+func pendingApprovalNextActions(reRunHint string) []string {
+	actions := make([]string, 0, 2)
+	if reRunHint != "" {
+		actions = append(actions, reRunHint)
+	}
+	return append(actions, "Approve out of band in the Alpacon console (web), then retry, or re-run with --wait to block.")
+}
+
+// PrintPendingApproval emits the structured "pending approval" feedback for an
+// action that requires out-of-band human approval and was not waited on. Under
+// --output json it writes a {"status":"pending_approval", ...} envelope to
+// stdout; otherwise it writes an actionable message to stderr. requestID may be
+// empty when the surface cannot supply one. reRunHint is a surface-specific
+// retry instruction (e.g. the exact command to re-run). It never exits — the
+// caller owns process exit so the exit-code contract stays in one place.
+func PrintPendingApproval(message, requestID, reRunHint string) {
+	if OutputFormat == OutputFormatJSON {
+		envelope := pendingApprovalJSON{
+			OK:          false,
+			Status:      PendingApprovalStatus,
+			ExitCode:    ExitCodePendingApproval,
+			Message:     message,
+			RequestID:   requestID,
+			Context:     pendingApprovalCtx{RequestID: requestID},
+			NextActions: pendingApprovalNextActions(reRunHint),
+		}
+		if err := PrintJSONValue(os.Stdout, envelope); err != nil {
+			// Fall back to a minimal, still-parseable object so a machine consumer
+			// always sees the status field.
+			_, _ = fmt.Fprintf(os.Stdout, `{"ok":false,"status":%q}`+"\n", PendingApprovalStatus)
+		}
+		return
+	}
+
+	CliWarning("%s", message)
+	for _, action := range pendingApprovalNextActions(reRunHint) {
+		fmt.Fprintf(os.Stderr, "  %s\n", action)
+	}
+}

--- a/utils/pending_approval.go
+++ b/utils/pending_approval.go
@@ -34,7 +34,7 @@ func pendingApprovalNextActions(reRunHint string) []string {
 	if reRunHint != "" {
 		actions = append(actions, reRunHint)
 	}
-	return append(actions, "Approve out of band in the Alpacon console (web), then retry, or re-run with --wait to block.")
+	return append(actions, "Approve it out of band in the Alpacon console (web/Slack). Where supported, pass --wait on the original command to block until approval.")
 }
 
 // PrintPendingApproval emits the structured "pending approval" feedback for an

--- a/utils/pending_approval_test.go
+++ b/utils/pending_approval_test.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintPendingApproval_JSONOutput(t *testing.T) {
+	var out string
+	withFormat(OutputFormatJSON, func() {
+		out = captureStdout(t, func() {
+			PrintPendingApproval("needs approval", "apr-123", "alpacon exec srv -- sudo reboot")
+		})
+	})
+
+	var got struct {
+		OK        bool   `json:"ok"`
+		Status    string `json:"status"`
+		ExitCode  int    `json:"exit_code"`
+		Message   string `json:"message"`
+		RequestID string `json:"request_id"`
+		Context   struct {
+			RequestID string `json:"request_id"`
+		} `json:"context"`
+		NextActions []string `json:"next_actions"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "output: %s", out)
+
+	assert.False(t, got.OK)
+	assert.Equal(t, PendingApprovalStatus, got.Status, "status must be the stable machine-readable string")
+	assert.Equal(t, ExitCodePendingApproval, got.ExitCode)
+	assert.Equal(t, "apr-123", got.RequestID)
+	assert.Equal(t, "apr-123", got.Context.RequestID)
+	assert.Equal(t, "needs approval", got.Message)
+	require.NotEmpty(t, got.NextActions)
+	assert.Equal(t, "alpacon exec srv -- sudo reboot", got.NextActions[0], "the re-run hint leads the next actions")
+}
+
+func TestPrintPendingApproval_JSONOutput_OmitsEmptyRequestID(t *testing.T) {
+	var out string
+	withFormat(OutputFormatJSON, func() {
+		out = captureStdout(t, func() {
+			PrintPendingApproval("needs approval", "", "")
+		})
+	})
+
+	// request_id has omitempty, so an absent id must not appear as an empty string.
+	assert.NotContains(t, out, `"request_id"`, "empty request_id must be omitted, not serialized as \"\"")
+	// status stays present and stable even without a request id.
+	assert.Contains(t, out, `"status": "`+PendingApprovalStatus+`"`)
+}


### PR DESCRIPTION
## Summary

Implements the alpacon-cli side of ADR 0015: the CLI is an execution and request surface only—approval happens out of band in the Alpacon console (web/Slack). When an action lands pending human approval the CLI now signals "pending approval—wait or check later" instead of looking like a failure, and it no longer offers approve/reject as if they work (the server now 403s those from the CLI credential channel).

## Changes

### 1. `--wait` blocking mode for `exec`
- `alpacon exec` gets a `--wait` flag. On a `SUDO_APPROVAL_REQUIRED` sudo denial, it blocks and re-attempts the command on a fixed interval until a reviewer approves it out of band (the re-run then succeeds or hits a different, terminal denial), or the bounded timeout elapses.
- Re-attempting is the only poll available: the plugin denial line carries the denial code but no approval request id, and this credential channel has no approval-status endpoint to query. Re-running is side-effect-safe—a pending sudo command is denied server-side and never executes until approved, so each tick is a no-op denial until approval, then runs exactly once.
- The poll mirrors the existing MFA step-up structure (`api/mfa/mfa.go` `StepUpForSudo`): a spinner, a fixed-interval ticker, and a precise deadline.
- `work-session create --wait` already existed (`pollForApproval`) and is unchanged.

### 2. Structured pending feedback when not waiting
- New stable exit code `4` (`ExitCodePendingApproval`)—distinct from `3` (WorkSession gate denied). The action was not refused; it is awaiting an out-of-band approve/reject. Documented in the README "Exit codes" table and in `exec --help`.
- New shared `utils.PrintPendingApproval` helper. Under `--output json` it emits `{"ok":false,"status":"pending_approval","exit_code":4,...}` on stdout; otherwise it prints an actionable message to stderr.
- `exec` (`SUDO_APPROVAL_REQUIRED`, no `--wait`) and `work-session create` (lands pending, no `--wait`) both emit the signal and exit `4`. `work-session create` includes the real `approval_request_id`; the exec sudo denial line carries no request id, so that field is omitted (documented in code).
- Security: the exec pending signal is anchored on the same unforgeable plugin denial line as `sudoDenialHint`/`hasSudoPresenceDenial` (full `Alpacon denied this sudo command (CODE).` line plus a non-zero exit), so a command that merely prints the token in its own output cannot forge a pending signal or wedge `--wait` into an indefinite re-run loop.

### 3. Approve/reject excluded from the execution surface
- `alpacon approval approve|reject` and `alpacon work-session approve|reject` now exit non-zero with "Approvals must be done in the Alpacon console (web), not the CLI." rather than calling the now-403'd endpoint. They exit non-zero (not 0) so a script that expected the approval to happen does not mistake it for success—the CLI must never pretend to approve.
- The subcommands stay registered (shown as "moved to the Alpacon console" in help) so the message is discoverable and existing scripts get an intentional, actionable exit instead of an "unknown command". Read-only `ls`/`describe` and requester-side `cancel` are unchanged. The API-layer wrappers stay (still tested, and the 403-propagation test documents the server behavior).

## Testing
- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass.
- New tests: `hasSudoApprovalDenial`/`isApprovalDenial` anchoring and forgery-safety, `reRunHint` reconstruction, `PrintPendingApproval` JSON shape (including `request_id` omitempty), and an end-to-end helper-process test asserting exec exits `4` with the `pending_approval` JSON signal.

## Note for reviewers
The exec `--wait` poll re-attempts the command because, on this credential channel, there is no approval-status endpoint to query and the denial line has no request id. If a dedicated approval-status endpoint becomes reachable from the CLI later, the poll could switch to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)