### PR TITLE
fix: reject attaching an agent work session in 'work-session use'

### DIFF
--- a/cmd/worksession/worksession_use.go
+++ b/cmd/worksession/worksession_use.go
@@ -105,6 +105,13 @@ func RunUseSession(ac *client.AlpaconClient, uuid string) (*wsapi.WorkSession, e
 	if ws.Status != activeWorkSessionStatus {
 		return nil, fmt.Errorf("work-session %s is in '%s' state and cannot be used", ws.ID, ws.Status)
 	}
+	// Agent sessions are not workspace-attachable (mirrors the create --use guard):
+	// they run non-interactively via their assigned token, not the interactive
+	// current-session path. Attaching one would let interactive exec/websh run
+	// against it and fail opaquely, so reject it here with a clear message.
+	if ws.RequesterType == "agent" {
+		return nil, fmt.Errorf("work-session %s is an agent session and is not workspace-attachable; agent sessions run non-interactively via their assigned token", ws.ID)
+	}
 	// Persist the canonical ID from the API rather than the raw argument so config
 	// stays consistent with server-side canonicalization and the printed JSON fields.
 	if err := config.SetActiveWorkSession(ws.ID); err != nil {

--- a/cmd/worksession/worksession_use_test.go
+++ b/cmd/worksession/worksession_use_test.go
@@ -90,6 +90,30 @@ func TestRunUse_RejectsNonActiveStatus(t *testing.T) {
 	assert.Equal(t, "", got)
 }
 
+func TestRunUse_RejectsAgentSession(t *testing.T) {
+	setupTmpConfig(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":             "ses-agent",
+			"description":    "agent job",
+			"status":         "active",
+			"requester_type": "agent",
+		})
+	}))
+	defer ts.Close()
+	ac := newTestClient(ts)
+
+	// Agent sessions are not workspace-attachable; even when active they must be
+	// rejected here so an interactive exec/websh never silently runs against one.
+	_, err := worksession.RunUse(ac, "ses-agent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not workspace-attachable")
+
+	got, _ := config.GetActiveWorkSession()
+	assert.Equal(t, "", got, "config must not be updated for an agent session")
+}
+
 func TestRunUnset_Idempotent(t *testing.T) {
 	setupTmpConfig(t)
 

--- a/cmd/worksession/worksession_use_test.go
+++ b/cmd/worksession/worksession_use_test.go
@@ -93,6 +93,10 @@ func TestRunUse_RejectsNonActiveStatus(t *testing.T) {
 func TestRunUse_RejectsAgentSession(t *testing.T) {
 	setupTmpConfig(t)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/api/work-sessions/sessions/ses-agent/") {
+			http.NotFound(w, r)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":             "ses-agent",


### PR DESCRIPTION
## Summary

Found while dogfooding the ADR 0015 flow on dev. Agent-type work sessions are **not workspace-attachable** — `work-session create --use` already rejects them (`worksession_create.go:121`). But the standalone `work-session use <id>` (`RunUseSession`) only validated *status*, so a human could attach an agent session, and then interactive `exec`/`websh` ran against it and **failed opaquely** (empty output, no error).

## Fix
Add a `requester_type == "agent"` guard in `RunUseSession`, returning a clear error **before** persisting to config — consistent with the `create --use` rejection.

```
work-session <id> is an agent session and is not workspace-attachable;
agent sessions run non-interactively via their assigned token
```

## Tests
- `TestRunUse_RejectsAgentSession` — active + `requester_type=agent` ⇒ error, and the active work-session config is **not** mutated.
- `go build ./...`, `go vet`, `go test ./cmd/worksession/` green.

## Review
Self review run before PR — **APPROVED**. Guard placement makes the no-mutation property structural (early return before `SetActiveWorkSession`); a non-agent / legacy session with an absent `requester_type` passes through unchanged.