### PR TITLE
ci: bump create-github-app-token v1 → v3 and switch to client-id

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,9 +76,9 @@ jobs:
       # GitHub App instead.
       - name: Generate App token
         id: release-publisher-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_PUBLISHER_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PUBLISHER_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |


### PR DESCRIPTION
## Background

The GoReleaser job in the release workflow (`release.yaml`) emits this deprecation warning:

> Node.js 20 actions are deprecated. ... `actions/create-github-app-token@v1` ...
> Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

The cause is not our code—the third-party action `create-github-app-token@v1` still runs on the Node 20 runtime. The action switched to Node 24 starting in v3.0.0.

## Changes

In the token-minting step of `.github/workflows/release.yaml`:

- `actions/create-github-app-token@v1` → `@v3` (Node 24 → clears the warning)
- `app-id` → `client-id` input (`app-id` is deprecated as of v3.1.0)

The `private-key`, `owner`, `repositories`, and `permission-contents` inputs are unchanged—their format did not change.

> `@v3` is a moving major tag (currently resolves to v3.2.0) and matches the existing convention in this workflow (`goreleaser/goreleaser-action@v7`). It auto-tracks 3.x patches/minors but never crosses to v4.

## ⚠️ Required before merge

The switch to `client-id` requires a **new repo secret**. Without it the release workflow will fail authentication.

1. Copy the **Client ID** (`Iv23li...`) from the `alpacax-release-publisher` GitHub App settings
2. Register it as the secret `RELEASE_PUBLISHER_CLIENT_ID` on the `alpacon-cli` repo:
   - `gh secret set RELEASE_PUBLISHER_CLIENT_ID --repo alpacax/alpacon-cli`

> Note: the existing `RELEASE_PUBLISHER_APP_ID` secret is no longer used. It is kept for now (rollback safety) and can be cleaned up later. `RELEASE_PUBLISHER_PRIVATE_KEY` is still used.

## Compatibility check (v1 → v3 breaking changes)

| Change | Impact |
|---|---|
| v2.0.0: removed underscore inputs (`app_id`, etc.) | None—already using hyphenated inputs |
| v3.0.0: removed custom proxy handling | None—no `HTTP_PROXY`/`HTTPS_PROXY` in use |
| v3.0.0: requires self-hosted runner v2.327.1+ | None—GitHub-hosted runners |

## References

- v3.0.0 (Node 24): https://github.com/actions/create-github-app-token/releases/tag/v3.0.0
- v3.1.0 (`client-id` added, `app-id` deprecated): https://github.com/actions/create-github-app-token/releases/tag/v3.1.0