### PR TITLE
docs: simplify Homebrew install to avoid tap trust prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ For production usage, see the [official documentation](https://docs.alpacax.com/
 
 ### macOS (Homebrew)
 ```bash
-brew tap alpacax/alpacon
-brew install alpacon-cli
+brew install alpacax/alpacon/alpacon-cli
 ```
 
 ### Linux (Debian / Ubuntu)


### PR DESCRIPTION
## Background

**Homebrew 5.1.15** (merged on 2026-05-30) introduced the **Tap Trust** security feature. Loading a formula from a third-party tap now requires the user to explicitly trust it, and this will be enforced starting with Homebrew 6.0.0 (or 5.2.0, whichever comes first).

As a result, installing via the current README instructions fails with:

```
Error: Refusing to load formula alpacax/alpacon/alpacon-cli from untrusted tap alpacax/alpacon
```

Users are now forced to run `brew trust` in addition to `brew tap` + `brew install`.

## Changes

Replaced the two-step Homebrew install in the README with a single fully-qualified command:

```diff
-brew tap alpacax/alpacon
-brew install alpacon-cli
+brew install alpacax/alpacon/alpacon-cli
```

Installing by the fully-qualified name (`owner/repo/formula`) makes Homebrew:
1. Automatically add the `alpacax/homebrew-alpacon` tap
2. Trust only that formula
3. Install it

No separate `brew tap` / `brew trust` step is required. This also stays backward-compatible with older Homebrew versions, where fully-qualified install has always worked.

## Notes

- Tap maintainers cannot make a third-party tap trusted by default (no signing, metadata, or allowlist is supported). The root-cause fix would be homebrew-core registration, but that is gated by notability requirements, so this is the practical workaround for now.
- No build/config changes (`.goreleaser.yaml`) — the tap setup itself is correct.

## Follow-up

Once this PR is approved, the docs will be updated to match.

## References

- [Homebrew Tap Trust](https://docs.brew.sh/Tap-Trust)
- [Homebrew 5.1.15 release](https://github.com/Homebrew/brew/releases/tag/5.1.15)
