### PR TITLE
docs(worksession): guide agent requester-type and a specific --purpose

### DIFF
--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -68,9 +68,8 @@ prompt. The 'sudo' scope is added automatically, and the policies are submitted 
 approval together with the session. If a sudo command is later denied, add it to the
 session with 'alpacon work-session update <id> --sudo "<command>"'.
 
-When an AI agent (rather than a human) drives the session, pass --requester-type=agent
-so it is recorded and scoped accordingly. Token-authenticated callers are treated as
-agents automatically.`,
+When an AI agent (rather than a human) drives the session, pass --requester-type agent
+so it is recorded and scoped accordingly.`,
 	Example: `  alpacon work-session create --scope command,websh --server web-01 --expires-in 2h --purpose "nginx fix"
   alpacon work-session create --scope command --server web-01,db-01 --expires-at 2027-01-15T10:00:00Z --purpose "deploy" --wait
   alpacon work-session create --scope command --server web-01 --expires-in 1h --purpose "hotfix" --use
@@ -427,7 +426,7 @@ func init() {
 	workSessionCreateCmd.Flags().StringSliceVar(&createServers, "server", nil, "Target server names (repeatable; comma-separated values also accepted)")
 	workSessionCreateCmd.Flags().StringVar(&expiresIn, "expires-in", "", "Session duration (e.g. 1h, 2h, 4h)")
 	workSessionCreateCmd.Flags().StringVar(&expiresAt, "expires-at", "", "Absolute expiry time (RFC3339)")
-	workSessionCreateCmd.Flags().StringVar(&requesterType, "requester-type", "user", "Requester type: 'user' (default) or 'agent'. Set 'agent' when an AI agent drives the session.")
+	workSessionCreateCmd.Flags().StringVar(&requesterType, "requester-type", "user", "Requester type: 'user' (default) or 'agent' (set when an AI agent drives the session)")
 	workSessionCreateCmd.Flags().BoolVar(&waitApproval, "wait", false, "Poll until the session is approved, then exit (does not set as active; combine with --use to attach automatically)")
 	workSessionCreateCmd.Flags().BoolVar(&useAfterCreate, "use", false, "Set the created session as the workspace's active session (requires status to reach 'active'; combine with --wait when approval is needed)")
 	workSessionCreateCmd.Flags().StringArrayVar(&createSudo, "sudo", nil, "Pre-declare sudo command patterns to run without interactive MFA (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed; literal commas inside a pattern are not supported — pass the flag again for each policy that needs them). Required for non-interactive sudo via 'exec' (e.g. AI agents). Implies the 'sudo' scope. Patterns are submitted for approval with the session.")

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -66,11 +66,16 @@ MFA-bypass sudo policies to the session so a non-interactive caller (e.g. an AI 
 running 'exec') can run those exact sudo commands without an interactive MFA
 prompt. The 'sudo' scope is added automatically, and the policies are submitted for
 approval together with the session. If a sudo command is later denied, add it to the
-session with 'alpacon work-session update <id> --sudo "<command>"'.`,
+session with 'alpacon work-session update <id> --sudo "<command>"'.
+
+When an AI agent (rather than a human) drives the session, pass --requester-type=agent
+so it is recorded and scoped accordingly. Token-authenticated callers are treated as
+agents automatically.`,
 	Example: `  alpacon work-session create --scope command,websh --server web-01 --expires-in 2h --purpose "nginx fix"
   alpacon work-session create --scope command --server web-01,db-01 --expires-at 2027-01-15T10:00:00Z --purpose "deploy" --wait
   alpacon work-session create --scope command --server web-01 --expires-in 1h --purpose "hotfix" --use
   alpacon work-session create --scope command --server web-01 --expires-in 2h --purpose "deploy" --wait --use
+  alpacon work-session create --scope command --server web-01 --expires-in 2h --purpose "automated remediation" --requester-type agent
   alpacon work-session create --server web-01 --expires-in 2h --purpose "nginx hotfix" \
     --sudo "systemctl restart nginx,systemctl reload nginx" --sudo "tail -f /var/log/nginx/*.log"`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -422,7 +427,7 @@ func init() {
 	workSessionCreateCmd.Flags().StringSliceVar(&createServers, "server", nil, "Target server names (repeatable; comma-separated values also accepted)")
 	workSessionCreateCmd.Flags().StringVar(&expiresIn, "expires-in", "", "Session duration (e.g. 1h, 2h, 4h)")
 	workSessionCreateCmd.Flags().StringVar(&expiresAt, "expires-at", "", "Absolute expiry time (RFC3339)")
-	workSessionCreateCmd.Flags().StringVar(&requesterType, "requester-type", "user", "Requester type: user or agent")
+	workSessionCreateCmd.Flags().StringVar(&requesterType, "requester-type", "user", "Requester type: 'user' (default) or 'agent'. Set 'agent' when an AI agent drives the session.")
 	workSessionCreateCmd.Flags().BoolVar(&waitApproval, "wait", false, "Poll until the session is approved, then exit (does not set as active; combine with --use to attach automatically)")
 	workSessionCreateCmd.Flags().BoolVar(&useAfterCreate, "use", false, "Set the created session as the workspace's active session (requires status to reach 'active'; combine with --wait when approval is needed)")
 	workSessionCreateCmd.Flags().StringArrayVar(&createSudo, "sudo", nil, "Pre-declare sudo command patterns to run without interactive MFA (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed; literal commas inside a pattern are not supported — pass the flag again for each policy that needs them). Required for non-interactive sudo via 'exec' (e.g. AI agents). Implies the 'sudo' scope. Patterns are submitted for approval with the session.")


### PR DESCRIPTION
## What
Improve `work-session create` help so an AI agent (a) knows to declare `--requester-type agent`, and (b) writes a specific, scoped `--purpose`. Help text only — no behavior change.

- **requester-type**: guide callers to pass `--requester-type agent` when an AI agent drives the session. The default is `user`, and the CLI credential can't tell a human apart from an agent, so it must be declared.
- **purpose**: `--purpose` is the session's declared intent. Approvers review it to decide and it is the session's record, so guide a specific, scoped description over a vague one-liner like "maintenance". Note multi-line Markdown is supported (renders in the web approval view).
- Make the examples model concrete, scoped intent.

## Verify
- `gofmt` clean, `go build ./...` exit 0
- `work-session create --help` renders the guidance, examples, and flag descriptions