### PR TITLE
fix(login): support service-token login (alpst-)

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -482,10 +482,11 @@ func formatHostURL(host string) string {
 }
 
 // shouldFailOnProfileError reports whether a failed user-profile load should abort
-// login. Browser/password logins (no token) always have a user profile and were not
-// separately credential-checked, so a failure there is fatal. Token logins already
-// validated the credential against /api/status/ in LoginAndSaveCredentials, so a
-// missing user profile (e.g. a service token, an application principal) is non-fatal.
+// login. Browser (Auth0) and username/password logins are human logins that always
+// have a user profile, so a failed preload signals a real problem and is fatal. Token
+// logins were already validated against /api/status/ in LoginAndSaveCredentials, and a
+// service token is an application principal that legitimately has no user profile, so a
+// failed preload is non-fatal.
 func shouldFailOnProfileError(token string) bool {
 	return token == ""
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -166,15 +166,15 @@ with the saved target as the default. Non-interactive login requires a HOST or
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
-		if err := ac.LoadCurrentUser(); err != nil {
+		if config.IsServiceToken(token) {
+			// Service tokens are application principals with no user profile, so the
+			// preload would always 401. Skip it and report the credential directly.
+			utils.CliInfo("Authenticated with a service token. Service tokens are application principals and have no user profile, so user details are unavailable.")
+		} else if err := ac.LoadCurrentUser(); err != nil {
 			if shouldFailOnProfileError(token) {
 				utils.CliErrorWithExit("Login succeeded but failed to verify user profile: %s. Please try logging in again.", err)
 			}
-			if config.IsServiceToken(token) {
-				utils.CliInfo("Authenticated with a service token. Service tokens are application principals and have no user profile, so user details are unavailable.")
-			} else {
-				utils.CliInfo("Could not preload your user profile; continuing since the credential was verified.")
-			}
+			utils.CliInfo("Could not preload your user profile; continuing since the credential was verified.")
 		}
 
 		utils.CliSuccess("Login succeeded!")
@@ -482,11 +482,11 @@ func formatHostURL(host string) string {
 }
 
 // shouldFailOnProfileError reports whether a failed user-profile load should abort
-// login. Browser (Auth0) and username/password logins are human logins that always
-// have a user profile, so a failed preload signals a real problem and is fatal. Token
-// logins were already validated against /api/status/ in LoginAndSaveCredentials, and a
-// service token is an application principal that legitimately has no user profile, so a
-// failed preload is non-fatal.
+// login. It is only consulted for non-service-token logins; service tokens skip the
+// preload entirely. Browser (Auth0) and username/password logins are human logins that
+// always have a user profile, so a failed preload signals a real problem and is fatal.
+// A personal API token was already validated against /api/status/ in
+// LoginAndSaveCredentials, so a failed preload is non-fatal.
 func shouldFailOnProfileError(token string) bool {
 	return token == ""
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -174,7 +174,14 @@ Re-login: 'alpacon login' without arguments reuses the saved workspace.`,
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 		if err := ac.LoadCurrentUser(); err != nil {
-			utils.CliErrorWithExit("Login succeeded but failed to verify user profile: %s. Please try logging in again.", err)
+			if shouldFailOnProfileError(token) {
+				utils.CliErrorWithExit("Login succeeded but failed to verify user profile: %s. Please try logging in again.", err)
+			}
+			if config.IsServiceToken(token) {
+				utils.CliInfo("Authenticated with a service token. Service tokens are application principals and have no user profile, so user details are unavailable.")
+			} else {
+				utils.CliInfo("Could not preload your user profile; continuing since the credential was verified.")
+			}
 		}
 
 		utils.CliSuccess("Login succeeded!")
@@ -311,4 +318,13 @@ func formatHostURL(host string) string {
 		scheme = "http"
 	}
 	return fmt.Sprintf("%s://%s", scheme, strings.TrimSuffix(host, "/"))
+}
+
+// shouldFailOnProfileError reports whether a failed user-profile load should abort
+// login. Browser/password logins (no token) always have a user profile and were not
+// separately credential-checked, so a failure there is fatal. Token logins already
+// validated the credential against /api/status/ in LoginAndSaveCredentials, so a
+// missing user profile (e.g. a service token, an application principal) is non-fatal.
+func shouldFailOnProfileError(token string) bool {
+	return token == ""
 }

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -721,9 +721,10 @@ func TestValidateCloudFlags(t *testing.T) {
 func TestShouldFailOnProfileError(t *testing.T) {
 	// Browser/password login (no token) → profile failure is fatal.
 	assert.True(t, shouldFailOnProfileError(""))
-	// Service token → credential already validated, profile failure is non-fatal.
+	// Any token login → profile failure is non-fatal (credential already validated via
+	// /api/status/). Service tokens skip the preload entirely; these cases cover the
+	// personal-token path and the pure predicate.
 	assert.False(t, shouldFailOnProfileError("alpst-x"))
-	// Personal token → preload failure is non-fatal (re-fetched later if needed).
 	assert.False(t, shouldFailOnProfileError("alpat-x"))
 }
 

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -216,3 +216,12 @@ func TestValidateCloudFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldFailOnProfileError(t *testing.T) {
+	// Browser/password login (no token) → profile failure is fatal.
+	assert.True(t, shouldFailOnProfileError(""))
+	// Service token → credential already validated, profile failure is non-fatal.
+	assert.False(t, shouldFailOnProfileError("alpst-x"))
+	// Personal token → preload failure is non-fatal (re-fetched later if needed).
+	assert.False(t, shouldFailOnProfileError("alpat-x"))
+}

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -172,20 +172,20 @@ func getRole(isStaff, isSuperuser bool) string {
 	return "user"
 }
 
+// getAuthClassification returns the machine-readable auth classification for cfg.
+// It delegates to GetAuthMethod + authClassificationFromMethod so the auth-method
+// buckets live in exactly one place (config.GetAuthMethod) rather than being
+// re-derived here.
 func getAuthClassification(cfg config.Config) string {
-	if cfg.AccessToken != "" {
-		return "browser_login"
-	}
-	if cfg.Token != "" {
-		return "token"
-	}
-	return "unknown"
+	return authClassificationFromMethod(config.GetAuthMethod(cfg))
 }
 
 func authClassificationFromMethod(method string) string {
 	switch method {
 	case "Browser login":
 		return "browser_login"
+	case "Service token":
+		return "service_token"
 	case "Token":
 		return "token"
 	default:

--- a/cmd/whoami_test.go
+++ b/cmd/whoami_test.go
@@ -19,6 +19,7 @@ func TestGetAuthMethod(t *testing.T) {
 		expected string
 	}{
 		{"browser login", "", "some-access-token", "Browser login"},
+		{"service token", "alpst-abc", "", "Service token"},
 		{"token", "some-token", "", "Token"},
 		{"both tokens prefers browser", "some-token", "some-access-token", "Browser login"},
 		{"no tokens", "", "", "unknown"},
@@ -39,6 +40,7 @@ func TestGetAuthClassification(t *testing.T) {
 		expected string
 	}{
 		{"browser login", config.Config{AccessToken: "some-access-token"}, "browser_login"},
+		{"service token", config.Config{Token: "alpst-x"}, "service_token"},
 		{"token", config.Config{Token: "some-token"}, "token"},
 		{"both tokens prefers browser", config.Config{Token: "some-token", AccessToken: "some-access-token"}, "browser_login"},
 		{"no tokens", config.Config{}, "unknown"},
@@ -47,6 +49,25 @@ func TestGetAuthClassification(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, getAuthClassification(tt.cfg))
+		})
+	}
+}
+
+func TestAuthClassificationFromMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		expected string
+	}{
+		{"browser login", "Browser login", "browser_login"},
+		{"service token", "Service token", "service_token"},
+		{"token", "Token", "token"},
+		{"unknown", "something else", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, authClassificationFromMethod(tt.method))
 		})
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/xtaci/smux"
@@ -14,6 +15,10 @@ import (
 const (
 	ConfigFileName = "config.json"
 	ConfigFileDir  = ".alpacon"
+
+	// ServiceTokenPrefix is the default key prefix for service tokens
+	// (server setting SERVICE_TOKEN_PREFIX). Personal API tokens use "alpat-".
+	ServiceTokenPrefix = "alpst-"
 )
 
 func CreateConfig(workspaceURL, workspaceName, token, expiresAt, accessToken, refreshToken, baseDomain string, expiresIn int, insecure bool) error {
@@ -191,10 +196,19 @@ func GetActiveWorkSession() (string, error) {
 	return cfg.ActiveWorkSessions[cfg.WorkspaceName], nil
 }
 
+// IsServiceToken reports whether token is a service token, identified by its key
+// prefix. Service tokens are application principals and have no user profile.
+func IsServiceToken(token string) bool {
+	return strings.HasPrefix(strings.TrimSpace(token), ServiceTokenPrefix)
+}
+
 // GetAuthMethod returns a human-readable authentication method string for cfg.
 func GetAuthMethod(cfg Config) string {
 	if cfg.AccessToken != "" {
 		return "Browser login"
+	}
+	if IsServiceToken(cfg.Token) {
+		return "Service token"
 	}
 	if cfg.Token != "" {
 		return "Token"

--- a/config/config.go
+++ b/config/config.go
@@ -16,8 +16,10 @@ const (
 	ConfigFileName = "config.json"
 	ConfigFileDir  = ".alpacon"
 
-	// ServiceTokenPrefix is the default key prefix for service tokens
-	// (server setting SERVICE_TOKEN_PREFIX). Personal API tokens use "alpat-".
+	// ServiceTokenPrefix is the default service-token key prefix, hard-coded here.
+	// It matches the server's default SERVICE_TOKEN_PREFIX; if a self-hosted server
+	// overrides that setting, its service tokens will not match this prefix and are
+	// treated as generic tokens. Personal API tokens use "alpat-".
 	ServiceTokenPrefix = "alpst-"
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -231,6 +231,25 @@ func TestActiveWorkSession_PerWorkspaceIsolation(t *testing.T) {
 	assert.Equal(t, "uuid-A", got, "switching back should restore original active session")
 }
 
+func TestIsServiceToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{"service token", "alpst-abc123", true},
+		{"personal api token", "alpat-abc123", false},
+		{"empty", "", false},
+		{"leading whitespace", "  alpst-x", true},
+		{"custom prefix not recognized", "custom-abc123", false}, // documented limitation
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsServiceToken(tt.token))
+		})
+	}
+}
+
 func TestGetAuthMethod(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -243,6 +262,11 @@ func TestGetAuthMethod(t *testing.T) {
 			expected: "Browser login",
 		},
 		{
+			name:     "service token → Service token",
+			cfg:      Config{Token: "alpst-abc"},
+			expected: "Service token",
+		},
+		{
 			name:     "token only → Token",
 			cfg:      Config{Token: "abc123"},
 			expected: "Token",
@@ -250,6 +274,11 @@ func TestGetAuthMethod(t *testing.T) {
 		{
 			name:     "both tokens → AccessToken wins",
 			cfg:      Config{AccessToken: "eyJ...", Token: "abc123"},
+			expected: "Browser login",
+		},
+		{
+			name:     "access token wins over service token",
+			cfg:      Config{AccessToken: "eyJ...", Token: "alpst-abc"},
 			expected: "Browser login",
 		},
 		{


### PR DESCRIPTION
## Summary

Logging in to the CLI with a **service token** (key prefix `alpst-`) failed even though the token authenticates correctly to the API. After saving the token, login called `LoadCurrentUser()` (`GET /api/iam/users/-`), which is a user-only endpoint and returns 401 for an application principal — a service token has no user profile — aborting the whole login with a non-zero exit:

```
Login succeeded but failed to verify user profile:
  Authentication credentials were not provided (401)
```

## Root cause

The credential is already validated against `GET /api/status/` before the token is saved (`api/auth/auth.go`). The subsequent `LoadCurrentUser()` is a human-profile preload that does not apply to a non-human principal, yet its failure was treated as fatal.

## What changed

- **`config`** — add `ServiceTokenPrefix` (`alpst-`) and `IsServiceToken()`; `GetAuthMethod` now reports `Service token`.
- **`login`** — the post-login user-profile preload is now **non-fatal for token logins** (the credential was already validated by `/api/status/`). Browser/password logins keep the existing strict behavior. A genuinely invalid/expired token still fails earlier at the `/api/status/` step, so credential checking is not weakened.
- **`whoami`** — classify service tokens as `service_token` (`auth_method: "Service token"`, `auth_classification: "service_token"`). `getAuthClassification` now routes through `GetAuthMethod` so the auth-method buckets live in one place instead of being re-derived.

## Out of scope

Other commands that independently load the current user and gate on its privileges (`user`/`group` management, `approval list`, `webhook create`) are intentionally unchanged — they are user-administration commands, not part of the service-token workflow, and gating on an empty privilege set would misbehave. The blast radius is limited to login plus the `whoami` label.

Making identity principal-agnostic server-side (so infrastructure commands fully recognize an application identity) is tracked separately as follow-up work; this PR is the CLI-side hotfix that unblocks service-token login.

## Testing

- `go build ./...`
- `go test -race ./config/... ./client/... ./cmd/...` — green (existing client-layer 401 tests untouched)
- `go vet ./...` and `golangci-lint run ./...` (v2.9.0) — 0 issues
- Added unit tests: `IsServiceToken` prefix matching, `GetAuthMethod`/`whoami` classification, and the login profile-error decision (fatal only for browser/password logins)

## Acceptance criteria

- [x] `alpacon login <host> -t alpst-<token>` prints the service-token notice and `Login succeeded!`, exit code 0
- [x] `alpacon login <host> -t alpat-<token>` is unchanged (user profile still preloaded)
- [x] Browser/password login still fails hard if the user profile cannot be loaded
- [x] `alpacon login <host> -t alpst-<invalid>` still fails (rejected at the `/api/status/` step)
- [x] `alpacon whoami` with a service token reports `auth_method: "Service token"` / `auth_classification: "service_token"` and does not crash

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
