### PR TITLE
fix(exec): recognize awaiting_approval status as pending approval

### DIFF
--- a/api/event/event.go
+++ b/api/event/event.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -104,6 +105,13 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 		return "", err
 	}
 
+	return classifyCommandResult(result)
+}
+
+// classifyCommandResult maps a polled command's terminal (or held) state to a
+// (output, error) pair. It is shared by RunCommand and WaitForCommandApproval so
+// the synchronous run and the --wait approval poll classify outcomes identically.
+func classifyCommandResult(result EventDetails) (string, error) {
 	if result.Status == "stuck" || result.Status == "error" || result.Status == "cancelled" {
 		if result.ErrorPhase != nil && *result.ErrorPhase != "" {
 			return "", fmt.Errorf("command failed: [%s] %s (status=%s)",
@@ -130,11 +138,56 @@ func RunCommand(ac *client.AlpaconClient, serverName, command string, username, 
 		}
 	}
 
+	// HITL: the command is parked server-side pending human approval. Surface a
+	// typed signal so the caller can emit the pending-approval contract (exit 4)
+	// or, with --wait, poll this same job until it is approved.
+	if IsAwaitingApprovalStatus(result.Status) {
+		return result.Result, &PendingApprovalError{CommandID: result.ID}
+	}
+
+	// A reviewer rejected the approval request: the command will never run.
+	if result.Status == "rejected" {
+		return result.Result, fmt.Errorf("command was rejected by a reviewer")
+	}
+
 	if result.Success == nil && result.Status != "completed" && result.Status != "success" {
 		return result.Result, fmt.Errorf("command ended with unrecognised status: %s", result.Status)
 	}
 
 	return result.Result, nil
+}
+
+// isApprovalTransitionStatus reports whether status is a state the held command
+// legitimately passes through while waiting for and applying an approval, so the
+// approval poll keeps waiting instead of resolving. Besides "awaiting_approval"
+// it includes "error": the server's documented-unreachable compute_status
+// fallback, which surfaces transiently in the sub-millisecond window after an
+// approval flips verification to "approved" but before the command is delivered
+// (delivered_at is set). Treating it as transient here keeps the approve→deliver
+// step from being misreported as a failure; the real failure states the command
+// can reach (stuck, failed, cancelled, rejected) are classified normally.
+func isApprovalTransitionStatus(status string) bool {
+	return IsAwaitingApprovalStatus(status) || status == "error"
+}
+
+// WaitForCommandApproval polls a command parked at "awaiting_approval" until a
+// reviewer approves it out of band (the same job then runs and resolves) or the
+// timeout elapses while it is still parked. It polls the existing job rather than
+// re-submitting, so the original command runs exactly once on approval. The
+// approval wait is bounded by timeout (the timer is not reset while parked);
+// once the command starts running the timer resets per tick so a long execution
+// is not cut off. On timeout while still parked it returns a PendingApprovalError
+// so the caller emits the standard pending-approval signal.
+func WaitForCommandApproval(ac *client.AlpaconClient, commandID string, timeout, tick time.Duration) (string, error) {
+	result, err := pollCommand(ac, commandID, timeout, tick, true)
+	if err != nil {
+		var clientTimeout *ClientTimeoutError
+		if errors.As(err, &clientTimeout) && IsAwaitingApprovalStatus(result.Status) {
+			return result.Result, &PendingApprovalError{CommandID: commandID}
+		}
+		return result.Result, err
+	}
+	return classifyCommandResult(result)
 }
 
 func GetCommandByID(ac *client.AlpaconClient, cmdID string) (EventDetails, error) {
@@ -165,6 +218,16 @@ func execTimeout() time.Duration {
 }
 
 func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration) (EventDetails, error) {
+	return pollCommand(ac, cmdId, timeout, tick, false)
+}
+
+// pollCommand polls a command until it leaves the in-progress states. A running
+// command resets the timer each tick so a long execution is never cut off. When
+// awaitApproval is true, a command parked at "awaiting_approval" keeps being
+// polled too, but the timer is NOT reset for it, so timeout bounds the wait for
+// the out-of-band approval; when awaitApproval is false the parked status is
+// returned immediately (the caller decides whether to wait).
+func pollCommand(ac *client.AlpaconClient, cmdId string, timeout, tick time.Duration, awaitApproval bool) (EventDetails, error) {
 	var response EventDetails
 
 	timer := time.NewTimer(timeout)
@@ -194,6 +257,11 @@ func pollCommandExecution(ac *client.AlpaconClient, cmdId string, timeout, tick 
 					}
 				}
 				timer.Reset(timeout)
+				continue
+			}
+			if awaitApproval && isApprovalTransitionStatus(response.Status) {
+				// Keep waiting through the approval transition, but let timeout
+				// bound this phase: do not reset the timer.
 				continue
 			}
 			return response, nil

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -181,8 +181,12 @@ func isApprovalTransitionStatus(status string) bool {
 func WaitForCommandApproval(ac *client.AlpaconClient, commandID string, timeout, tick time.Duration) (string, error) {
 	result, err := pollCommand(ac, commandID, timeout, tick, true)
 	if err != nil {
+		// The wait elapsed while the job was still parked or transitioning
+		// through approval (awaiting_approval or the transient "error" state
+		// pollCommand also keeps polling). Surface the pending-approval signal so
+		// the caller emits exit 4 rather than a generic timeout.
 		var clientTimeout *ClientTimeoutError
-		if errors.As(err, &clientTimeout) && IsAwaitingApprovalStatus(result.Status) {
+		if errors.As(err, &clientTimeout) && isApprovalTransitionStatus(result.Status) {
 			return result.Result, &PendingApprovalError{CommandID: commandID}
 		}
 		return result.Result, err

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -618,7 +618,7 @@ func TestWaitForCommandApproval_ResolvesToSuccess(t *testing.T) {
 	assert.Equal(t, "done", result)
 }
 
-func TestWaitForCommandApproval_TolueratesTransitionError(t *testing.T) {
+func TestWaitForCommandApproval_ToleratesTransitionError(t *testing.T) {
 	// After approval the server briefly reports the unreachable "error" fallback
 	// (verification flipped to approved, delivered_at not yet set) before the
 	// command is delivered. The approval poll must wait through it, not fail.

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -577,6 +577,107 @@ func TestRunCommand_401WithDetailSurfacesServerReason(t *testing.T) {
 	assert.Contains(t, err.Error(), "alpacon login")
 }
 
+func TestRunCommand_AwaitingApprovalReturnsPendingApprovalError(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
+	ts := newRunCommandServerWithDetails(t, EventDetails{ID: "cmd-1", Status: "awaiting_approval"})
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := RunCommand(ac, "server-x", "sudo reboot", "", "", nil, "")
+	require.Error(t, err)
+	var pending *PendingApprovalError
+	require.True(t, errors.As(err, &pending), "expected PendingApprovalError, got %T: %v", err, err)
+	assert.Equal(t, "cmd-1", pending.CommandID)
+}
+
+func TestRunCommand_RejectedReturnsError(t *testing.T) {
+	t.Setenv("ALPACON_EXEC_TIMEOUT", "")
+	ts := newRunCommandServerWithDetails(t, EventDetails{ID: "cmd-1", Status: "rejected"})
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := RunCommand(ac, "server-x", "sudo reboot", "", "", nil, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rejected")
+	var pending *PendingApprovalError
+	assert.False(t, errors.As(err, &pending), "rejected must not be a PendingApprovalError")
+}
+
+func TestWaitForCommandApproval_ResolvesToSuccess(t *testing.T) {
+	ts := newCommandPollServer([]EventDetails{
+		{ID: "cmd-1", Status: "awaiting_approval"},
+		{ID: "cmd-1", Status: "awaiting_approval"},
+		{ID: "cmd-1", Status: "running"},
+		{ID: "cmd-1", Status: "success", Success: boolPtr(true), Result: "done"},
+	})
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	result, err := WaitForCommandApproval(ac, "cmd-1", time.Second, time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "done", result)
+}
+
+func TestWaitForCommandApproval_TolueratesTransitionError(t *testing.T) {
+	// After approval the server briefly reports the unreachable "error" fallback
+	// (verification flipped to approved, delivered_at not yet set) before the
+	// command is delivered. The approval poll must wait through it, not fail.
+	ts := newCommandPollServer([]EventDetails{
+		{ID: "cmd-1", Status: "awaiting_approval"},
+		{ID: "cmd-1", Status: "error"},
+		{ID: "cmd-1", Status: "running"},
+		{ID: "cmd-1", Status: "success", Success: boolPtr(true), Result: "done"},
+	})
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	result, err := WaitForCommandApproval(ac, "cmd-1", time.Second, time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "done", result)
+}
+
+func TestWaitForCommandApproval_TimeoutReturnsPendingApproval(t *testing.T) {
+	ts := newCommandPollServer([]EventDetails{{ID: "cmd-1", Status: "awaiting_approval"}})
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	// The job never leaves awaiting_approval, so the bounded wait elapses and we
+	// surface a PendingApprovalError so the caller emits the pending signal.
+	_, err := WaitForCommandApproval(ac, "cmd-1", 40*time.Millisecond, 5*time.Millisecond)
+	require.Error(t, err)
+	var pending *PendingApprovalError
+	require.True(t, errors.As(err, &pending), "expected PendingApprovalError on timeout, got %T: %v", err, err)
+	assert.Equal(t, "cmd-1", pending.CommandID)
+}
+
+func TestWaitForCommandApproval_RejectedReturnsError(t *testing.T) {
+	ts := newCommandPollServer([]EventDetails{
+		{ID: "cmd-1", Status: "awaiting_approval"},
+		{ID: "cmd-1", Status: "rejected"},
+	})
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := WaitForCommandApproval(ac, "cmd-1", time.Second, time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rejected")
+}
+
+// newCommandPollServer serves GET /api/events/commands/{id}/ by returning each
+// EventDetails in seq on successive calls; the final entry repeats. Used to drive
+// WaitForCommandApproval through a status transition.
+func newCommandPollServer(seq []EventDetails) *httptest.Server {
+	var calls atomic.Int32
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		idx := int(calls.Add(1)) - 1
+		if idx >= len(seq) {
+			idx = len(seq) - 1
+		}
+		_ = json.NewEncoder(w).Encode(seq[idx])
+	}))
+}
+
 func newRunCommandServerWithDetails(t *testing.T, details EventDetails) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/event/types.go
+++ b/api/event/types.go
@@ -29,6 +29,15 @@ type RemoteCommandError struct {
 // result before the server reported a terminal status.
 type ClientTimeoutError struct{}
 
+// PendingApprovalError is returned when the server parked a command at the
+// "awaiting_approval" status: the job was accepted but a human must approve it
+// out of band in the Alpacon console before it runs. CommandID identifies the
+// parked job so a --wait caller can poll it to completion—re-submitting would
+// create a duplicate command (and a duplicate approval request).
+type PendingApprovalError struct {
+	CommandID string
+}
+
 type EventAttributes struct {
 	Server      string `json:"server"`
 	Shell       string `json:"shell"`
@@ -94,6 +103,10 @@ func (*ClientTimeoutError) Error() string {
 	return "CLI timed out waiting for command result"
 }
 
+func (*PendingApprovalError) Error() string {
+	return "command is awaiting human approval"
+}
+
 // DescribePhase returns the human-readable description for an error_phase,
 // or the raw identifier when the phase is unknown.
 func DescribePhase(phase string) string {
@@ -111,4 +124,12 @@ func IsRunningStatus(status string) bool {
 	default:
 		return false
 	}
+}
+
+// IsAwaitingApprovalStatus reports whether status is the server's hold state for a
+// command parked pending out-of-band human approval (HITL). The server exposes
+// this via Command.compute_status when verification_status is "awaiting_approval"
+// and the command has not yet been delivered to the agent.
+func IsAwaitingApprovalStatus(status string) bool {
+	return status == "awaiting_approval"
 }

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -70,6 +70,23 @@ func logsCommandOutcome(details event.EventDetails) (stdoutLine, stderrLine stri
 		return "", stderrLine, 0
 	}
 
+	// HITL: the command is held pending out-of-band human approval. It runs once
+	// approved, so report it as in-progress (exit 0) and point at a later re-check
+	// rather than treating it as an unrecognised terminal status.
+	if event.IsAwaitingApprovalStatus(details.Status) {
+		stderrLine = fmt.Sprintf(
+			"command is awaiting approval (status: %s).\nIt runs once a reviewer approves it in the Alpacon console (web). Run `alpacon exec logs %s` again to check later.\n",
+			details.Status, details.ID,
+		)
+		return "", stderrLine, 0
+	}
+
+	if details.Status == "rejected" {
+		stderrLine = fmt.Sprintf("%s: command was rejected by a reviewer (status: %s)\n",
+			utils.Red("Error"), details.Status)
+		return "", stderrLine, 1
+	}
+
 	if details.Status == "stuck" || details.Status == "error" || details.Status == "cancelled" {
 		if details.ErrorPhase != nil && *details.ErrorPhase != "" {
 			stderrLine = fmt.Sprintf("%s: [%s] %s (status=%s)\n",

--- a/cmd/exec/logs_test.go
+++ b/cmd/exec/logs_test.go
@@ -60,6 +60,20 @@ func TestLogsCommandOutcome(t *testing.T) {
 			wantExitCode:       0,
 		},
 		{
+			name:               "awaiting approval is informational, exit 0",
+			details:            event.EventDetails{ID: "job-3", Status: "awaiting_approval"},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"awaiting approval", "status: awaiting_approval", "job-3"},
+			wantExitCode:       0,
+		},
+		{
+			name:               "rejected exits 1",
+			details:            event.EventDetails{ID: "job-4", Status: "rejected"},
+			wantStdoutLine:     "",
+			wantStderrContains: []string{"rejected", "status: rejected"},
+			wantExitCode:       1,
+		},
+		{
 			name:               "stuck without phase",
 			details:            event.EventDetails{ID: "job-1", Status: "stuck"},
 			wantStdoutLine:     "",

--- a/cmd/exec/pending_approval_test.go
+++ b/cmd/exec/pending_approval_test.go
@@ -47,6 +47,80 @@ func newApprovalDenialServer() *httptest.Server {
 	}))
 }
 
+// newAwaitingApprovalServer returns a test server whose exec command parks at the
+// server-side "awaiting_approval" status (HITL hold), so the command is pending
+// human approval without ever producing a denial line.
+func newAwaitingApprovalServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-1","name":"prod"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/events/commands/":
+			_, _ = fmt.Fprintf(w, `[{"id":"cmd-1"}]`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/events/commands/cmd-1/":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":     "cmd-1",
+				"status": "awaiting_approval",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestExecStatusAwaitingApprovalExits4WithJSONSignal drives the status-level HITL
+// hold (server status "awaiting_approval", no denial line) through the real exec
+// command and asserts it converges on the same pending-approval contract as the
+// denial-code path: exit 4 and a {"status":"pending_approval", ...} envelope.
+func TestExecStatusAwaitingApprovalExits4WithJSONSignal(t *testing.T) {
+	ts := newAwaitingApprovalServer()
+	defer ts.Close()
+
+	home := t.TempDir()
+	writeExecCommandTestConfig(t, home, ts.URL)
+
+	helper := osexec.Command(
+		os.Args[0],
+		"-test.run=^TestExecCommandWorkSessionGateHelperProcess$",
+		"--",
+		"exec-worksession-helper",
+		"--output",
+		"json",
+		"prod",
+		"--",
+		"sudo",
+		"reboot",
+	)
+	helper.Env = append(os.Environ(),
+		"GO_WANT_EXEC_WORKSESSION_HELPER=1",
+		"ALPACON_WORK_SESSION=",
+		"HOME="+home,
+	)
+	var stdout, stderr bytes.Buffer
+	helper.Stdout = &stdout
+	helper.Stderr = &stderr
+
+	err := helper.Run()
+	require.Error(t, err)
+	var exitErr *osexec.ExitError
+	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	assert.Equal(t, utils.ExitCodePendingApproval, exitErr.ExitCode(), "pending approval must exit 4")
+
+	var got struct {
+		OK          bool     `json:"ok"`
+		Status      string   `json:"status"`
+		ExitCode    int      `json:"exit_code"`
+		NextActions []string `json:"next_actions"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got), "stdout: %s", stdout.String())
+	assert.False(t, got.OK)
+	assert.Equal(t, utils.PendingApprovalStatus, got.Status)
+	assert.Equal(t, utils.ExitCodePendingApproval, got.ExitCode)
+	require.NotEmpty(t, got.NextActions)
+	assert.Equal(t, "alpacon exec logs cmd-1", got.NextActions[0], "hint should point at exec logs for the held job")
+}
+
 func TestExecPendingApprovalExits4WithJSONSignal(t *testing.T) {
 	ts := newApprovalDenialServer()
 	defer ts.Close()

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -169,6 +169,23 @@ func isApprovalDenial(result string, err error) bool {
 // fixed-interval ticker, and a precise deadline.
 func RunExecWithApprovalWait(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, wait bool) (string, error) {
 	result, err := RunExecWithPresenceStepUp(ac, serverName, command, username, groupname, env, workSessionID)
+
+	// Status-level hold: the server parked this job at "awaiting_approval". With
+	// --wait, poll the SAME job until a reviewer approves it (re-submitting would
+	// create a duplicate command and approval request). Without --wait, return so
+	// the caller emits the pending-approval signal.
+	var pendingErr *event.PendingApprovalError
+	if errors.As(err, &pendingErr) {
+		if !wait {
+			return result, err
+		}
+		spinner := utils.NewSpinner("Waiting for approval in the Alpacon console...")
+		spinner.Start()
+		result, err = event.WaitForCommandApproval(ac, pendingErr.CommandID, approvalWaitTimeout, approvalWaitPollInterval)
+		spinner.Stop()
+		return result, err
+	}
+
 	if !wait || !isApprovalDenial(result, err) {
 		return result, err
 	}
@@ -209,6 +226,21 @@ func RunExecWithApprovalWait(ac *client.AlpaconClient, serverName, command, user
 // reRunHint is the exact command the caller invoked, so a human can copy-paste
 // it once the request is approved.
 func HandlePendingApproval(result string, err error, reRunHint string) bool {
+	// Status-level hold: the server parked the command at "awaiting_approval".
+	// The held job runs once approved, so point the user at `exec logs` to fetch
+	// the result later (re-running would submit a new, separately-held command).
+	var pendingErr *event.PendingApprovalError
+	if errors.As(err, &pendingErr) {
+		utils.PrintPendingApproval(
+			"Approval required—this command is held for human approval in the Alpacon console (web). "+
+				"It runs automatically once approved; pass --wait to block until then.",
+			"", // the command detail carries no approval request id
+			fmt.Sprintf("alpacon exec logs %s", pendingErr.CommandID),
+		)
+		os.Exit(utils.ExitCodePendingApproval)
+		return true
+	}
+
 	if !isApprovalDenial(result, err) {
 		return false
 	}
@@ -228,8 +260,8 @@ func HandlePendingApproval(result string, err error, reRunHint string) bool {
 // to omit it.
 func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string) (string, error) {
 	result, err := event.RunCommand(ac, serverName, command, username, groupname, env, workSessionID)
-	if phased, ok := asPhasedError(err); ok {
-		return result, phased
+	if propagated, ok := propagateCommandError(err); ok {
+		return result, propagated
 	}
 	if err != nil {
 		err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
@@ -249,9 +281,9 @@ func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username
 				return err
 			},
 		})
-		// RetryOperation may surface a phased error; re-check after HandleCommonErrors.
-		if phased, ok := asPhasedError(err); ok {
-			return result, phased
+		// RetryOperation may surface a command-outcome error; re-check after HandleCommonErrors.
+		if propagated, ok := propagateCommandError(err); ok {
+			return result, propagated
 		}
 		if err != nil {
 			return "", fmt.Errorf("failed to execute command on '%s' server: %w", serverName, err)
@@ -289,6 +321,22 @@ func HandleCommandResult(result string, err error) {
 	if hint := sudoDenialHint(result); hint != "" {
 		fmt.Fprint(os.Stderr, hint)
 	}
+}
+
+// propagateCommandError reports errors that represent a command outcome the
+// caller must receive unchanged: phased errors (RemoteCommandError,
+// ClientTimeoutError) and a PendingApprovalError (a job held for human approval).
+// RunCommandWithRetry returns these as-is so they are never MFA-retried or
+// wrapped, keeping the result intact for the caller's outcome handling.
+func propagateCommandError(err error) (error, bool) {
+	if phased, ok := asPhasedError(err); ok {
+		return phased, true
+	}
+	var pending *event.PendingApprovalError
+	if errors.As(err, &pending) {
+		return pending, true
+	}
+	return nil, false
 }
 
 // asPhasedError unwraps err to a RemoteCommandError or ClientTimeoutError.


### PR DESCRIPTION
## Overview

`alpacon exec` of a sudo command that needs HITL approval (run without `--wait`) exited with an error even though the command had correctly entered the approval queue:

```
❯ alpacon exec sudo-test -- sudo rm -rf /tmp/hitl-test-dir
Error: failed to execute command on 'sudo-test' server: command ended with unrecognised status: awaiting_approval
```

The server-side flow was fine—approving in the Alpacon console (web) proceeded with MFA and execution. Only the CLI mishandled the wait state. This PR makes `exec` recognize the `awaiting_approval` status and converge it onto the existing `SUDO_APPROVAL_REQUIRED` pending-approval UX.

Closes #233

## Root cause

Two different approval mechanisms exist:

- **denial-code** (`SUDO_APPROVAL_REQUIRED`): the command runs, the sudo plugin denies it, and the CLI detects the denial line in the output (exit 4 / `--wait` re-run).
- **status-level** (`awaiting_approval`): the server *parks* the command (HITL) and exposes it via `Command.compute_status` (`verification_status == 'awaiting_approval'`, not yet delivered). The CLI poller only classified `stuck`/`error`/`cancelled`, `success`, and `completed`/`success`; everything else fell through to a generic *"unrecognised status"* error (`api/event/event.go`).

## What changed

**`api/event`**
- Added `PendingApprovalError{CommandID}` and `IsAwaitingApprovalStatus`.
- Extracted `classifyCommandResult`, shared by `RunCommand` and the new wait, so the synchronous run and the `--wait` poll classify outcomes identically. `awaiting_approval` → `PendingApprovalError`; a reviewer `rejected` → a clear terminal error.
- Added `WaitForCommandApproval`, which polls the **same** held job to completion (re-submitting would create a duplicate command and approval request). The wait is bounded by the timeout while parked; once the command starts running the timer resets so a long execution is not cut off. On timeout while still parked it returns `PendingApprovalError` so the caller emits the standard signal.

**`cmd/exec`**
- `RunExecWithApprovalWait`: on `awaiting_approval`, return for the pending signal (no `--wait`) or poll the held job (`--wait`), reusing the existing `approvalWaitTimeout` / `approvalWaitPollInterval`.
- `HandlePendingApproval`: emits the `pending_approval` envelope (exit 4) for the status path, pointing at `alpacon exec logs <id>` to retrieve the result once approved.
- `propagateCommandError`: a `PendingApprovalError` propagates through `RunCommandWithRetry` unchanged (never MFA-retried or wrapped).
- `exec logs`: recognizes `awaiting_approval` (informational, exit 0) and `rejected` (exit 1) instead of "unrecognised status".

## Behavior (converges with the denial-code path)

- **Without `--wait`** — exit `4` + guidance; `--output json` emits `{"status":"pending_approval", ...}` on stdout. The held job still runs server-side once approved; `alpacon exec logs <id>` fetches the result.
- **With `--wait`** — blocks on the held job until a reviewer approves it (then runs to completion), it is rejected, or the wait elapses (→ exit 4).

## Security

The status path keys off a **structured server field**, not command output, so—unlike the denial-code detector—a command cannot forge a pending signal from its own stdout. `--wait` polls the existing job by id rather than re-running, so it cannot spam duplicate approval requests. The wait is bounded.

## Note: transient `error` during approve→deliver

Approval flips `verification_status` to `approved` in a transaction, then delivers via `on_commit`, so there is a sub-millisecond window where `compute_status` returns its documented-unreachable `error` fallback (approved, `delivered_at` not yet set). The `--wait` poll—which newly polls *through* the approval transition—treats `error` as a transient and keeps waiting (bounded by the timeout) so an approved command is never misreported as failed; real failure states (`stuck`/`failed`/`cancelled`/`rejected`) are classified normally. The synchronous path is unchanged. A cleaner long-term fix is server-side (mapping approved-not-delivered to a running status); happy to file a follow-up.

## Tests

- `api/event`: `RunCommand` → `PendingApprovalError` for `awaiting_approval` and a clear error for `rejected`; `WaitForCommandApproval` resolves to success, tolerates the transient `error`, surfaces `PendingApprovalError` on timeout, and errors on `rejected`.
- `cmd/exec`: end-to-end (helper process) status-path `exec` exits `4` with the `pending_approval` JSON envelope and an `alpacon exec logs <id>` hint; `logsCommandOutcome` covers `awaiting_approval`/`rejected`.

Local `go build ./...`, `go test -race ./...`, `go vet ./...`, and `golangci-lint run` (v2, matching CI) all pass.