### PR TITLE
fix(iam): resolve username prompt hang in non-interactive environments, add username get/set

### DIFF
--- a/api/iam/iam.go
+++ b/api/iam/iam.go
@@ -381,6 +381,11 @@ func HandleUsernameRequired() (*SetUsernameResponse, error) {
 				utils.CliWarning("%s", msg)
 				continue
 			}
+			if code == codeUsernameAlreadySet {
+				// Username was set concurrently (e.g. another session); treat as success so the original command proceeds.
+				utils.CliInfo("Username is already set; continuing.")
+				return nil, nil
+			}
 			return nil, errors.New(msg)
 		}
 		return nil, fmt.Errorf("failed to set username: %v", err)

--- a/api/iam/iam.go
+++ b/api/iam/iam.go
@@ -343,17 +343,33 @@ func GetUserMemberships(ac *client.AlpaconClient, userID string) ([]GroupMembers
 }
 
 func HandleUsernameRequired() (*SetUsernameResponse, error) {
-	utils.CliInfo("Username is required for your account.")
-	username := utils.PromptForRequiredInput("Please enter your username: ")
-
-	response, err := SetUsername(username)
-	if err != nil {
-		return nil, fmt.Errorf("failed to set username: %v", err)
+	if !utils.IsInteractiveShell() {
+		return nil, errors.New("username is not set for your account; run 'alpacon username set <name>' to set it (lowercase letters, digits, '-', '_'; must start with a letter)")
 	}
 
-	utils.CliSuccess("Username set to %q", response.Username)
+	utils.CliInfo("Username is required for your account.")
+	utils.CliInfo("You can also set it anytime with 'alpacon username set <name>'.")
 
-	return response, nil
+	for {
+		username := utils.PromptForRequiredInput("Please enter your username: ")
+
+		response, err := SetUsername(username)
+		if err == nil {
+			utils.CliSuccess("Username set to %q", response.Username)
+			return response, nil
+		}
+
+		code, _ := utils.ParseErrorResponse(err)
+		msg, known := UsernameErrorMessage(code)
+		if known {
+			if isRetryableUsernameError(code) {
+				utils.CliWarning("%s", msg)
+				continue
+			}
+			return nil, errors.New(msg)
+		}
+		return nil, fmt.Errorf("failed to set username: %v", err)
+	}
 }
 
 func SetUsername(username string) (*SetUsernameResponse, error) {

--- a/api/iam/iam.go
+++ b/api/iam/iam.go
@@ -16,6 +16,13 @@ const (
 	membershipURL = "/api/iam/memberships/"
 	usernameURL   = "/api/iam/username/"
 	inviteUserURL = "/api/workspaces/users/invite/"
+
+	// Server username error codes (alpacon-server iam/api/serializers.py)
+	codeUsernameInvalid    = "user_username_invalid"
+	codeUsernameDisallowed = "user_username_disallowed"
+	codeUsernameInUse      = "user_username_in_use"
+	codeUsernameAlreadySet = "user_username_already_set"
+	codeUsernameApproval   = "approval_superuser_approve_required"
 )
 
 func GetUserList(ac *client.AlpaconClient) ([]UserAttributes, error) {
@@ -371,4 +378,34 @@ func SetUsername(username string) (*SetUsernameResponse, error) {
 	}
 
 	return &response, nil
+}
+
+// UsernameErrorMessage maps a server username error code to a human-readable
+// message. Returns ("", false) for unrecognized codes.
+func UsernameErrorMessage(code string) (string, bool) {
+	switch code {
+	case codeUsernameInvalid:
+		return "invalid username format: use lowercase letters, digits, '-', '_', and start with a letter", true
+	case codeUsernameDisallowed:
+		return "this username is reserved and cannot be used (e.g. alpacon, root, admin)", true
+	case codeUsernameInUse:
+		return "this username is already in use", true
+	case codeUsernameAlreadySet:
+		return "username is already set and cannot be changed here", true
+	case codeUsernameApproval:
+		return "this username conflicts with an existing system account and is pending superuser approval", true
+	default:
+		return "", false
+	}
+}
+
+// isRetryableUsernameError reports whether the error can be resolved by
+// entering a different username.
+func isRetryableUsernameError(code string) bool {
+	switch code {
+	case codeUsernameInvalid, codeUsernameDisallowed, codeUsernameInUse:
+		return true
+	default:
+		return false
+	}
 }

--- a/api/iam/iam.go
+++ b/api/iam/iam.go
@@ -25,6 +25,9 @@ const (
 	codeUsernameApproval   = "approval_superuser_approve_required"
 )
 
+// UsernameSetSuccessFmt is the confirmation format shown after a username is set.
+const UsernameSetSuccessFmt = "Username set to %q"
+
 // usernameErrors maps each server username error code to its user-facing message and whether re-entering a different name can resolve it.
 var usernameErrors = map[string]struct {
 	message   string
@@ -367,7 +370,7 @@ func HandleUsernameRequired() (*SetUsernameResponse, error) {
 
 		response, err := SetUsername(username)
 		if err == nil {
-			utils.CliSuccess("Username set to %q", response.Username)
+			utils.CliSuccess(UsernameSetSuccessFmt, response.Username)
 			return response, nil
 		}
 

--- a/api/iam/iam.go
+++ b/api/iam/iam.go
@@ -25,6 +25,18 @@ const (
 	codeUsernameApproval   = "approval_superuser_approve_required"
 )
 
+// usernameErrors maps each server username error code to its user-facing message and whether re-entering a different name can resolve it.
+var usernameErrors = map[string]struct {
+	message   string
+	retryable bool
+}{
+	codeUsernameInvalid:    {"invalid username format: use lowercase letters, digits, '-', '_', and start with a letter", true},
+	codeUsernameDisallowed: {"this username is reserved and cannot be used (e.g. alpacon, root, admin)", true},
+	codeUsernameInUse:      {"this username is already in use", true},
+	codeUsernameAlreadySet: {"username is already set and cannot be changed here", false},
+	codeUsernameApproval:   {"this username conflicts with an existing system account and is pending superuser approval", false},
+}
+
 func GetUserList(ac *client.AlpaconClient) ([]UserAttributes, error) {
 	users, err := api.FetchAllPages[UserResponse](ac, userURL, nil)
 	if err != nil {
@@ -398,28 +410,11 @@ func SetUsername(username string) (*SetUsernameResponse, error) {
 
 // UsernameErrorMessage maps a server username error code to a human-readable message; ok is false for unrecognized codes.
 func UsernameErrorMessage(code string) (string, bool) {
-	switch code {
-	case codeUsernameInvalid:
-		return "invalid username format: use lowercase letters, digits, '-', '_', and start with a letter", true
-	case codeUsernameDisallowed:
-		return "this username is reserved and cannot be used (e.g. alpacon, root, admin)", true
-	case codeUsernameInUse:
-		return "this username is already in use", true
-	case codeUsernameAlreadySet:
-		return "username is already set and cannot be changed here", true
-	case codeUsernameApproval:
-		return "this username conflicts with an existing system account and is pending superuser approval", true
-	default:
-		return "", false
-	}
+	info, ok := usernameErrors[code]
+	return info.message, ok
 }
 
 // isRetryableUsernameError reports whether re-entering a different username can resolve the error.
 func isRetryableUsernameError(code string) bool {
-	switch code {
-	case codeUsernameInvalid, codeUsernameDisallowed, codeUsernameInUse:
-		return true
-	default:
-		return false
-	}
+	return usernameErrors[code].retryable
 }

--- a/api/iam/iam.go
+++ b/api/iam/iam.go
@@ -396,8 +396,7 @@ func SetUsername(username string) (*SetUsernameResponse, error) {
 	return &response, nil
 }
 
-// UsernameErrorMessage maps a server username error code to a human-readable
-// message. Returns ("", false) for unrecognized codes.
+// UsernameErrorMessage maps a server username error code to a human-readable message; ok is false for unrecognized codes.
 func UsernameErrorMessage(code string) (string, bool) {
 	switch code {
 	case codeUsernameInvalid:
@@ -415,8 +414,7 @@ func UsernameErrorMessage(code string) (string, bool) {
 	}
 }
 
-// isRetryableUsernameError reports whether the error can be resolved by
-// entering a different username.
+// isRetryableUsernameError reports whether re-entering a different username can resolve the error.
 func isRetryableUsernameError(code string) bool {
 	switch code {
 	case codeUsernameInvalid, codeUsernameDisallowed, codeUsernameInUse:

--- a/api/iam/username_error_test.go
+++ b/api/iam/username_error_test.go
@@ -41,3 +41,11 @@ func TestIsRetryableUsernameError(t *testing.T) {
 	assert.False(t, isRetryableUsernameError("approval_superuser_approve_required"))
 	assert.False(t, isRetryableUsernameError("unknown"))
 }
+
+func TestHandleUsernameRequired_NonTTY(t *testing.T) {
+	_, err := HandleUsernameRequired()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "alpacon username set")
+		assert.NotContains(t, err.Error(), "Please enter")
+	}
+}

--- a/api/iam/username_error_test.go
+++ b/api/iam/username_error_test.go
@@ -1,0 +1,43 @@
+package iam
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsernameErrorMessage(t *testing.T) {
+	tests := []struct {
+		code      string
+		wantOK    bool
+		wantMatch string
+	}{
+		{"user_username_invalid", true, "lowercase letters"},
+		{"user_username_disallowed", true, "reserved"},
+		{"user_username_in_use", true, "already in use"},
+		{"user_username_already_set", true, "already set"},
+		{"approval_superuser_approve_required", true, "superuser approval"},
+		{"some_unknown_code", false, ""},
+		{"", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			msg, ok := UsernameErrorMessage(tt.code)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Contains(t, msg, tt.wantMatch)
+			} else {
+				assert.Empty(t, msg)
+			}
+		})
+	}
+}
+
+func TestIsRetryableUsernameError(t *testing.T) {
+	assert.True(t, isRetryableUsernameError("user_username_invalid"))
+	assert.True(t, isRetryableUsernameError("user_username_disallowed"))
+	assert.True(t, isRetryableUsernameError("user_username_in_use"))
+	assert.False(t, isRetryableUsernameError("user_username_already_set"))
+	assert.False(t, isRetryableUsernameError("approval_superuser_approve_required"))
+	assert.False(t, isRetryableUsernameError("unknown"))
+}

--- a/api/iam/username_error_test.go
+++ b/api/iam/username_error_test.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +44,21 @@ func TestIsRetryableUsernameError(t *testing.T) {
 }
 
 func TestHandleUsernameRequired_NonTTY(t *testing.T) {
-	_, err := HandleUsernameRequired()
+	// Replace stdin with a pipe so IsInteractiveShell() reports non-TTY; otherwise
+	// running `go test` from a terminal would enter the prompt loop and hang.
+	orig := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Stdin = orig
+		_ = r.Close()
+		_ = w.Close()
+	})
+	os.Stdin = r
+
+	_, err = HandleUsernameRequired()
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "alpacon username set")
 		assert.NotContains(t, err.Error(), "Please enter")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/alpacax/alpacon-cli/cmd/server"
 	"github.com/alpacax/alpacon-cli/cmd/token"
 	"github.com/alpacax/alpacon-cli/cmd/tunnel"
+	"github.com/alpacax/alpacon-cli/cmd/username"
 	"github.com/alpacax/alpacon-cli/cmd/webftp"
 	"github.com/alpacax/alpacon-cli/cmd/webhook"
 	"github.com/alpacax/alpacon-cli/cmd/websh"
@@ -138,6 +139,9 @@ func init() {
 
 	// tunnel
 	RootCmd.AddCommand(tunnel.TunnelCmd)
+
+	// username
+	RootCmd.AddCommand(username.UsernameCmd)
 
 	// workspace
 	RootCmd.AddCommand(workspace.WorkspaceCmd)

--- a/cmd/username/username.go
+++ b/cmd/username/username.go
@@ -18,5 +18,6 @@ var UsernameCmd = &cobra.Command{
 }
 
 func init() {
+	UsernameCmd.AddCommand(usernameGetCmd)
 	UsernameCmd.AddCommand(usernameSetCmd)
 }

--- a/cmd/username/username.go
+++ b/cmd/username/username.go
@@ -1,0 +1,22 @@
+package username
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var UsernameCmd = &cobra.Command{
+	Use:   "username",
+	Short: "Manage the username for your account's server access",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+		return errors.New("a subcommand is required. Run 'alpacon username --help' for more information")
+	},
+}
+
+func init() {
+	UsernameCmd.AddCommand(usernameSetCmd)
+}

--- a/cmd/username/username.go
+++ b/cmd/username/username.go
@@ -6,6 +6,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// opGet is the operation identifier carried in JSON error envelopes (context.operation).
+const opGet = "get"
+
 var UsernameCmd = &cobra.Command{
 	Use:   "username",
 	Short: "Manage the username for your account's server access",

--- a/cmd/username/username_get.go
+++ b/cmd/username/username_get.go
@@ -35,7 +35,7 @@ var usernameGetCmd = &cobra.Command{
 
 		if utils.OutputFormat == utils.OutputFormatJSON {
 			if err := utils.PrintJSONValue(os.Stdout, map[string]string{"username": user.Username}); err != nil {
-				utils.CliErrorWithExit("Failed to encode username: %s.", err)
+				utils.CliErrorEnvelopeWithExit(opGet, err, "Failed to encode username: %s.", err)
 			}
 			return
 		}

--- a/cmd/username/username_get.go
+++ b/cmd/username/username_get.go
@@ -3,7 +3,6 @@ package username
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/client"
@@ -22,18 +21,16 @@ var usernameGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+			utils.CliErrorEnvelopeWithExit(opGet, err, "Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
 		user, err := iam.GetCurrentUser(alpaconClient)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve the current user: %s.", err)
+			utils.CliErrorEnvelopeWithExit(opGet, err, "Failed to retrieve the current user: %s.", err)
 		}
 
 		if user.Username == "" {
-			fmt.Fprintf(os.Stderr, "%s: username is not set.\n", utils.Red("Error"))
-			fmt.Fprintln(os.Stderr, "Run 'alpacon username set <name>' to set it.")
-			os.Exit(1)
+			utils.CliErrorEnvelopeWithExit(opGet, nil, "Username is not set. Run 'alpacon username set <name>' to set it.")
 		}
 
 		if utils.OutputFormat == utils.OutputFormatJSON {

--- a/cmd/username/username_get.go
+++ b/cmd/username/username_get.go
@@ -1,0 +1,50 @@
+package username
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/alpacax/alpacon-cli/api/iam"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var usernameGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Show the username for your account",
+	Example: `
+	alpacon username get
+	alpacon username get --output json
+	`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		user, err := iam.GetCurrentUser(alpaconClient)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve the current user: %s.", err)
+		}
+
+		if user.Username == "" {
+			fmt.Fprintf(os.Stderr, "%s: username is not set.\n", utils.Red("Error"))
+			fmt.Fprintln(os.Stderr, "Run 'alpacon username set <name>' to set it.")
+			os.Exit(1)
+		}
+
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			out, err := json.Marshal(map[string]string{"username": user.Username})
+			if err != nil {
+				utils.CliErrorWithExit("Failed to encode username: %s.", err)
+			}
+			utils.PrintJson(out)
+			return
+		}
+
+		fmt.Println(user.Username)
+	},
+}

--- a/cmd/username/username_get.go
+++ b/cmd/username/username_get.go
@@ -1,8 +1,8 @@
 package username
 
 import (
-	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/client"
@@ -34,11 +34,9 @@ var usernameGetCmd = &cobra.Command{
 		}
 
 		if utils.OutputFormat == utils.OutputFormatJSON {
-			out, err := json.Marshal(map[string]string{"username": user.Username})
-			if err != nil {
+			if err := utils.PrintJSONValue(os.Stdout, map[string]string{"username": user.Username}); err != nil {
 				utils.CliErrorWithExit("Failed to encode username: %s.", err)
 			}
-			utils.PrintJson(out)
 			return
 		}
 

--- a/cmd/username/username_set.go
+++ b/cmd/username/username_set.go
@@ -1,6 +1,8 @@
 package username
 
 import (
+	"fmt"
+
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
@@ -22,13 +24,18 @@ var usernameSetCmd = &cobra.Command{
 
 		response, err := iam.SetUsername(name)
 		if err != nil {
-			code, _ := utils.ParseErrorResponse(err)
-			if msg, ok := iam.UsernameErrorMessage(code); ok {
-				utils.CliErrorWithExit("%s", msg)
-			}
-			utils.CliErrorWithExit("Failed to set username: %s", err)
+			utils.CliErrorWithExit("%s", setUsernameErrorText(err))
 		}
 
 		utils.CliSuccess("Username set to %q", response.Username)
 	},
+}
+
+// setUsernameErrorText maps a SetUsername error to the message shown to the user.
+func setUsernameErrorText(err error) string {
+	code, _ := utils.ParseErrorResponse(err)
+	if msg, ok := iam.UsernameErrorMessage(code); ok {
+		return msg
+	}
+	return fmt.Sprintf("Failed to set username: %s", err)
 }

--- a/cmd/username/username_set.go
+++ b/cmd/username/username_set.go
@@ -1,0 +1,34 @@
+package username
+
+import (
+	"github.com/alpacax/alpacon-cli/api/iam"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var usernameSetCmd = &cobra.Command{
+	Use:   "set NAME",
+	Short: "Set the username for your account",
+	Long: `
+	Set the username used for server access services like websh and webftp.
+	The username can be set once; it cannot be changed here afterward.
+	`,
+	Example: `
+	alpacon username set jschae
+	`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := args[0]
+
+		response, err := iam.SetUsername(name)
+		if err != nil {
+			code, _ := utils.ParseErrorResponse(err)
+			if msg, ok := iam.UsernameErrorMessage(code); ok {
+				utils.CliErrorWithExit("%s", msg)
+			}
+			utils.CliErrorWithExit("Failed to set username: %s", err)
+		}
+
+		utils.CliSuccess("Username set to %q", response.Username)
+	},
+}

--- a/cmd/username/username_set.go
+++ b/cmd/username/username_set.go
@@ -27,7 +27,7 @@ var usernameSetCmd = &cobra.Command{
 			utils.CliErrorWithExit("%s", setUsernameErrorText(err))
 		}
 
-		utils.CliSuccess("Username set to %q", response.Username)
+		utils.CliSuccess(iam.UsernameSetSuccessFmt, response.Username)
 	},
 }
 

--- a/cmd/username/username_test.go
+++ b/cmd/username/username_test.go
@@ -1,0 +1,31 @@
+package username
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetUsernameErrorText(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantMatch  string
+		wantDetail string // when set, the fallback must preserve the original error detail
+	}{
+		{"in_use mapped", errors.New(`{"code": "user_username_in_use", "source": ""}`), "already in use", ""},
+		{"disallowed mapped", errors.New(`{"code": "user_username_disallowed"}`), "reserved", ""},
+		{"invalid mapped", errors.New(`{"code": "user_username_invalid"}`), "lowercase letters", ""},
+		{"unknown falls back", errors.New("some network failure"), "Failed to set username", "some network failure"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := setUsernameErrorText(tt.err)
+			assert.Contains(t, got, tt.wantMatch)
+			if tt.wantDetail != "" {
+				assert.Contains(t, got, tt.wantDetail)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Background

In non-interactive environments (CI, AI agents, pipelines), running `websh`/`exec`/`cp` for an account without a username caused the username input prompt to **hang forever** waiting on stdin. AI agents and CI had no way to self-recover.

Closes #212

## Changes

### Features
- **`alpacon username get`** — show the current account's username (supports `--output json`)
- **`alpacon username set NAME`** — set the username, mapping server error codes to human-readable messages

### Fixes
- **Non-interactive guard**: `HandleUsernameRequired` no longer prompts when stdin is not a TTY; it returns an error immediately with guidance to self-recover via `alpacon username set <name>` (hang → fail fast)
- **Interactive retry loop**: on a TTY, an invalid username can be re-entered instead of aborting
- **Concurrent-set race**: if another session sets the username while the prompt is open (`user_username_already_set`), treat it as success so the original command proceeds instead of aborting

### Cleanup / consistency
- Emit `username get` failures as a structured JSON error envelope under `--output json` (previously plain text, unparseable by JSON consumers)
- Unify the username error code's message and retryable flag into a single `usernameErrors` table to prevent drift
- Share the success message via the `iam.UsernameSetSuccessFmt` constant
- Route JSON output through `utils.PrintJSONValue`

## Testing
- Added unit tests for username error-code mapping, retryable classification, and the non-interactive guard
- Added tests for the `set` command's error mapping and fallback
- `go test -race ./...` passes
