### PR TITLE
refactor: remove redundant wrappers and consolidate stdlib helper

### DIFF
--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -578,11 +578,6 @@ func saveDownloadedURL(httpClient *http.Client, url, dest, remotePath string, re
 	return filePath, written, err
 }
 
-func downloadSingleFile(ac *client.AlpaconClient, remotePath, dest, serverID, username, groupname, resourceType, workSessionID string, recursive bool) error {
-	_, err := downloadSingleFileWithResult(ac, remotePath, dest, serverID, username, groupname, resourceType, workSessionID, recursive)
-	return err
-}
-
 func downloadSingleFileWithResult(ac *client.AlpaconClient, remotePath, dest, serverID, username, groupname, resourceType, workSessionID string, recursive bool) (DownloadedFile, error) {
 	downloadRequest := &DownloadRequest{
 		Path:         remotePath,
@@ -737,7 +732,8 @@ func DownloadFile(ac *client.AlpaconClient, sources []string, dest, username, gr
 		resourceType = "folder"
 	}
 
-	return downloadSingleFile(ac, remotePaths[0], dest, serverID, username, groupname, resourceType, workSessionID, recursive)
+	_, err = downloadSingleFileWithResult(ac, remotePaths[0], dest, serverID, username, groupname, resourceType, workSessionID, recursive)
+	return err
 }
 
 func DownloadFileToPath(ac *client.AlpaconClient, serverName, remotePath, localPath, username, groupname, workSessionID string) (DownloadedFile, error) {

--- a/cmd/tunnel/run.go
+++ b/cmd/tunnel/run.go
@@ -117,7 +117,7 @@ func monitorLocalCommand(runtime tunnelCommandRuntime, localCmd *exec.Cmd) (int,
 			}
 
 			utils.CliWarning("Tunnel closed: %s", cause)
-			interruptProcess(localCmd)
+			signalProcess(localCmd, os.Interrupt)
 			err := waitForProcessExit(waitCh, localCmd, remoteCloseGracePeriod)
 			exitCode := exitCodeFromProcessError(err)
 			if exitCode == 0 {
@@ -130,7 +130,7 @@ func monitorLocalCommand(runtime tunnelCommandRuntime, localCmd *exec.Cmd) (int,
 			if interruptCount == 1 {
 				if sig == os.Interrupt {
 					utils.CliInfo("Interrupt received. Stopping local command... (Press Ctrl+C again to force stop)")
-					interruptProcess(localCmd)
+					signalProcess(localCmd, os.Interrupt)
 				} else {
 					utils.CliInfo("Termination signal received. Stopping local command...")
 					signalProcess(localCmd, sig)
@@ -173,15 +173,11 @@ func waitForProcessExit(waitCh <-chan error, localCmd *exec.Cmd, timeout time.Du
 	}
 }
 
-func interruptProcess(localCmd *exec.Cmd) {
-	signalProcess(localCmd, os.Interrupt)
-}
-
 func killProcess(localCmd *exec.Cmd) {
 	if localCmd == nil || localCmd.Process == nil {
 		return
 	}
-	if err := killCommandProcess(localCmd); err != nil && !errors.Is(err, os.ErrProcessDone) {
+	if err := localCmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 		utils.CliWarning("Failed to force stop local command: %s", err)
 	}
 }
@@ -190,7 +186,7 @@ func signalProcess(localCmd *exec.Cmd, sig os.Signal) {
 	if localCmd == nil || localCmd.Process == nil {
 		return
 	}
-	if err := signalCommandProcess(localCmd, sig); err != nil && !errors.Is(err, os.ErrProcessDone) {
+	if err := localCmd.Process.Signal(sig); err != nil && !errors.Is(err, os.ErrProcessDone) {
 		utils.CliWarning("Failed to signal local command: %s", err)
 	}
 }
@@ -207,18 +203,4 @@ func exitCodeFromProcessError(err error) int {
 		}
 	}
 	return 1
-}
-
-func signalCommandProcess(cmd *exec.Cmd, sig os.Signal) error {
-	if cmd == nil || cmd.Process == nil {
-		return nil
-	}
-	return cmd.Process.Signal(sig)
-}
-
-func killCommandProcess(cmd *exec.Cmd) error {
-	if cmd == nil || cmd.Process == nil {
-		return nil
-	}
-	return cmd.Process.Kill()
 }

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -89,13 +89,13 @@ so it is recorded and scoped accordingly.`,
 			if !utils.IsInteractiveShell() {
 				utils.CliUsageErrorEnvelopeWithExit(opCreate, "Non-interactive mode requires --scope.")
 			}
-			createScopes = splitCSV(utils.PromptForRequiredInput("Scopes (comma-separated, e.g. command,websh): "))
+			createScopes = utils.SplitAndTrim(utils.PromptForRequiredInput("Scopes (comma-separated, e.g. command,websh): "), ",")
 		}
 		if len(createServers) == 0 {
 			if !utils.IsInteractiveShell() {
 				utils.CliUsageErrorEnvelopeWithExit(opCreate, "Non-interactive mode requires --server.")
 			}
-			createServers = splitCSV(utils.PromptForRequiredInput("Servers (comma-separated server names): "))
+			createServers = utils.SplitAndTrim(utils.PromptForRequiredInput("Servers (comma-separated server names): "), ",")
 		}
 
 		expiresAtVal, err := parseExpiryFlag(expiresIn, expiresAt)
@@ -357,7 +357,7 @@ func validateAgentScopes(requesterType string, scopes []string) error {
 func buildSudoPolicies(specs []string, reason string) []wsapi.SudoPolicyInline {
 	var policies []wsapi.SudoPolicyInline
 	for _, spec := range specs {
-		commands := splitCSV(spec)
+		commands := utils.SplitAndTrim(spec, ",")
 		if len(commands) == 0 {
 			continue
 		}
@@ -368,19 +368,6 @@ func buildSudoPolicies(specs []string, reason string) []wsapi.SudoPolicyInline {
 		})
 	}
 	return policies
-}
-
-// splitCSV splits a comma-separated string and trims whitespace.
-func splitCSV(s string) []string {
-	parts := strings.Split(s, ",")
-	result := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			result = append(result, p)
-		}
-	}
-	return result
 }
 
 // pollForApproval polls every 10 seconds until the session reaches a terminal state.

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -152,24 +152,3 @@ func TestDecideUseAction(t *testing.T) {
 		})
 	}
 }
-
-func TestSplitCSV(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  []string
-	}{
-		{"normal", "command,websh", []string{"command", "websh"}},
-		{"whitespace around values", " command , websh ", []string{"command", "websh"}},
-		{"trailing comma", "command,websh,", []string{"command", "websh"}},
-		{"leading comma", ",command,websh", []string{"command", "websh"}},
-		{"empty input", "", []string{}},
-		{"single value", "command", []string{"command"}},
-		{"only commas", ",,,", []string{}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, splitCSV(tt.input))
-		})
-	}
-}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -321,3 +321,24 @@ func TestZipToWriter(t *testing.T) {
 	assert.Equal(t, "hello", contents[filepath.ToSlash(filepath.Join(folderName, "file.txt"))])
 	assert.Equal(t, "world", contents[filepath.ToSlash(filepath.Join(folderName, "nested", "child.txt"))])
 }
+
+func TestSplitAndTrim(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"normal", "command,websh", []string{"command", "websh"}},
+		{"whitespace around values", " command , websh ", []string{"command", "websh"}},
+		{"trailing comma", "command,websh,", []string{"command", "websh"}},
+		{"leading comma", ",command,websh", []string{"command", "websh"}},
+		{"empty input", "", nil},
+		{"single value", "command", []string{"command"}},
+		{"only commas", ",,,", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SplitAndTrim(tt.input, ","))
+		})
+	}
+}


### PR DESCRIPTION
## Overview

While auditing the codebase for over-engineering, I found a few single-caller wrappers and a duplicated helper. This PR cleans them up. No behavior change; net 35 lines removed.

## Changes

### 1. Remove `downloadSingleFile` (`api/ftp/ftp.go`)

A pass-through that discarded the result and delegated straight to `downloadSingleFileWithResult`. The sole caller now calls `downloadSingleFileWithResult` directly.

### 2. Replace `splitCSV` with `utils.SplitAndTrim` (`cmd/worksession/`)

`splitCSV` was a duplicate of the existing `utils.SplitAndTrim(s, sep)`. Replaced all three call sites with `utils.SplitAndTrim(s, ",")` and deleted `splitCSV`. The only difference is the return value on empty input (`[]string{}` vs `nil`), which is irrelevant here since every caller only uses `len()`/`range`. Moved `TestSplitCSV` to `TestSplitAndTrim` in the `utils` package to preserve coverage.

### 3. Collapse tunnel signal wrappers (`cmd/tunnel/run.go`)

`interruptProcess` was a one-line delegation to `signalProcess(cmd, os.Interrupt)`; inlined at both call sites. `signalCommandProcess`/`killCommandProcess` duplicated the nil check already performed by their parents `signalProcess`/`killProcess`, making the inner check a dead branch — folded into the parents.

## Verification

`go build`, `go vet`, and `go test -race` all pass for `utils/`, `cmd/tunnel/`, `cmd/worksession/`, and `api/ftp/`.

## Intentionally kept

`truncateBody` and `createFolderZipTempFile` each have two callers; inlining them would duplicate code, so they stay.