### PR TITLE
perf(ftp): adaptive backoff for transfer status polling

### DIFF
--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -27,12 +27,7 @@ const (
 	downloadBulkAPIURL   = "/api/webftp/downloads/bulk/"
 	downloadStatusURL    = "/api/webftp/downloads/%s/status/"
 
-	// Polling configuration for transfer status. The poll interval backs off
-	// exponentially from initialPollInterval up to maxPollInterval so small
-	// files that finish quickly are detected within a fraction of a second,
-	// while large transfers settle at the cap where steady-state poll load
-	// matches the old fixed interval. (Bulk transfers polling concurrently can
-	// briefly raise request density during the sub-cap ramp.)
+	// Poll interval backs off exponentially up to maxPollInterval.
 	initialPollInterval = 250 * time.Millisecond
 	maxPollInterval     = 2 * time.Second
 	pollBackoffFactor   = 2
@@ -45,8 +40,7 @@ const (
 )
 
 // nextPollInterval returns the backoff delay for a 0-based poll attempt:
-// initialPollInterval doubled per attempt, capped at maxPollInterval. The cap
-// is checked each step, so the value never overflows for large attempt counts.
+// initialPollInterval doubled per attempt, capped at maxPollInterval.
 func nextPollInterval(attempt int) time.Duration {
 	d := initialPollInterval
 	for i := 0; i < attempt; i++ {

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -57,6 +57,14 @@ func nextPollInterval(attempt int) time.Duration {
 // boundary measured from the polling start. Snapping to that grid makes the
 // schedule a superset of a fixed maxPollInterval poller, so faster small-file
 // detection never costs a slower detection for any completion time.
+//
+// Aligning to absolute grid boundaries (rather than sleeping a full interval
+// after each response) absorbs request latency into the sleep, so in steady
+// state polls fire ~every maxPollInterval from the start instead of
+// maxPollInterval+RTT. This keeps detection bounded but makes the request rate
+// slightly higher than the old poller on high-latency links—negligible for the
+// short-lived transfers this polls, and a deliberate trade for the superset
+// guarantee.
 func alignedPollDelay(attempt int, elapsed time.Duration) time.Duration {
 	backoff := nextPollInterval(attempt)
 	toBoundary := maxPollInterval - elapsed%maxPollInterval
@@ -84,8 +92,10 @@ func PollTransferStatus(ac *client.AlpaconClient, transferType, id string, timeo
 	for attempt := 0; ; attempt++ {
 		respBody, err := ac.SendGetRequest(statusURL)
 		if err != nil {
-			// A 422 (transfer in progress) is expected while the transfer is
-			// still running: back off and retry. Any other error is fatal.
+			// A "webftp_transfer_in_progress" payload is expected while the
+			// transfer is still running: back off and retry. Any other error
+			// is fatal. SendGetRequest returns the parsed API error message,
+			// not the HTTP status, so we key off the payload text.
 			if !strings.Contains(err.Error(), "webftp_transfer_in_progress") {
 				return false, "", fmt.Errorf("failed to check transfer status: %w", err)
 			}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -90,6 +90,12 @@ func PollTransferStatus(ac *client.AlpaconClient, transferType, id string, timeo
 	deadline := start.Add(timeout)
 
 	for attempt := 0; ; attempt++ {
+		// Enforce the deadline before every request: time.Sleep can oversleep, so
+		// this top-of-loop check is what actually prevents a request firing past
+		// the timeout window.
+		if !time.Now().Before(deadline) {
+			break
+		}
 		respBody, err := ac.SendGetRequest(statusURL)
 		if err != nil {
 			// A "webftp_transfer_in_progress" payload is expected while the
@@ -111,9 +117,8 @@ func PollTransferStatus(ac *client.AlpaconClient, transferType, id string, timeo
 
 		now := time.Now()
 		delay := alignedPollDelay(attempt, now.Sub(start))
-		// Break if the next poll would start at or after the deadline: a single
-		// captured now keeps the loop strictly deadline-based, so no request
-		// fires past the timeout window even if time.Sleep oversleeps.
+		// Avoid sleeping into a poll whose scheduled start is already at or past
+		// the deadline; the top-of-loop check handles oversleep.
 		if !now.Add(delay).Before(deadline) {
 			break
 		}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -58,6 +58,20 @@ func nextPollInterval(attempt int) time.Duration {
 	return d
 }
 
+// alignedPollDelay returns the sleep before the next poll: the backoff for this
+// attempt, clamped so the poll never lands past the next maxPollInterval grid
+// boundary measured from the polling start. Snapping to that grid makes the
+// schedule a superset of a fixed maxPollInterval poller, so faster small-file
+// detection never costs a slower detection for any completion time.
+func alignedPollDelay(attempt int, elapsed time.Duration) time.Duration {
+	backoff := nextPollInterval(attempt)
+	toBoundary := maxPollInterval - elapsed%maxPollInterval
+	if toBoundary < backoff {
+		return toBoundary
+	}
+	return backoff
+}
+
 // PollTransferStatus polls the transfer status API until success/failure or timeout.
 // transferType should be "upload" or "download", id is the transfer ID.
 // timeout controls how long to poll before giving up.
@@ -70,7 +84,8 @@ func PollTransferStatus(ac *client.AlpaconClient, transferType, id string, timeo
 		statusURL = fmt.Sprintf(downloadStatusURL, id)
 	}
 
-	deadline := time.Now().Add(timeout)
+	start := time.Now()
+	deadline := start.Add(timeout)
 
 	for attempt := 0; ; attempt++ {
 		respBody, err := ac.SendGetRequest(statusURL)
@@ -90,7 +105,7 @@ func PollTransferStatus(ac *client.AlpaconClient, transferType, id string, timeo
 			}
 		}
 
-		delay := nextPollInterval(attempt)
+		delay := alignedPollDelay(attempt, time.Since(start))
 		if time.Now().Add(delay).After(deadline) {
 			break
 		}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -27,15 +27,36 @@ const (
 	downloadBulkAPIURL   = "/api/webftp/downloads/bulk/"
 	downloadStatusURL    = "/api/webftp/downloads/%s/status/"
 
-	// Polling configuration for transfer status
-	pollInterval       = 2 * time.Second
-	basePollTimeout    = 30 * time.Second
-	perFilePollTimeout = 10 * time.Second
-	perMBPollTimeout   = 5 * time.Second
+	// Polling configuration for transfer status. The poll interval backs off
+	// exponentially from initialPollInterval up to maxPollInterval so small
+	// files that finish quickly are detected within a fraction of a second,
+	// while large transfers settle at the cap where steady-state poll load
+	// matches the old fixed interval. (Bulk transfers polling concurrently can
+	// briefly raise request density during the sub-cap ramp.)
+	initialPollInterval = 250 * time.Millisecond
+	maxPollInterval     = 2 * time.Second
+	pollBackoffFactor   = 2
+	basePollTimeout     = 30 * time.Second
+	perFilePollTimeout  = 10 * time.Second
+	perMBPollTimeout    = 5 * time.Second
 
 	bulkUploadConcurrency = 4 // uploads transfer payload bytes, keep low
 	bulkPollConcurrency   = 8 // status polls are lightweight, allow more
 )
+
+// nextPollInterval returns the backoff delay for a 0-based poll attempt:
+// initialPollInterval doubled per attempt, capped at maxPollInterval. The cap
+// is checked each step, so the value never overflows for large attempt counts.
+func nextPollInterval(attempt int) time.Duration {
+	d := initialPollInterval
+	for i := 0; i < attempt; i++ {
+		d *= pollBackoffFactor
+		if d >= maxPollInterval {
+			return maxPollInterval
+		}
+	}
+	return d
+}
 
 // PollTransferStatus polls the transfer status API until success/failure or timeout.
 // transferType should be "upload" or "download", id is the transfer ID.
@@ -49,32 +70,31 @@ func PollTransferStatus(ac *client.AlpaconClient, transferType, id string, timeo
 		statusURL = fmt.Sprintf(downloadStatusURL, id)
 	}
 
-	maxRetries := int(timeout / pollInterval)
-	if maxRetries < 1 {
-		maxRetries = 1
-	}
+	deadline := time.Now().Add(timeout)
 
-	for i := 0; i < maxRetries; i++ {
+	for attempt := 0; ; attempt++ {
 		respBody, err := ac.SendGetRequest(statusURL)
 		if err != nil {
-			// Check if it's a 422 error (transfer in progress)
-			if strings.Contains(err.Error(), "webftp_transfer_in_progress") {
-				time.Sleep(pollInterval)
-				continue
+			// A 422 (transfer in progress) is expected while the transfer is
+			// still running: back off and retry. Any other error is fatal.
+			if !strings.Contains(err.Error(), "webftp_transfer_in_progress") {
+				return false, "", fmt.Errorf("failed to check transfer status: %w", err)
 			}
-			return false, "", fmt.Errorf("failed to check transfer status: %w", err)
+		} else {
+			var statusResp TransferStatusResponse
+			if err := json.Unmarshal(respBody, &statusResp); err != nil {
+				return false, statusResp.Message, fmt.Errorf("failed to parse transfer status response: %w", err)
+			}
+			if statusResp.Success != nil {
+				return *statusResp.Success, statusResp.Message, nil
+			}
 		}
 
-		var statusResp TransferStatusResponse
-		if err := json.Unmarshal(respBody, &statusResp); err != nil {
-			return false, statusResp.Message, fmt.Errorf("failed to parse transfer status response: %w", err)
+		delay := nextPollInterval(attempt)
+		if time.Now().Add(delay).After(deadline) {
+			break
 		}
-
-		if statusResp.Success != nil {
-			return *statusResp.Success, statusResp.Message, nil
-		}
-
-		time.Sleep(pollInterval)
+		time.Sleep(delay)
 	}
 
 	return false, "", fmt.Errorf("transfer status polling timed out after %v", timeout)

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -109,8 +109,12 @@ func PollTransferStatus(ac *client.AlpaconClient, transferType, id string, timeo
 			}
 		}
 
-		delay := alignedPollDelay(attempt, time.Since(start))
-		if time.Now().Add(delay).After(deadline) {
+		now := time.Now()
+		delay := alignedPollDelay(attempt, now.Sub(start))
+		// Break if the next poll would start at or after the deadline: a single
+		// captured now keeps the loop strictly deadline-based, so no request
+		// fires past the timeout window even if time.Sleep oversleeps.
+		if !now.Add(delay).Before(deadline) {
 			break
 		}
 		time.Sleep(delay)

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1365,3 +1365,25 @@ func TestPollTransferStatus_FatalErrorNoRetry(t *testing.T) {
 	assert.False(t, success)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "fatal error must not be retried")
 }
+
+func TestPollTransferStatus_TimesOut(t *testing.T) {
+	// Server never completes (success=null). With a timeout below the initial
+	// poll interval, the deadline check breaks before the first sleep, so a
+	// single poll happens and the timeout error is returned.
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(TransferStatusResponse{Success: nil})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	success, _, err := PollTransferStatus(ac, "upload", "test-id", 50*time.Millisecond)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+	assert.False(t, success)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1320,8 +1320,8 @@ func TestPollTransferStatus_BacksOffThenSucceeds(t *testing.T) {
 }
 
 func TestPollTransferStatus_RetriesWhileInProgress(t *testing.T) {
-	// A 422 with the in-progress code is expected while the transfer runs:
-	// PollTransferStatus must back off and retry, not treat it as fatal.
+	// Retry keys off the "webftp_transfer_in_progress" payload, not the 422
+	// status: PollTransferStatus must back off and retry, not treat it as fatal.
 	var calls int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := atomic.AddInt32(&calls, 1)

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1252,6 +1252,39 @@ func TestNextPollInterval(t *testing.T) {
 	}
 }
 
+func TestAlignedPollDelay(t *testing.T) {
+	// The delay is the backoff for the attempt, clamped so the poll never lands
+	// past the next maxPollInterval grid boundary. This keeps the adaptive
+	// schedule a superset of a fixed maxPollInterval poller (poll points 0, 250,
+	// 750, 1750, 2000, 4000, 6000, ...), so it is never slower for any completion
+	// time while small files are still detected during the early ramp.
+	tests := []struct {
+		name    string
+		attempt int
+		elapsed time.Duration
+		want    time.Duration
+	}{
+		{name: "ramp: first attempt", attempt: 0, elapsed: 0, want: 250 * time.Millisecond},
+		{name: "ramp: second", attempt: 1, elapsed: 250 * time.Millisecond, want: 500 * time.Millisecond},
+		{name: "ramp: third", attempt: 2, elapsed: 750 * time.Millisecond, want: 1 * time.Second},
+		{name: "clamp to first boundary", attempt: 3, elapsed: 1750 * time.Millisecond, want: 250 * time.Millisecond},
+		{name: "steady state on boundary", attempt: 4, elapsed: 2 * time.Second, want: 2 * time.Second},
+		{name: "steady state stays on grid", attempt: 5, elapsed: 4 * time.Second, want: 2 * time.Second},
+		// The cases below exercise the clamp arithmetic in isolation: by attempt 4
+		// nextPollInterval saturates at maxPollInterval, so the result is purely
+		// the distance to the next 2s boundary regardless of the attempt value.
+		{name: "clamp from mid grid cell", attempt: 9, elapsed: 2500 * time.Millisecond, want: 1500 * time.Millisecond},
+		{name: "clamp just before boundary", attempt: 9, elapsed: 3800 * time.Millisecond, want: 200 * time.Millisecond},
+		{name: "large elapsed wraps onto grid", attempt: 9, elapsed: time.Hour + 500*time.Millisecond, want: 1500 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, alignedPollDelay(tt.attempt, tt.elapsed))
+		})
+	}
+}
+
 func TestPollTransferStatus_BacksOffThenSucceeds(t *testing.T) {
 	// Server reports "not yet complete" (success=null) twice, then succeeds.
 	// With adaptive backoff the two waits are 250ms + 500ms = 750ms, far below

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1230,3 +1230,105 @@ func TestDownloadFile_WorkSession(t *testing.T) {
 		})
 	}
 }
+
+func TestNextPollInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		attempt int
+		want    time.Duration
+	}{
+		{name: "first attempt is initial interval", attempt: 0, want: 250 * time.Millisecond},
+		{name: "second doubles", attempt: 1, want: 500 * time.Millisecond},
+		{name: "third doubles", attempt: 2, want: 1 * time.Second},
+		{name: "fourth reaches cap", attempt: 3, want: 2 * time.Second},
+		{name: "beyond cap stays capped", attempt: 4, want: 2 * time.Second},
+		{name: "large attempt does not overflow", attempt: 64, want: 2 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nextPollInterval(tt.attempt))
+		})
+	}
+}
+
+func TestPollTransferStatus_BacksOffThenSucceeds(t *testing.T) {
+	// Server reports "not yet complete" (success=null) twice, then succeeds.
+	// With adaptive backoff the two waits are 250ms + 500ms = 750ms, far below
+	// the old fixed 2s+2s = 4s. Assert both the poll count and a loose upper
+	// bound that the old fixed interval could not have met.
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n < 3 {
+			_ = json.NewEncoder(w).Encode(TransferStatusResponse{Success: nil})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(TransferStatusResponse{Success: boolPtr(true), Message: "done"})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	start := time.Now()
+	success, message, err := PollTransferStatus(ac, "upload", "test-id", 30*time.Second)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.True(t, success)
+	assert.Equal(t, "done", message)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+	// Lower bound proves the two waits actually backed off (250ms+500ms);
+	// loose upper bound proves it beat the old fixed 2s+2s without being
+	// flaky under slow CI scheduling.
+	assert.GreaterOrEqual(t, elapsed, 750*time.Millisecond, "two backoff waits should sum to at least 250ms+500ms")
+	assert.Less(t, elapsed, 3*time.Second, "adaptive backoff should finish well under the old fixed 2s+2s")
+}
+
+func TestPollTransferStatus_RetriesWhileInProgress(t *testing.T) {
+	// A 422 with the in-progress code is expected while the transfer runs:
+	// PollTransferStatus must back off and retry, not treat it as fatal.
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n < 3 {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(map[string]string{"detail": "webftp_transfer_in_progress"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(TransferStatusResponse{Success: boolPtr(true), Message: "done"})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	success, message, err := PollTransferStatus(ac, "upload", "test-id", 30*time.Second)
+
+	require.NoError(t, err)
+	assert.True(t, success)
+	assert.Equal(t, "done", message)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+}
+
+func TestPollTransferStatus_FatalErrorNoRetry(t *testing.T) {
+	// A non-in-progress error (e.g. 403) is fatal: return immediately without
+	// polling again.
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "permission denied"})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	success, _, err := PollTransferStatus(ac, "upload", "test-id", 30*time.Second)
+
+	assert.Error(t, err)
+	assert.False(t, success)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "fatal error must not be retried")
+}


### PR DESCRIPTION
## Summary

Replaces the fixed 2s transfer-status poll with adaptive exponential backoff (250ms → 2s cap, ×2). Fast/small transfers are detected up to ~1.75s sooner, while large transfers settle into a ~2s steady-state cadence. The poll loop is also switched from a retry-count to a deadline basis.

Note on steady-state rate: grid alignment absorbs request latency into the sleep, so steady-state polls fire ~every 2s from the start rather than 2s+RTT like the old poller. On high-latency links this is a slightly higher request rate—a deliberate trade for the superset guarantee below, and negligible for the short-lived transfers this polls.

## Grid alignment

Each delay is clamped to the next 2s boundary, so the adaptive schedule (`0, 0.25, 0.75, 1.75, 2.0, 4.0, 6.0…`) is a strict superset of the old fixed-2s schedule. This guarantees detection is **never slower than before** at any completion time.

Plain backoff would drift out of phase with the 2s grid (`1.75, 3.75, 5.75…`), making completions that land just after a poll (e.g. ~3.8s) detected 1.75s slower than the old poller. Alignment re-syncs to the grid each poll and removes that regression.

## Measurements

Detection latency vs. true completion time T (isolated httptest harness, best of 5, ms):

| T | fixed (old) | adaptive (this PR) | plain backoff |
|---|---|---|---|
| 100 | 2001 | **251** | 251 |
| 300 | 2001 | **754** | 754 |
| 1000 | 2002 | **1756** | 1756 |
| 3800 | 4003 | **4000** | 5758 |
| 5800 | 6006 | **6001** | 7760 |

Adaptive ≤ fixed at every completion time; plain backoff regresses by 1.75s at T=3800 and T=5800, which alignment prevents.

## Test plan

- `go test -race ./...` — pass
- `go vet ./...` — clean
- Manual `alpacon cp` against a live server, 1KB–50MB, no wall-clock regression

