### PR TITLE
fix(worksession): agent path and accurate not_active gate-denial remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,10 @@ Error: the command operation requires an active WorkSession on this authenticati
   target server : prod-1
 
 Next:
-  alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose "<intent>" --use  # create a new session and attach it
-  alpacon work-session ls --status active  # or reuse an existing active session
-  alpacon work-session use <ID>
+  alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it via --work-session <ID> on the gated command
+  alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)
+  alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose "<intent>" --use  # none active? create a new one (human)
+  alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose "<intent>" --requester-type agent  # none active? create a new one (AI agent; pass --work-session <ID> to subsequent commands)
 
 Note: Tokens issued by Alpacon (service or personal API token) bypass this check.
 ```
@@ -260,9 +261,10 @@ With `--output json`, the same refusal is a structured envelope on stderr—scri
     "current_worksession": null
   },
   "next_actions": [
-    "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --use  # create a new session and attach it",
-    "alpacon work-session ls --status active  # or reuse an existing active session",
-    "alpacon work-session use <ID>"
+    "alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it via --work-session <ID> on the gated command",
+    "alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
+    "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --use  # none active? create a new one (human)",
+    "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --requester-type agent  # none active? create a new one (AI agent; pass --work-session <ID> to subsequent commands)"
   ]
 }
 ```
@@ -272,7 +274,7 @@ What each refusal code means and what to do next:
 | `error_code` | Meaning | Next |
 |---|---|---|
 | `work_session_required` | no session selected for this shell | `work-session create --use` or `work-session use <ID>` |
-| `work_session_not_active` | session not active (pending, completed, or revoked) | if pending, wait; otherwise create or reuse a session |
+| `work_session_not_active` | session not active (pending, approved, completed, or revoked) | if pending or approved, wait; otherwise create or reuse a session |
 | `work_session_expired` | session has expired | `work-session extend <ID>` or create a new one |
 | `work_session_scope_not_allowed` | operation not in session scopes | create a session with the right `--scope` |
 | `work_session_server_not_allowed` | target server not in session | create a session with the right `--server` |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ What each refusal code means and what to do next:
 | `error_code` | Meaning | Next |
 |---|---|---|
 | `work_session_required` | no session selected for this shell | `work-session create --use` or `work-session use <ID>` |
-| `work_session_not_active` | session not yet active (check `starts_at`) | wait, then `work-session current` |
+| `work_session_not_active` | session not active (pending, completed, or revoked) | if pending, wait; otherwise create or reuse a session |
 | `work_session_expired` | session has expired | `work-session extend <ID>` or create a new one |
 | `work_session_scope_not_allowed` | operation not in session scopes | create a session with the right `--scope` |
 | `work_session_server_not_allowed` | target server not in session | create a session with the right `--server` |

--- a/README.md
+++ b/README.md
@@ -237,10 +237,10 @@ Error: the command operation requires an active WorkSession on this authenticati
   target server : prod-1
 
 Next:
-  alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it via --work-session <ID> on the gated command
+  alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>
   alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)
   alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose "<intent>" --use  # none active? create a new one (human)
-  alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose "<intent>" --requester-type agent  # none active? create a new one (AI agent; pass --work-session <ID> to subsequent commands)
+  alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose "<intent>" --requester-type agent  # none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)
 
 Note: Tokens issued by Alpacon (service or personal API token) bypass this check.
 ```
@@ -261,10 +261,10 @@ With `--output json`, the same refusal is a structured envelope on stderr—scri
     "current_worksession": null
   },
   "next_actions": [
-    "alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it via --work-session <ID> on the gated command",
+    "alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>",
     "alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
     "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --use  # none active? create a new one (human)",
-    "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --requester-type agent  # none active? create a new one (AI agent; pass --work-session <ID> to subsequent commands)"
+    "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --requester-type agent  # none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)"
   ]
 }
 ```

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -50,7 +50,7 @@ Lifecycle:  pending → approved → active → complete | expired | revoked
 
 Error codes returned when a session check fails:
   work_session_required           no session selected for this shell
-  work_session_not_active         session not active (pending, completed, or revoked)
+  work_session_not_active         session not active (pending, approved, completed, or revoked)
   work_session_expired            session has expired
   work_session_scope_not_allowed  operation not in session scopes
   work_session_server_not_allowed target server not in session

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -50,7 +50,7 @@ Lifecycle:  pending → approved → active → complete | expired | revoked
 
 Error codes returned when a session check fails:
   work_session_required           no session selected for this shell
-  work_session_not_active         session not yet active (check starts_at)
+  work_session_not_active         session not active (pending, completed, or revoked)
   work_session_expired            session has expired
   work_session_scope_not_allowed  operation not in session scopes
   work_session_server_not_allowed target server not in session

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -18,7 +18,7 @@ type workSessionErrorCtx struct {
 var workSessionReasonMap = map[string]string{
 	WorkSessionRequired:         "no WorkSession selected for this shell",
 	WorkSessionNotUsable:        "session is no longer usable",
-	WorkSessionNotActive:        "selected session is not yet active",
+	WorkSessionNotActive:        "selected session is not active",
 	WorkSessionExpired:          "selected session has expired",
 	WorkSessionScopeNotAllowed:  "session does not include this scope",
 	WorkSessionServerNotAllowed: "target server is not in this session",
@@ -127,7 +127,10 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	case WorkSessionRequired:
 		return createOrReuse
 	case WorkSessionNotActive:
-		return []string{"alpacon work-session current"}
+		// Activation is approval/server-driven, not user-run; guide toward an active session.
+		return append([]string{
+			"alpacon work-session current  # pending: wait until active; completed/revoked: create or reuse below",
+		}, createOrReuse...)
 	case WorkSessionExpired:
 		extendCmd := "alpacon work-session extend <ID>"
 		if activeWS != "" {

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -119,9 +119,9 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	createOrReuse := []string{
 		createCmd + "  # create a new session and attach it (human)",
 		"alpacon work-session ls --status active  # or reuse an existing active session",
-		"alpacon work-session use <ID>",
+		"alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
 		agentCreateCmd + "  # AI agent (non-interactive); agent sessions aren't attachable via --use",
-		"export ALPACON_WORK_SESSION=<ID>",
+		"export ALPACON_WORK_SESSION=<ID>  # agent equivalent of the use step",
 	}
 	switch code {
 	case WorkSessionRequired:

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -119,10 +119,10 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	// Reuse an active session first (ls), then create as the fallback. Humans attach via `use`;
 	// agents can't `use` (it rejects agent sessions) and instead pass --work-session <ID> downstream.
 	createOrReuse := []string{
-		"alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it via --work-session <ID> on the gated command",
+		"alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>",
 		"alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
 		createCmd + "  # none active? create a new one (human)",
-		agentCreateCmd + "  # none active? create a new one (AI agent; pass --work-session <ID> to subsequent commands)",
+		agentCreateCmd + "  # none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)",
 	}
 	switch code {
 	case WorkSessionRequired:

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -112,11 +112,18 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>" --use`,
 		operation, serverArg,
 	)
-	// createOrReuse leads with create-and-attach, then the reuse path.
+	// Agent sessions are not workspace-attachable (no --use); they run non-interactively
+	// via an explicitly passed session, so guide AI agents down their own path.
+	agentCreateCmd := fmt.Sprintf(
+		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>" --requester-type agent`,
+		operation, serverArg,
+	)
+	// createOrReuse leads with create-and-attach, then the reuse path, then the agent path.
 	createOrReuse := []string{
-		createCmd + "  # create a new session and attach it",
+		createCmd + "  # create a new session and attach it (human)",
 		"alpacon work-session ls --status active  # or reuse an existing active session",
 		"alpacon work-session use <ID>",
+		agentCreateCmd + "  # AI agent: then export ALPACON_WORK_SESSION=<ID> (agent sessions aren't attachable via --use)",
 	}
 	switch code {
 	case WorkSessionRequired:

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -116,13 +116,12 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>" --requester-type agent`,
 		operation, serverArg,
 	)
-	// Reuse first (ls → use/export), then create as the fallback—for human and agent alike.
+	// Reuse first (ls → use), then create as the fallback—for human and agent alike.
 	createOrReuse := []string{
 		"alpacon work-session ls --status active  # find an existing active session",
 		"alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
-		"export ALPACON_WORK_SESSION=<ID>  # agent: use an existing session",
 		createCmd + "  # none active? create a new one (human)",
-		agentCreateCmd + "  # none active? create a new one (AI agent; not attachable via --use)",
+		agentCreateCmd + "  # none active? create a new one (AI agent; pass --work-session <ID> to subsequent commands)",
 	}
 	switch code {
 	case WorkSessionRequired:

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -121,6 +121,7 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	createOrReuse := []string{
 		"alpacon work-session ls --status active  # find an existing active session",
 		"alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
+		"# AI agent: reuse by passing --work-session <ID> (an active ID from ls) to the gated command",
 		createCmd + "  # none active? create a new one (human)",
 		agentCreateCmd + "  # none active? create a new one (AI agent; pass --work-session <ID> to subsequent commands)",
 	}
@@ -137,12 +138,12 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 		if activeWS != "" {
 			extendCmd = fmt.Sprintf("alpacon work-session extend %s", activeWS)
 		}
-		return []string{extendCmd, createCmd}
+		return []string{extendCmd, createCmd, agentCreateCmd}
 	case WorkSessionAssigneeMismatch:
 		return []string{"alpacon work-session use <ID>"}
 	case WorkSessionNotUsable:
 		return createOrReuse
 	default: // scope_not_allowed, server_not_allowed
-		return []string{createCmd}
+		return []string{createCmd, agentCreateCmd}
 	}
 }

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -139,7 +139,9 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 		}
 		return []string{extendCmd, createCmd, agentCreateCmd}
 	case WorkSessionAssigneeMismatch:
-		return []string{"alpacon work-session use <ID>"}
+		// Session belongs to another principal; reuse/create one owned by this caller.
+		// Agents can't `use`, so route through the agent-aware reuse+create path.
+		return createOrReuse
 	case WorkSessionNotUsable:
 		return createOrReuse
 	default: // scope_not_allowed, server_not_allowed

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -119,9 +119,8 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	// Reuse an active session first (ls), then create as the fallback. Humans attach via `use`;
 	// agents can't `use` (it rejects agent sessions) and instead pass --work-session <ID> downstream.
 	createOrReuse := []string{
-		"alpacon work-session ls --status active  # find an existing active session",
+		"alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it via --work-session <ID> on the gated command",
 		"alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
-		"# AI agent: reuse by passing --work-session <ID> (an active ID from ls) to the gated command",
 		createCmd + "  # none active? create a new one (human)",
 		agentCreateCmd + "  # none active? create a new one (AI agent; pass --work-session <ID> to subsequent commands)",
 	}
@@ -131,7 +130,7 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	case WorkSessionNotActive:
 		// Activation is approval/server-driven, not user-run; guide toward an active session.
 		return append([]string{
-			"alpacon work-session current  # pending: wait until active; completed/revoked: create or reuse below",
+			"alpacon work-session current  # pending/approved: wait until active; completed/revoked: create or reuse below",
 		}, createOrReuse...)
 	case WorkSessionExpired:
 		extendCmd := "alpacon work-session extend <ID>"

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -120,7 +120,8 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 		createCmd + "  # create a new session and attach it (human)",
 		"alpacon work-session ls --status active  # or reuse an existing active session",
 		"alpacon work-session use <ID>",
-		agentCreateCmd + "  # AI agent: then export ALPACON_WORK_SESSION=<ID> (agent sessions aren't attachable via --use)",
+		agentCreateCmd + "  # AI agent (non-interactive); agent sessions aren't attachable via --use",
+		"export ALPACON_WORK_SESSION=<ID>",
 	}
 	switch code {
 	case WorkSessionRequired:

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -116,7 +116,8 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>" --requester-type agent`,
 		operation, serverArg,
 	)
-	// Reuse first (ls → use), then create as the fallback—for human and agent alike.
+	// Reuse an active session first (ls), then create as the fallback. Humans attach via `use`;
+	// agents can't `use` (it rejects agent sessions) and instead pass --work-session <ID> downstream.
 	createOrReuse := []string{
 		"alpacon work-session ls --status active  # find an existing active session",
 		"alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -116,12 +116,13 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>" --requester-type agent`,
 		operation, serverArg,
 	)
+	// Reuse first (ls → use/export), then create as the fallback—for human and agent alike.
 	createOrReuse := []string{
-		createCmd + "  # create a new session and attach it (human)",
-		"alpacon work-session ls --status active  # or reuse an existing active session",
+		"alpacon work-session ls --status active  # find an existing active session",
 		"alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
-		agentCreateCmd + "  # AI agent (non-interactive); agent sessions aren't attachable via --use",
-		"export ALPACON_WORK_SESSION=<ID>  # agent equivalent of the use step",
+		"export ALPACON_WORK_SESSION=<ID>  # agent: use an existing session",
+		createCmd + "  # none active? create a new one (human)",
+		agentCreateCmd + "  # none active? create a new one (AI agent; not attachable via --use)",
 	}
 	switch code {
 	case WorkSessionRequired:

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -112,13 +112,10 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>" --use`,
 		operation, serverArg,
 	)
-	// Agent sessions are not workspace-attachable (no --use); they run non-interactively
-	// via an explicitly passed session, so guide AI agents down their own path.
 	agentCreateCmd := fmt.Sprintf(
 		`alpacon work-session create --scope %s --server %s --expires-in 1h --purpose "<intent>" --requester-type agent`,
 		operation, serverArg,
 	)
-	// createOrReuse leads with create-and-attach, then the reuse path, then the agent path.
 	createOrReuse := []string{
 		createCmd + "  # create a new session and attach it (human)",
 		"alpacon work-session ls --status active  # or reuse an existing active session",

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -131,9 +131,7 @@ func TestBuildWorkSessionErrorEnvelope_RequiredKeepsPlaceholder(t *testing.T) {
 }
 
 func TestWorkSessionNextActions_IncludesAgentPath(t *testing.T) {
-	// The createOrReuse codes must offer a non-interactive agent path alongside
-	// the human --use path, so an AI agent hitting the gate is not steered into
-	// a user session it cannot attach.
+	// createOrReuse codes must offer an agent path, not just the human --use path.
 	for _, code := range []string{WorkSessionRequired, WorkSessionNotUsable} {
 		t.Run(code, func(t *testing.T) {
 			joined := strings.Join(workSessionNextActions(code, "command", "srv-1", ""), "\n")

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -61,8 +61,8 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 			}
 			if tt.reuseVsCreate {
 				assert.Contains(t, got, "alpacon work-session use <ID>")
-				assert.Contains(t, got, "reuse an existing")
-				assert.Contains(t, got, "create a new")
+				assert.Contains(t, got, "existing active session") // reuse path comes first
+				assert.Contains(t, got, "create a new one")         // create is the fallback
 			}
 		})
 	}
@@ -137,6 +137,9 @@ func TestWorkSessionNextActions_IncludesAgentPath(t *testing.T) {
 			joined := strings.Join(workSessionNextActions(code, "command", "srv-1", ""), "\n")
 			assert.Contains(t, joined, "--requester-type agent")
 			assert.Contains(t, joined, "ALPACON_WORK_SESSION")
+			// Reuse (ls) precedes create for both human (--use) and agent (--requester-type agent).
+			assert.Less(t, strings.Index(joined, "ls --status active"), strings.Index(joined, "--use"))
+			assert.Less(t, strings.Index(joined, "ALPACON_WORK_SESSION"), strings.Index(joined, "--requester-type agent"))
 		})
 	}
 }

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -41,7 +41,7 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 		{WorkSessionExpired, "has expired", "work-session extend", true, false},
 		{WorkSessionScopeNotAllowed, "does not include this scope", "work-session create", true, false},
 		{WorkSessionServerNotAllowed, "target server is not in this session", "work-session create", true, false},
-		{WorkSessionAssigneeMismatch, "assigned to another principal", "work-session use", false, false},
+		{WorkSessionAssigneeMismatch, "assigned to another principal", "work-session use", true, true},
 		{WorkSessionNotUsable, "no longer usable", "work-session create", true, true},
 	}
 

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -62,7 +62,7 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 			if tt.reuseVsCreate {
 				assert.Contains(t, got, "alpacon work-session use <ID>")
 				assert.Contains(t, got, "existing active session") // reuse path comes first
-				assert.Contains(t, got, "create a new one")         // create is the fallback
+				assert.Contains(t, got, "create a new one")        // create is the fallback
 			}
 		})
 	}

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -130,6 +130,19 @@ func TestBuildWorkSessionErrorEnvelope_RequiredKeepsPlaceholder(t *testing.T) {
 	assert.Contains(t, strings.Join(envelope.NextActions, "\n"), "alpacon work-session use <ID>")
 }
 
+func TestWorkSessionNextActions_IncludesAgentPath(t *testing.T) {
+	// The createOrReuse codes must offer a non-interactive agent path alongside
+	// the human --use path, so an AI agent hitting the gate is not steered into
+	// a user session it cannot attach.
+	for _, code := range []string{WorkSessionRequired, WorkSessionNotUsable} {
+		t.Run(code, func(t *testing.T) {
+			joined := strings.Join(workSessionNextActions(code, "command", "srv-1", ""), "\n")
+			assert.Contains(t, joined, "--requester-type agent")
+			assert.Contains(t, joined, "ALPACON_WORK_SESSION")
+		})
+	}
+}
+
 func TestHandleWorkSessionError_NoOp(t *testing.T) {
 	// Non-WorkSession errors must not trigger any exit — just return.
 	// If HandleWorkSessionError calls os.Exit for this error, the test process dies.

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -130,32 +130,6 @@ func TestBuildWorkSessionErrorEnvelope_RequiredKeepsPlaceholder(t *testing.T) {
 	assert.Contains(t, strings.Join(envelope.NextActions, "\n"), "alpacon work-session use <ID>")
 }
 
-func TestWorkSessionNextActions_IncludesAgentPath(t *testing.T) {
-	// createOrReuse codes must offer an agent path, not just the human --use path.
-	for _, code := range []string{WorkSessionRequired, WorkSessionNotUsable} {
-		t.Run(code, func(t *testing.T) {
-			joined := strings.Join(workSessionNextActions(code, "command", "srv-1", ""), "\n")
-			assert.Contains(t, joined, "--requester-type agent")
-			assert.Contains(t, joined, "ALPACON_WORK_SESSION")
-			// Reuse (ls) precedes create for both human (--use) and agent (--requester-type agent).
-			assert.Less(t, strings.Index(joined, "ls --status active"), strings.Index(joined, "--use"))
-			assert.Less(t, strings.Index(joined, "ALPACON_WORK_SESSION"), strings.Index(joined, "--requester-type agent"))
-		})
-	}
-}
-
-func TestWorkSessionNextActions_NotActiveGuidesWaitOrCreate(t *testing.T) {
-	// Activation is approval/server-driven, not user-run; guide toward an active session:
-	// pending → wait, completed/revoked → create or reuse (human and agent paths alike).
-	joined := strings.Join(workSessionNextActions(WorkSessionNotActive, "command", "srv-1", ""), "\n")
-	assert.Contains(t, joined, "work-session current")
-	assert.NotContains(t, joined, "work-session activate")
-	assert.Contains(t, joined, "wait")
-	assert.Contains(t, joined, "work-session use <ID>")
-	assert.Contains(t, joined, "--requester-type agent")
-	assert.Contains(t, joined, "ALPACON_WORK_SESSION")
-}
-
 func TestHandleWorkSessionError_NoOp(t *testing.T) {
 	// Non-WorkSession errors must not trigger any exit — just return.
 	// If HandleWorkSessionError calls os.Exit for this error, the test process dies.

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -37,7 +37,7 @@ func TestBuildWorkSessionDiagnostic(t *testing.T) {
 		reuseVsCreate bool // distinguishes reuse (use) vs create-and-attach paths
 	}{
 		{WorkSessionRequired, "no WorkSession selected", "work-session ls", true, true},
-		{WorkSessionNotActive, "not yet active", "work-session current", false, false},
+		{WorkSessionNotActive, "not active", "work-session current", true, true},
 		{WorkSessionExpired, "has expired", "work-session extend", true, false},
 		{WorkSessionScopeNotAllowed, "does not include this scope", "work-session create", true, false},
 		{WorkSessionServerNotAllowed, "target server is not in this session", "work-session create", true, false},
@@ -139,6 +139,18 @@ func TestWorkSessionNextActions_IncludesAgentPath(t *testing.T) {
 			assert.Contains(t, joined, "ALPACON_WORK_SESSION")
 		})
 	}
+}
+
+func TestWorkSessionNextActions_NotActiveGuidesWaitOrCreate(t *testing.T) {
+	// Activation is approval/server-driven, not user-run; guide toward an active session:
+	// pending → wait, completed/revoked → create or reuse (human and agent paths alike).
+	joined := strings.Join(workSessionNextActions(WorkSessionNotActive, "command", "srv-1", ""), "\n")
+	assert.Contains(t, joined, "work-session current")
+	assert.NotContains(t, joined, "work-session activate")
+	assert.Contains(t, joined, "wait")
+	assert.Contains(t, joined, "work-session use <ID>")
+	assert.Contains(t, joined, "--requester-type agent")
+	assert.Contains(t, joined, "ALPACON_WORK_SESSION")
 }
 
 func TestHandleWorkSessionError_NoOp(t *testing.T) {


### PR DESCRIPTION
## Background

Closes #240, #242

Three gaps in the WorkSession gate-denial remediation emitted by `workSessionNextActions()` (`utils/worksession_error.go`):

1. The `next_actions` only guided the human `--use` path. This JSON output is meant for scripts and AI agents to branch on (README.md:247), but agent sessions are not workspace-attachable, so an agent following `--use` is rejected or works around it and creates a `user` session, leaving the work unrecorded as agent-driven. The proactive guidance (`work-session create` help recommends `--requester-type agent`) and the reactive gate remediation contradicted each other.

2. `work_session_not_active` was reported as "selected session is not yet active" with a single `work-session current` next step. That code covers completed and revoked sessions too, not only pending ones, so the wording was inaccurate and the remediation gave no way forward for terminal sessions.

3. `work_session_assignee_mismatch` returned only `work-session use <ID>`. Same class of problem as gap 1: the session is assigned to another principal, and an agent can't attach one via `use`, so an agent hitting this gate got guidance it couldn't act on.

## Changes

- Reworked the `createOrReuse` branch (`work_session_required`, `work_session_not_usable`) to lead with reuse and fall back to create, for human and agent alike: `ls --status active` to find an active session, `use <ID>` for humans, then `create --use` (human) or `create --requester-type agent` (agent). Agent sessions can't attach via `--use`, so the guidance notes prefixing the gated command with `--work-session <ID>`.
- Broadened the `work_session_not_active` reason to "selected session is not active" and routed it through the same `createOrReuse` list, prefixed with `work-session current` and conditional guidance (pending/approved: wait until active; completed/revoked: create or reuse).
- Routed `work_session_assignee_mismatch` through the same `createOrReuse` list instead of the human-only `use <ID>`, so it now offers the reuse and create paths for both principals, consistent with the other gate codes.

The CLI can't auto-detect human vs AI (the User-Agent header carries no actor distinction), so both paths are exposed and the caller picks the right one. The plain-text diagnostic and the JSON envelope both go through this function, so one change covers both outputs.

## Output example

`work_session_not_active` gate denial now emits:

    reason: selected session is not active
    Next:
      alpacon work-session current  # pending/approved: wait until active; completed/revoked: create or reuse below
      alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>
      alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)
      alpacon work-session create --scope command --server web-01 --expires-in 1h --purpose "<intent>" --use  # none active? create a new one (human)
      alpacon work-session create --scope command --server web-01 --expires-in 1h --purpose "<intent>" --requester-type agent  # none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)

## Tests

Updated `TestBuildWorkSessionDiagnostic` to cover the `not_active` reason wording and to assert that both the reuse and create paths appear in the remediation, including for `work_session_assignee_mismatch`. `go test -race ./utils/` passes, `go vet` clean.

## Follow-up

`next_actions` still packs a shell-style `# ...` hint into each command string, so a machine consumer that execs an entry must strip the comment. Restructuring `next_actions` into a `{command, description}` shape is tracked separately and kept out of this PR.
