### PR TITLE
Add editable fields to work-session update (#239)

### DIFF
--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -54,10 +54,11 @@ type WorkSessionCreateRequest struct {
 // server binds the policy to the session assignee automatically so it never
 // applies to other workspace users.
 //
-// ID is set only on read and on modify: an update PATCH sends the FULL desired
-// set, so existing policies must be echoed back with their ID (modify in place)
-// alongside new entries without an ID (additions). Omitting an existing policy
-// from the set deletes it, so callers must preserve the current entries.
+// ID is set only on read and on modify: the sudo_policies field of an update
+// PATCH is the FULL desired set, so existing policies must be echoed back with
+// their ID (modify in place) alongside new entries without an ID (additions).
+// Omitting an existing policy from the set deletes it, so callers must preserve
+// the current entries.
 type SudoPolicyInline struct {
 	ID             string   `json:"id,omitempty"`
 	Commands       []string `json:"commands"`
@@ -65,18 +66,15 @@ type SudoPolicyInline struct {
 	AllowBypassMFA bool     `json:"allow_bypass_mfa"`
 }
 
-// WorkSessionUpdateRequest carries the FULL desired sudo policy set (PUT-style):
-// the server deletes any existing policy absent from the list. Callers that
-// only mean to add must echo the existing policies back.
-//
-// Note on Go JSON encoding: a nil slice marshals to JSON `null` (treated by
-// the server as "field not provided" → no change). To explicitly clear all
-// policies, pass an explicitly empty slice (`[]SudoPolicyInline{}`), which
-// marshals to `[]`. The current CLI never sends nil here because the update
-// command guards `len(newPolicies) == 0` upstream and always builds the
-// desired slice via `make(...)`.
+// Partial update (omitempty leaves unset fields untouched); SudoPolicies is PUT-style — echo existing back or they're deleted.
 type WorkSessionUpdateRequest struct {
-	SudoPolicies []SudoPolicyInline `json:"sudo_policies"`
+	Title        string             `json:"title,omitempty"`
+	Description  string             `json:"description,omitempty"`
+	Scopes       []string           `json:"scopes,omitempty"`
+	Servers      []string           `json:"servers,omitempty"`
+	StartsAt     string             `json:"starts_at,omitempty"`
+	ExpiresAt    string             `json:"expires_at,omitempty"`
+	SudoPolicies []SudoPolicyInline `json:"sudo_policies,omitempty"`
 }
 
 type WorkSessionExtendRequest struct {

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -66,7 +66,7 @@ type SudoPolicyInline struct {
 	AllowBypassMFA bool     `json:"allow_bypass_mfa"`
 }
 
-// Partial update (omitempty leaves unset fields untouched); SudoPolicies is PUT-style — echo existing back or they're deleted.
+// Partial update (omitempty leaves unset fields untouched); SudoPolicies is PUT-style — echo existing back or they're deleted ([] is omitted too, so it can't clear them).
 type WorkSessionUpdateRequest struct {
 	Title        string             `json:"title,omitempty"`
 	Description  string             `json:"description,omitempty"`

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -8,6 +8,7 @@ import (
 
 type WorkSession struct {
 	ID                string                `json:"id"`
+	Title             string                `json:"title"`
 	Description       string                `json:"description"`
 	Status            string                `json:"status"`
 	RequesterType     string                `json:"requester_type"`
@@ -16,6 +17,7 @@ type WorkSession struct {
 	CreatedBy         *types.UserSummary    `json:"created_by"`
 	AssignedUser      *types.UserSummary    `json:"assigned_user"`
 	ApprovalRequestID string                `json:"approval_request_id"`
+	StartsAt          *time.Time            `json:"starts_at"`
 	ExpiresAt         time.Time             `json:"expires_at"`
 	StartedAt         *time.Time            `json:"started_at"`
 	CompletedAt       *time.Time            `json:"completed_at"`

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -68,7 +68,10 @@ type SudoPolicyInline struct {
 	AllowBypassMFA bool     `json:"allow_bypass_mfa"`
 }
 
-// Partial update (omitempty leaves unset fields untouched); SudoPolicies is PUT-style — echo existing back or they're deleted ([] is omitted too, so it can't clear them).
+// WorkSessionUpdateRequest is a partial update: omitempty leaves unset fields
+// untouched. SudoPolicies is PUT-style — the server replaces the whole set, so
+// existing policies must be echoed back or they are deleted. An empty slice is
+// also omitted (omitempty), so this request cannot clear policies.
 type WorkSessionUpdateRequest struct {
 	Title        string             `json:"title,omitempty"`
 	Description  string             `json:"description,omitempty"`

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -159,14 +159,15 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 	},
 }
 
-func validateSessionForSudoUpdate(session *wsapi.WorkSession) error {
+// scopes is the effective scope list: req.Scopes when --scope replaces the list, else the session's current scopes.
+func validateSessionForSudoUpdate(session *wsapi.WorkSession, scopes []string) error {
 	if session.Status == pendingWorkSessionStatus {
 		return fmt.Errorf(
 			"work session %s is pending approval; sudo policies cannot be modified yet. Set them at create time with --sudo, or wait until it is approved",
 			session.ID,
 		)
 	}
-	if !slices.Contains(session.Scopes, "sudo") {
+	if !slices.Contains(scopes, "sudo") {
 		return fmt.Errorf(
 			"work session %s does not include the 'sudo' scope; sudo policies cannot be added. Create a new session with --sudo (it adds the 'sudo' scope automatically)",
 			session.ID,
@@ -182,7 +183,11 @@ func applyWorkSessionUpdate(ac *client.AlpaconClient, sessionID string, req wsap
 		if err != nil {
 			return nil, fmt.Errorf("failed to load work session %s: %w", sessionID, err)
 		}
-		if err := validateSessionForSudoUpdate(session); err != nil {
+		effectiveScopes := session.Scopes
+		if len(req.Scopes) > 0 {
+			effectiveScopes = req.Scopes
+		}
+		if err := validateSessionForSudoUpdate(session, effectiveScopes); err != nil {
 			return nil, err
 		}
 		desired := make([]wsapi.SudoPolicyInline, 0, len(session.SudoPolicies)+len(newSudo))

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -99,6 +99,9 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 			req.ExpiresAt = val
 			changed++
 		}
+		if cmd.Flags().Changed("server") {
+			changed++ // resolved below once the client exists
+		}
 		if cmd.Flags().Changed("sudo") {
 			newSudo = buildSudoPolicies(updateSudo, updateSudoReason)
 			changed++

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -35,7 +35,7 @@ Only the flags you pass are changed; the rest are left untouched. Which fields
 the server accepts depends on the session status (e.g. --starts-at/--expires-at
 on a pending session; --sudo on an approved/active one). The CLI sends what you
 provide and surfaces the server's validation error if a field isn't editable for
-the current status.
+the current status (--sudo is also validated locally before the request).
 
 --scope and --server replace the whole list (not append). --sudo adds MFA-bypass
 sudo command patterns to the session's existing policies; this is the recovery
@@ -68,17 +68,19 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 		var newSudo []wsapi.SudoPolicyInline
 		changed := 0
 		if cmd.Flags().Changed("title") {
-			if strings.TrimSpace(updateTitle) == "" {
+			title := strings.TrimSpace(updateTitle)
+			if title == "" {
 				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--title cannot be empty.")
 			}
-			req.Title = updateTitle
+			req.Title = title
 			changed++
 		}
 		if cmd.Flags().Changed("description") {
-			if strings.TrimSpace(updateDescription) == "" {
+			description := strings.TrimSpace(updateDescription)
+			if description == "" {
 				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--description cannot be empty.")
 			}
-			req.Description = updateDescription
+			req.Description = description
 			changed++
 		}
 		if cmd.Flags().Changed("scope") {

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -27,7 +27,7 @@ var (
 )
 
 var workSessionUpdateCmd = &cobra.Command{
-	Use:   "update [SESSION_ID] [flags]",
+	Use:   "update [SESSION_ID]",
 	Short: "Update an existing work session",
 	Long: `Update fields of an existing work session.
 

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -68,15 +68,24 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 		var newSudo []wsapi.SudoPolicyInline
 		changed := 0
 		if cmd.Flags().Changed("title") {
+			if strings.TrimSpace(updateTitle) == "" {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--title cannot be empty.")
+			}
 			req.Title = updateTitle
 			changed++
 		}
 		if cmd.Flags().Changed("description") {
+			if strings.TrimSpace(updateDescription) == "" {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--description cannot be empty.")
+			}
 			req.Description = updateDescription
 			changed++
 		}
 		if cmd.Flags().Changed("scope") {
 			scopes := utils.CompactStrings(updateScopes)
+			if len(scopes) == 0 {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--scope must contain at least one scope.")
+			}
 			if err := validateScopeEnum(scopes); err != nil {
 				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "Invalid --scope: %s", err)
 			}
@@ -104,6 +113,9 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 		}
 		if cmd.Flags().Changed("sudo") {
 			newSudo = buildSudoPolicies(updateSudo, updateSudoReason)
+			if len(newSudo) == 0 {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--sudo must contain at least one command pattern.")
+			}
 			changed++
 		}
 

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -169,7 +169,7 @@ func validateSessionForSudoUpdate(session *wsapi.WorkSession, scopes []string) e
 	}
 	if !slices.Contains(scopes, "sudo") {
 		return fmt.Errorf(
-			"work session %s does not include the 'sudo' scope; sudo policies cannot be added. Add it with --scope (e.g. --scope sudo) in this same update, or create a new session with --sudo (which adds the 'sudo' scope automatically)",
+			"work session %s does not include the 'sudo' scope; sudo policies cannot be added. Include 'sudo' in the scope list via --scope in this same update (note --scope replaces the whole list, so list every scope you want to keep), or create a new session with --sudo (which adds the 'sudo' scope automatically)",
 			session.ID,
 		)
 	}

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -37,7 +37,7 @@ on a pending session; --sudo on an approved/active one). The CLI sends what you
 provide and surfaces the server's validation error if a field isn't editable for
 the current status.
 
---scope and --server REPLACE the whole list (not append). --sudo adds MFA-bypass
+--scope and --server replace the whole list (not append). --sudo adds MFA-bypass
 sudo command patterns to the session's existing policies; this is the recovery
 path when an 'exec' sudo was denied. The additions may require approval before
 they take effect.
@@ -202,8 +202,8 @@ func parseRFC3339Flag(flag, val string) (string, error) {
 func init() {
 	workSessionUpdateCmd.Flags().StringVar(&updateTitle, "title", "", "New session title")
 	workSessionUpdateCmd.Flags().StringVar(&updateDescription, "description", "", "New session description (markdown supported)")
-	workSessionUpdateCmd.Flags().StringSliceVar(&updateScopes, "scope", nil, "Replace the session scopes. Valid: command, editor, sudo, tunnel, webftp, websh (repeatable; comma-separated values also accepted; REPLACES the whole list)")
-	workSessionUpdateCmd.Flags().StringSliceVar(&updateServers, "server", nil, "Replace the target servers by name (repeatable; comma-separated values also accepted; REPLACES the whole list)")
+	workSessionUpdateCmd.Flags().StringSliceVar(&updateScopes, "scope", nil, "Replace the session scopes. Valid: command, editor, sudo, tunnel, webftp, websh (repeatable; comma-separated values also accepted; replaces the whole list)")
+	workSessionUpdateCmd.Flags().StringSliceVar(&updateServers, "server", nil, "Replace the target servers by name (repeatable; comma-separated values also accepted; replaces the whole list)")
 	workSessionUpdateCmd.Flags().StringVar(&updateStartsAt, "starts-at", "", "New scheduled start time (RFC3339; pending sessions only)")
 	workSessionUpdateCmd.Flags().StringVar(&updateExpiresAt, "expires-at", "", "New absolute expiry time (RFC3339; pending sessions only — use 'extend' for approved/active sessions)")
 	workSessionUpdateCmd.Flags().StringArrayVar(&updateSudo, "sudo", nil, "Sudo command patterns to add as MFA-bypass policies (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed)")

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -110,8 +110,13 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 			req.ExpiresAt = val
 			changed++
 		}
+		var serverNames []string
 		if cmd.Flags().Changed("server") {
-			changed++ // resolved below once the client exists
+			serverNames = utils.CompactStrings(updateServers)
+			if len(serverNames) == 0 {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--server must contain at least one valid server name.")
+			}
+			changed++ // names resolved to IDs below once the client exists
 		}
 		if cmd.Flags().Changed("sudo") {
 			newSudo = buildSudoPolicies(updateSudo, updateSudoReason)
@@ -119,6 +124,8 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--sudo must contain at least one command pattern.")
 			}
 			changed++
+		} else if cmd.Flags().Changed("sudo-reason") {
+			utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--sudo-reason has no effect without --sudo.")
 		}
 
 		if changed == 0 {
@@ -130,12 +137,8 @@ ALPACON_WORK_SESSION environment variable, then the workspace's active session
 			utils.CliErrorEnvelopeWithExit(opUpdate, err, "Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		if cmd.Flags().Changed("server") {
-			names := utils.CompactStrings(updateServers)
-			if len(names) == 0 {
-				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--server must contain at least one valid server name.")
-			}
-			ids, err := server.ResolveServerNames(ac, names)
+		if len(serverNames) > 0 {
+			ids, err := server.ResolveServerNames(ac, serverNames)
 			if err != nil {
 				utils.CliErrorEnvelopeWithExit(opUpdate, err, "%s.", err)
 			}

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -3,7 +3,10 @@ package worksession
 import (
 	"fmt"
 	"slices"
+	"strings"
+	"time"
 
+	"github.com/alpacax/alpacon-cli/api/server"
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
@@ -12,9 +15,133 @@ import (
 
 const pendingWorkSessionStatus = "pending"
 
-// validateSessionForSudoUpdate checks the preconditions for adding sudo
-// policies to an existing work session. It is extracted from the command Run
-// so the guard logic can be unit-tested without driving the cobra/HTTP stack.
+var (
+	updateTitle       string
+	updateDescription string
+	updateScopes      []string
+	updateServers     []string
+	updateStartsAt    string
+	updateExpiresAt   string
+	updateSudo        []string
+	updateSudoReason  string
+)
+
+var workSessionUpdateCmd = &cobra.Command{
+	Use:   "update [SESSION_ID] [flags]",
+	Short: "Update an existing work session",
+	Long: `Update fields of an existing work session.
+
+Only the flags you pass are changed; the rest are left untouched. Which fields
+the server accepts depends on the session status (e.g. --starts-at/--expires-at
+on a pending session; --sudo on an approved/active one). The CLI sends what you
+provide and surfaces the server's validation error if a field isn't editable for
+the current status.
+
+--scope and --server REPLACE the whole list (not append). --sudo adds MFA-bypass
+sudo command patterns to the session's existing policies; this is the recovery
+path when an 'exec' sudo was denied. The additions may require approval before
+they take effect.
+
+If SESSION_ID is omitted, the effective work session is resolved from the
+ALPACON_WORK_SESSION environment variable, then the workspace's active session
+(set via 'alpacon work-session use').`,
+	Args: cobra.MaximumNArgs(1),
+	Example: `  alpacon work-session update ses-abc123 --title "deploy v2" --description "rollout"
+  alpacon work-session update ses-abc123 --server web-01,db-01
+  alpacon work-session update ses-abc123 --scope command,websh
+  alpacon work-session update ses-abc123 --starts-at 2027-01-15T10:00:00Z --expires-at 2027-01-15T12:00:00Z
+  alpacon work-session update ses-abc123 --sudo "systemctl restart nginx"
+  alpacon work-session update --sudo "tail -f /var/log/nginx/*.log"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var sessionID string
+		if len(args) == 1 {
+			sessionID = args[0]
+		} else {
+			resolved, err := Resolve("")
+			if err != nil || resolved == "" {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "No SESSION_ID given and no active work session. Pass an ID, set ALPACON_WORK_SESSION, or run 'alpacon work-session use <id>' first.")
+			}
+			sessionID = resolved
+		}
+
+		var req wsapi.WorkSessionUpdateRequest
+		var newSudo []wsapi.SudoPolicyInline
+		changed := 0
+		if cmd.Flags().Changed("title") {
+			req.Title = updateTitle
+			changed++
+		}
+		if cmd.Flags().Changed("description") {
+			req.Description = updateDescription
+			changed++
+		}
+		if cmd.Flags().Changed("scope") {
+			scopes := utils.CompactStrings(updateScopes)
+			if err := validateScopeEnum(scopes); err != nil {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "Invalid --scope: %s", err)
+			}
+			req.Scopes = scopes
+			changed++
+		}
+		if cmd.Flags().Changed("starts-at") {
+			val, err := parseRFC3339Flag("--starts-at", updateStartsAt)
+			if err != nil {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "%s.", err)
+			}
+			req.StartsAt = val
+			changed++
+		}
+		if cmd.Flags().Changed("expires-at") {
+			val, err := parseRFC3339Flag("--expires-at", updateExpiresAt)
+			if err != nil {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "%s.", err)
+			}
+			req.ExpiresAt = val
+			changed++
+		}
+		if cmd.Flags().Changed("sudo") {
+			newSudo = buildSudoPolicies(updateSudo, updateSudoReason)
+			changed++
+		}
+
+		if changed == 0 {
+			utils.CliUsageErrorEnvelopeWithExit(opUpdate, "Nothing to update. Pass at least one of --title, --description, --scope, --server, --starts-at, --expires-at, or --sudo.")
+		}
+
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorEnvelopeWithExit(opUpdate, err, "Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if cmd.Flags().Changed("server") {
+			names := utils.CompactStrings(updateServers)
+			if len(names) == 0 {
+				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "--server must contain at least one valid server name.")
+			}
+			ids, err := server.ResolveServerNames(ac, names)
+			if err != nil {
+				utils.CliErrorEnvelopeWithExit(opUpdate, err, "%s.", err)
+			}
+			req.Servers = ids
+		}
+
+		updated, err := applyWorkSessionUpdate(ac, sessionID, req, newSudo)
+		if err != nil {
+			utils.CliErrorEnvelopeWithExit(opUpdate, err, "%s.", err)
+		}
+
+		message := fmt.Sprintf("Work session %s updated (status: %s).", updated.ID, updated.Status)
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			printWorkSessionMutationJSON(newWorkSessionMutationOutput(opUpdate, message, updated, nil))
+			return
+		}
+		utils.CliSuccess("%s", message)
+		if len(newSudo) > 0 {
+			utils.CliInfo("Added sudo policies may require approval before they take effect. Re-run your command once the session reflects the change.")
+		}
+	},
+}
+
 func validateSessionForSudoUpdate(session *wsapi.WorkSession) error {
 	if session.Status == pendingWorkSessionStatus {
 		return fmt.Errorf(
@@ -31,85 +158,39 @@ func validateSessionForSudoUpdate(session *wsapi.WorkSession) error {
 	return nil
 }
 
-// attachSudoPoliciesToSession is the testable core of the update command Run:
-// load the current session, validate it can accept sudo policy changes, then
-// PATCH the full desired set (existing policies echoed back by ID + new
-// additions). The modify endpoint is PUT-style — any policy absent from the
-// request is deleted — so the echo-existing step is the regression bait this
-// helper exists to lock down.
-func attachSudoPoliciesToSession(
-	ac *client.AlpaconClient,
-	sessionID string,
-	newPolicies []wsapi.SudoPolicyInline,
-) (*wsapi.WorkSession, error) {
-	session, err := wsapi.GetWorkSession(ac, sessionID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load work session %s: %w", sessionID, err)
+// sudo_policies is PUT-style: echo existing policies back so adding doesn't delete them.
+func applyWorkSessionUpdate(ac *client.AlpaconClient, sessionID string, req wsapi.WorkSessionUpdateRequest, newSudo []wsapi.SudoPolicyInline) (*wsapi.WorkSession, error) {
+	if len(newSudo) > 0 {
+		session, err := wsapi.GetWorkSession(ac, sessionID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load work session %s: %w", sessionID, err)
+		}
+		if err := validateSessionForSudoUpdate(session); err != nil {
+			return nil, err
+		}
+		desired := make([]wsapi.SudoPolicyInline, 0, len(session.SudoPolicies)+len(newSudo))
+		desired = append(desired, session.SudoPolicies...)
+		desired = append(desired, newSudo...)
+		req.SudoPolicies = desired
 	}
-	if err := validateSessionForSudoUpdate(session); err != nil {
-		return nil, err
-	}
-	desired := make([]wsapi.SudoPolicyInline, 0, len(session.SudoPolicies)+len(newPolicies))
-	desired = append(desired, session.SudoPolicies...)
-	desired = append(desired, newPolicies...)
-	return wsapi.UpdateWorkSession(ac, sessionID, wsapi.WorkSessionUpdateRequest{SudoPolicies: desired})
+	return wsapi.UpdateWorkSession(ac, sessionID, req)
 }
 
-var (
-	updateSudo       []string
-	updateSudoReason string
-)
-
-var workSessionUpdateCmd = &cobra.Command{
-	Use:   "update [SESSION_ID]",
-	Short: "Update a work session (e.g. add sudo command patterns)",
-	Long: `Update an existing work session.
-
-Use --sudo to add MFA-bypass sudo command patterns to the session. This is the
-recovery path when an 'exec' sudo was denied: add the command and re-run.
-Each --sudo value is a comma-separated pattern list (wildcards allowed) forming one
-policy. The session's existing policies are preserved; the additions may require
-approval before they take effect.
-
-If SESSION_ID is omitted, the effective work session is resolved from the
-ALPACON_WORK_SESSION environment variable, then the workspace's active session
-(set via 'alpacon work-session use').`,
-	Args: cobra.MaximumNArgs(1),
-	Example: `  alpacon work-session update ses-abc123 --sudo "systemctl restart nginx"
-  alpacon work-session update --sudo "tail -f /var/log/nginx/*.log"`,
-	Run: func(cmd *cobra.Command, args []string) {
-		var sessionID string
-		if len(args) == 1 {
-			sessionID = args[0]
-		} else {
-			resolved, err := Resolve("")
-			if err != nil || resolved == "" {
-				utils.CliUsageErrorEnvelopeWithExit(opUpdate, "No SESSION_ID given and no active work session. Pass an ID, set ALPACON_WORK_SESSION, or run 'alpacon work-session use <id>' first.")
-			}
-			sessionID = resolved
-		}
-
-		newPolicies := buildSudoPolicies(updateSudo, updateSudoReason)
-		if len(newPolicies) == 0 {
-			utils.CliUsageErrorEnvelopeWithExit(opUpdate, "Nothing to update. Pass --sudo with at least one command pattern.")
-		}
-
-		ac, err := client.NewAlpaconAPIClient()
-		if err != nil {
-			utils.CliErrorEnvelopeWithExit(opUpdate, err, "Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		}
-
-		updated, err := attachSudoPoliciesToSession(ac, sessionID, newPolicies)
-		if err != nil {
-			utils.CliErrorEnvelopeWithExit(opUpdate, err, "%s.", err)
-		}
-
-		utils.CliSuccess("Work session %s updated (status: %s).", updated.ID, updated.Status)
-		utils.CliInfo("Added sudo policies may require approval before they take effect. Re-run your command once the session reflects the change.")
-	},
+func parseRFC3339Flag(flag, val string) (string, error) {
+	val = strings.TrimSpace(val)
+	if _, err := time.Parse(time.RFC3339, val); err != nil {
+		return "", fmt.Errorf("invalid %s value %q: must be RFC3339 format", flag, val)
+	}
+	return val, nil
 }
 
 func init() {
+	workSessionUpdateCmd.Flags().StringVar(&updateTitle, "title", "", "New session title")
+	workSessionUpdateCmd.Flags().StringVar(&updateDescription, "description", "", "New session description (markdown supported)")
+	workSessionUpdateCmd.Flags().StringSliceVar(&updateScopes, "scope", nil, "Replace the session scopes. Valid: command, editor, sudo, tunnel, webftp, websh (repeatable; comma-separated values also accepted; REPLACES the whole list)")
+	workSessionUpdateCmd.Flags().StringSliceVar(&updateServers, "server", nil, "Replace the target servers by name (repeatable; comma-separated values also accepted; REPLACES the whole list)")
+	workSessionUpdateCmd.Flags().StringVar(&updateStartsAt, "starts-at", "", "New scheduled start time (RFC3339; pending sessions only)")
+	workSessionUpdateCmd.Flags().StringVar(&updateExpiresAt, "expires-at", "", "New absolute expiry time (RFC3339; pending sessions only — use 'extend' for approved/active sessions)")
 	workSessionUpdateCmd.Flags().StringArrayVar(&updateSudo, "sudo", nil, "Sudo command patterns to add as MFA-bypass policies (repeatable; each value is a comma-separated pattern list forming one policy, wildcards allowed)")
 	workSessionUpdateCmd.Flags().StringVar(&updateSudoReason, "sudo-reason", "", "Justification applied to the sudo policies added via --sudo")
 }

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -169,7 +169,7 @@ func validateSessionForSudoUpdate(session *wsapi.WorkSession, scopes []string) e
 	}
 	if !slices.Contains(scopes, "sudo") {
 		return fmt.Errorf(
-			"work session %s does not include the 'sudo' scope; sudo policies cannot be added. Create a new session with --sudo (it adds the 'sudo' scope automatically)",
+			"work session %s does not include the 'sudo' scope; sudo policies cannot be added. Add it with --scope (e.g. --scope sudo) in this same update, or create a new session with --sudo (which adds the 'sudo' scope automatically)",
 			session.ID,
 		)
 	}

--- a/cmd/worksession/worksession_update_test.go
+++ b/cmd/worksession/worksession_update_test.go
@@ -14,11 +14,12 @@ import (
 
 func TestValidateSessionForSudoUpdate(t *testing.T) {
 	t.Run("pending session is rejected with actionable message", func(t *testing.T) {
-		err := validateSessionForSudoUpdate(&wsapi.WorkSession{
+		session := &wsapi.WorkSession{
 			ID:     "ses-pending",
 			Status: pendingWorkSessionStatus,
 			Scopes: []string{"command", "sudo"},
-		})
+		}
+		err := validateSessionForSudoUpdate(session, session.Scopes)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "ses-pending")
 		assert.Contains(t, err.Error(), "pending")
@@ -26,11 +27,12 @@ func TestValidateSessionForSudoUpdate(t *testing.T) {
 	})
 
 	t.Run("missing sudo scope is rejected with guidance", func(t *testing.T) {
-		err := validateSessionForSudoUpdate(&wsapi.WorkSession{
+		session := &wsapi.WorkSession{
 			ID:     "ses-no-sudo",
 			Status: "active",
 			Scopes: []string{"command"},
-		})
+		}
+		err := validateSessionForSudoUpdate(session, session.Scopes)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "ses-no-sudo")
 		assert.Contains(t, err.Error(), "'sudo' scope")
@@ -40,19 +42,31 @@ func TestValidateSessionForSudoUpdate(t *testing.T) {
 	})
 
 	t.Run("active session with sudo scope passes", func(t *testing.T) {
-		assert.NoError(t, validateSessionForSudoUpdate(&wsapi.WorkSession{
+		session := &wsapi.WorkSession{
 			ID:     "ses-ok",
 			Status: "active",
 			Scopes: []string{"command", "sudo"},
-		}))
+		}
+		assert.NoError(t, validateSessionForSudoUpdate(session, session.Scopes))
 	})
 
 	t.Run("approved session with sudo scope passes (pre-active is allowed)", func(t *testing.T) {
-		assert.NoError(t, validateSessionForSudoUpdate(&wsapi.WorkSession{
+		session := &wsapi.WorkSession{
 			ID:     "ses-approved",
 			Status: "approved",
 			Scopes: []string{"sudo"},
-		}))
+		}
+		assert.NoError(t, validateSessionForSudoUpdate(session, session.Scopes))
+	})
+
+	t.Run("sudo scope added via --scope in the same update passes", func(t *testing.T) {
+		session := &wsapi.WorkSession{
+			ID:     "ses-add-scope",
+			Status: "active",
+			Scopes: []string{"command"},
+		}
+		// req.Scopes replaces the list and adds 'sudo', so the effective scopes include it.
+		assert.NoError(t, validateSessionForSudoUpdate(session, []string{"command", "sudo"}))
 	})
 }
 

--- a/cmd/worksession/worksession_update_test.go
+++ b/cmd/worksession/worksession_update_test.go
@@ -56,10 +56,7 @@ func TestValidateSessionForSudoUpdate(t *testing.T) {
 	})
 }
 
-// TestAttachSudoPoliciesToSession_PreservesExistingPolicies locks down the
-// "don't drop existing policies" invariant of the modify endpoint: a future
-// refactor that forgets to echo the current set back would silently delete it.
-func TestAttachSudoPoliciesToSession_PreservesExistingPolicies(t *testing.T) {
+func TestApplyWorkSessionUpdate_PreservesExistingSudoPolicies(t *testing.T) {
 	var gotPATCH wsapi.WorkSessionUpdateRequest
 	patchCalled := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -87,23 +84,18 @@ func TestAttachSudoPoliciesToSession_PreservesExistingPolicies(t *testing.T) {
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	newPolicies := []wsapi.SudoPolicyInline{
+	_, err := applyWorkSessionUpdate(ac, "ses-1", wsapi.WorkSessionUpdateRequest{}, []wsapi.SudoPolicyInline{
 		{Commands: []string{"systemctl reload nginx"}, AllowBypassMFA: true},
-	}
-	_, err := attachSudoPoliciesToSession(ac, "ses-1", newPolicies)
+	})
 	assert.NoError(t, err)
 	assert.True(t, patchCalled, "PATCH must be issued")
-	// Full desired set is sent: existing policy echoed back with its ID + the new addition without one.
 	assert.Len(t, gotPATCH.SudoPolicies, 2)
 	assert.Equal(t, "pol-old", gotPATCH.SudoPolicies[0].ID)
 	assert.Empty(t, gotPATCH.SudoPolicies[1].ID)
 	assert.Equal(t, []string{"systemctl reload nginx"}, gotPATCH.SudoPolicies[1].Commands)
 }
 
-// TestAttachSudoPoliciesToSession_PendingSessionAbortsBeforePATCH ensures the
-// validator runs in the wiring path: a pending session must error out without
-// issuing the PATCH so the server doesn't even see the request.
-func TestAttachSudoPoliciesToSession_PendingSessionAbortsBeforePATCH(t *testing.T) {
+func TestApplyWorkSessionUpdate_PendingSessionAbortsBeforePATCH(t *testing.T) {
 	patchCalled := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
@@ -120,9 +112,83 @@ func TestAttachSudoPoliciesToSession_PendingSessionAbortsBeforePATCH(t *testing.
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	_, err := attachSudoPoliciesToSession(ac, "ses-pending", []wsapi.SudoPolicyInline{
-		{Commands: []string{"x"}, AllowBypassMFA: true},
-	})
+	_, err := applyWorkSessionUpdate(ac, "ses-pending", wsapi.WorkSessionUpdateRequest{},
+		[]wsapi.SudoPolicyInline{{Commands: []string{"x"}, AllowBypassMFA: true}})
 	assert.Error(t, err)
 	assert.False(t, patchCalled, "PATCH must not be issued when the validator rejects")
+}
+
+func TestApplyWorkSessionUpdate_FieldsOnlySkipsGet(t *testing.T) {
+	var raw map[string]any
+	getCalled, patchCalled := false, false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getCalled = true
+		case http.MethodPatch:
+			patchCalled = true
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&raw))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(wsapi.WorkSession{ID: "ses-1", Status: "pending"})
+		default:
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := applyWorkSessionUpdate(ac, "ses-1", wsapi.WorkSessionUpdateRequest{
+		Title:    "deploy v2",
+		Servers:  []string{"srv-1", "srv-2"},
+		StartsAt: "2027-01-15T10:00:00Z",
+	}, nil)
+	assert.NoError(t, err)
+	assert.False(t, getCalled, "no GET should be issued when sudo is not touched")
+	assert.True(t, patchCalled)
+	assert.Equal(t, "deploy v2", raw["title"])
+	assert.Equal(t, []any{"srv-1", "srv-2"}, raw["servers"])
+	assert.Equal(t, "2027-01-15T10:00:00Z", raw["starts_at"])
+	_, hasDesc := raw["description"]
+	assert.False(t, hasDesc, "unset description must be omitted")
+	_, hasSudo := raw["sudo_policies"]
+	assert.False(t, hasSudo, "unset sudo_policies must be omitted so existing policies are kept")
+	_, hasScopes := raw["scopes"]
+	assert.False(t, hasScopes, "unset scopes must be omitted")
+}
+
+func TestApplyWorkSessionUpdate_SudoPlusFields(t *testing.T) {
+	var gotPATCH wsapi.WorkSessionUpdateRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(wsapi.WorkSession{
+				ID: "ses-1", Status: "active", Scopes: []string{"sudo"},
+			})
+		case http.MethodPatch:
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&gotPATCH))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(wsapi.WorkSession{ID: "ses-1", Status: "active"})
+		}
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := applyWorkSessionUpdate(ac, "ses-1",
+		wsapi.WorkSessionUpdateRequest{Description: "rollout"},
+		[]wsapi.SudoPolicyInline{{Commands: []string{"systemctl reload nginx"}, AllowBypassMFA: true}})
+	assert.NoError(t, err)
+	assert.Equal(t, "rollout", gotPATCH.Description)
+	assert.Len(t, gotPATCH.SudoPolicies, 1)
+}
+
+func TestParseRFC3339Flag(t *testing.T) {
+	v, err := parseRFC3339Flag("--starts-at", "  2027-01-15T10:00:00Z  ")
+	assert.NoError(t, err)
+	assert.Equal(t, "2027-01-15T10:00:00Z", v)
+
+	_, err = parseRFC3339Flag("--starts-at", "2027-01-15 10:00:00")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--starts-at")
+	assert.Contains(t, err.Error(), "RFC3339")
 }


### PR DESCRIPTION
## Overview
Extends `work-session update`—previously limited to `--sudo`—to edit the remaining fields supported by the server and web UI. Unspecified flags are not sent (partial update via `omitempty`).

## Changes
- New flags: `--title`, `--description`, `--scope` (repeatable, full replacement), `--server` (repeatable, full replacement), `--starts-at`, `--expires-at`
- Keeps existing `--sudo`/`--sudo-reason`
- `--server` resolves names to IDs via `server.ResolveServerNames` (same as create)
- `--output json` support (same `printWorkSessionMutationJSON` as create/extend)
- Adds `omitempty` to `WorkSessionUpdateRequest.SudoPolicies` so a non-sudo update doesn't wipe existing policies

## Design decisions
- **No status branching**—the server validates per status; the CLI sends what the user provides and surfaces the server's error as-is
- **Single PATCH**—a GET is issued only when `--sudo` is used, to echo existing policies back (PUT-style full replacement)
- `--starts-at`/`--expires-at` accept absolute RFC3339 only; relative values (`--expires-in`) remain owned by `extend`

## Bug fix
Fixed `--server` used alone being wrongly rejected with "Nothing to update." The `changed` counter was bumped only for the other flags, while server resolution runs after the `changed==0` guard—so a server-only update never reached the PATCH. Count it up front.

## Testing
- Unit tests: `applyWorkSessionUpdate` (sudo policy echo / pending abort / fields-only single PATCH / sudo+fields mix), `parseRFC3339Flag`, `validateSessionForSudoUpdate`
- Live verification (web-editor session):
  - `--description`/`--title`/`--scope`/`--server` PATCH succeeded; `--output json` correct
  - Validation paths (no args / invalid scope / invalid RFC3339 / unknown server) rejected appropriately
  - `--starts-at` on an active session → rejected by server, error surfaced as-is by the CLI
  - Unset fields preserved (omitempty)
- `go test -race` passes, `golangci-lint` 0 issues

Closes #239
