### PR TITLE
feat: integrate /api/auth/whoami/ for login verification and identity display

### DIFF
--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -23,7 +23,22 @@ const (
 	tokenURL       = "/api/auth/tokens/"
 	tokenScopesURL = "/api/auth/tokens/scopes/"
 	statusURL      = "/api/status/"
+	whoamiURL      = "/api/auth/whoami/"
 )
+
+// GetWhoami fetches the caller's identity; a 404 means the endpoint is absent (old server).
+func GetWhoami(ac *client.AlpaconClient) (*WhoamiResponse, error) {
+	body, err := ac.SendGetRequest(whoamiURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp WhoamiResponse
+	if err = json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
 
 func LoginAndSaveCredentials(loginReq *LoginRequest, token string, insecure bool) error {
 	httpClient := &http.Client{

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -37,6 +37,10 @@ func GetWhoami(ac *client.AlpaconClient) (*WhoamiResponse, error) {
 	if err = json.Unmarshal(body, &resp); err != nil {
 		return nil, err
 	}
+	// Fail closed: a 200 without a principal_type is a malformed identity response.
+	if resp.PrincipalType == "" {
+		return nil, errors.New("whoami response missing principal_type")
+	}
 	return &resp, nil
 }
 

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -477,3 +477,60 @@ func TestGetTokenScopes(t *testing.T) {
 		t.Errorf("expected empty ACL, got %q", scopes[2].ACL)
 	}
 }
+
+func TestGetWhoamiApplicationPrincipal(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != whoamiURL {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"principal_type": "application",
+			"auth": {"method": "service_token", "scopes": ["server:read", "command:create"]},
+			"application": {"id": "app-1", "name": "ci-runner", "service_type": "ci_cd", "username": "svc-ci"}
+		}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL, Token: "alpst-x"}
+	resp, err := GetWhoami(ac)
+	if err != nil {
+		t.Fatalf("GetWhoami returned error: %v", err)
+	}
+	if resp.PrincipalType != "application" {
+		t.Errorf("principal_type = %q, want application", resp.PrincipalType)
+	}
+	if len(resp.Auth.Scopes) != 2 || resp.Auth.Scopes[0] != "server:read" {
+		t.Errorf("auth.scopes = %v", resp.Auth.Scopes)
+	}
+	if resp.Application == nil {
+		t.Fatal("application block is nil")
+	}
+	if resp.Application.Name != "ci-runner" || resp.Application.ServiceType != "ci_cd" || resp.Application.Username != "svc-ci" {
+		t.Errorf("application = %+v", resp.Application)
+	}
+}
+
+func TestGetWhoamiUserPrincipal(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"principal_type": "user",
+			"auth": {"method": "jwt", "scopes": []},
+			"user": {"id": "u-1", "username": "alice", "email": "alice@example.com", "role": "superuser"}
+		}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL, Token: "t"}
+	resp, err := GetWhoami(ac)
+	if err != nil {
+		t.Fatalf("GetWhoami returned error: %v", err)
+	}
+	if resp.PrincipalType != "user" {
+		t.Errorf("principal_type = %q, want user", resp.PrincipalType)
+	}
+	if resp.Application != nil {
+		t.Errorf("application block should be nil for a user principal, got %+v", resp.Application)
+	}
+}

--- a/api/auth/auth_test.go
+++ b/api/auth/auth_test.go
@@ -534,3 +534,16 @@ func TestGetWhoamiUserPrincipal(t *testing.T) {
 		t.Errorf("application block should be nil for a user principal, got %+v", resp.Application)
 	}
 }
+
+func TestGetWhoamiEmptyPrincipalTypeFailsClosed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL, Token: "t"}
+	if _, err := GetWhoami(ac); err == nil {
+		t.Fatal("GetWhoami returned nil error for a response missing principal_type; want fail-closed error")
+	}
+}

--- a/api/auth/types.go
+++ b/api/auth/types.go
@@ -2,6 +2,9 @@ package auth
 
 import "time"
 
+// PrincipalTypeApplication is the whoami principal_type for service/application tokens.
+const PrincipalTypeApplication = "application"
+
 type LoginRequest struct {
 	WorkspaceURL  string `json:"workspace_url"`
 	Username      string `json:"username"`
@@ -59,4 +62,22 @@ type TokenScopeAttributes struct {
 	Name    string `json:"name" table:"Resource"`
 	Actions string `json:"actions" table:"Actions"`
 	ACL     string `json:"acl" table:"ACL"`
+}
+
+// WhoamiResponse is the GET /api/auth/whoami/ identity. Only the application
+// branch is consumed; user principals fall through to iam.GetCurrentUser.
+type WhoamiResponse struct {
+	PrincipalType string             `json:"principal_type"`
+	Auth          WhoamiAuth         `json:"auth"`
+	Application   *WhoamiApplication `json:"application,omitempty"`
+}
+
+type WhoamiAuth struct {
+	Scopes []string `json:"scopes"`
+}
+
+type WhoamiApplication struct {
+	Name        string `json:"name"`
+	ServiceType string `json:"service_type"`
+	Username    string `json:"username"` // service account name
 }

--- a/client/client.go
+++ b/client/client.go
@@ -30,6 +30,17 @@ type apiError struct {
 	statusCode int
 }
 
+// statusError carries an HTTP status on errors that aren't *apiError (e.g. an
+// HTML 404 page), so utils.HTTPStatusCode can still read it.
+type statusError struct {
+	err        error
+	statusCode int
+}
+
+func (e *statusError) Error() string      { return e.err.Error() }
+func (e *statusError) Unwrap() error       { return e.err }
+func (e *statusError) HTTPStatusCode() int { return e.statusCode }
+
 func NewAlpaconAPIClient() (*AlpaconClient, error) {
 	validConfig, err := config.LoadConfig()
 	if err != nil {
@@ -212,7 +223,7 @@ func readJSONResponse(resp *http.Response) ([]byte, error) {
 
 	// Empty content type is allowed for responses without content (e.g. PATCH).
 	if ct := resp.Header.Get("Content-Type"); ct != "" && !strings.Contains(ct, "application/json") {
-		return nil, fmt.Errorf("unexpected response from server (HTTP %d, Content-Type: %s)", resp.StatusCode, ct)
+		return nil, withStatus(fmt.Errorf("unexpected response from server (HTTP %d, Content-Type: %s)", resp.StatusCode, ct), resp.StatusCode)
 	}
 	return body, nil
 }
@@ -415,13 +426,18 @@ func newAPIError(message, code, source string) error {
 	return &apiError{message: message, code: code, source: source}
 }
 
-// withStatus tags an *apiError with its HTTP status so callers can tell 404 from 401.
+// withStatus tags err with its HTTP status so callers can tell 404 from 401,
+// wrapping non-*apiError errors so the status survives the error chain.
 func withStatus(err error, statusCode int) error {
+	if err == nil {
+		return nil
+	}
 	var ae *apiError
 	if errors.As(err, &ae) {
 		ae.statusCode = statusCode
+		return err
 	}
-	return err
+	return &statusError{err: err, statusCode: statusCode}
 }
 
 // parseAPIError extracts a human-readable error message from a JSON API error response.

--- a/client/client.go
+++ b/client/client.go
@@ -37,7 +37,7 @@ type statusError struct {
 	statusCode int
 }
 
-func (e *statusError) Error() string      { return e.err.Error() }
+func (e *statusError) Error() string       { return e.err.Error() }
 func (e *statusError) Unwrap() error       { return e.err }
 func (e *statusError) HTTPStatusCode() int { return e.statusCode }
 

--- a/client/client.go
+++ b/client/client.go
@@ -24,9 +24,10 @@ const (
 )
 
 type apiError struct {
-	message string
-	code    string
-	source  string
+	message    string
+	code       string
+	source     string
+	statusCode int
 }
 
 func NewAlpaconAPIClient() (*AlpaconClient, error) {
@@ -203,7 +204,7 @@ func (ac *AlpaconClient) createRequest(method, url string, body io.Reader) (*htt
 func readJSONResponse(resp *http.Response) ([]byte, error) {
 	body, readErr := io.ReadAll(resp.Body)
 	if err := checkAuthStatus(resp.StatusCode, body); err != nil {
-		return nil, err
+		return nil, withStatus(err, resp.StatusCode)
 	}
 	if readErr != nil {
 		return nil, readErr
@@ -229,7 +230,7 @@ func (ac *AlpaconClient) sendRequest(req *http.Request) ([]byte, error) {
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, parseAPIError(respBody)
+		return nil, withStatus(parseAPIError(respBody), resp.StatusCode)
 	}
 
 	return respBody, nil
@@ -310,7 +311,7 @@ func (ac *AlpaconClient) SendMultipartStreamRequest(url, contentType string, bod
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, parseAPIError(respBody)
+		return nil, withStatus(parseAPIError(respBody), resp.StatusCode)
 	}
 
 	return respBody, nil
@@ -406,18 +407,28 @@ func (e *apiError) ErrorSource() string {
 	return e.source
 }
 
+func (e *apiError) HTTPStatusCode() int {
+	return e.statusCode
+}
+
 func newAPIError(message, code, source string) error {
 	return &apiError{message: message, code: code, source: source}
+}
+
+// withStatus tags an *apiError with its HTTP status so callers can tell 404 from 401.
+func withStatus(err error, statusCode int) error {
+	var ae *apiError
+	if errors.As(err, &ae) {
+		ae.statusCode = statusCode
+	}
+	return err
 }
 
 // parseAPIError extracts a human-readable error message from a JSON API error response.
 // Handles common formats: {"detail": "..."}, {"field": ["error", ...]}, {"non_field_errors": ["..."]}
 func parseAPIError(body []byte) error {
-	message, code, source, ok := parseAPIErrorPayload(body)
-	if ok {
-		return newAPIError(message, code, source)
-	}
-	return errors.New(message)
+	message, code, source, _ := parseAPIErrorPayload(body)
+	return newAPIError(message, code, source)
 }
 
 func parseAPIErrorPayload(body []byte) (message string, code string, source string, ok bool) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -89,6 +89,22 @@ func TestSendRequest_404EmptyBodyExposesStatusCode(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, utils.HTTPStatusCode(err))
 }
 
+func TestSendRequest_404HTMLBodyExposesStatusCode(t *testing.T) {
+	// An old server/proxy without the endpoint may answer 404 with an HTML page;
+	// the status must still reach callers so the whoami legacy fallback triggers.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`<html><body>404 Not Found</body></html>`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusNotFound, utils.HTTPStatusCode(err))
+}
+
 func TestSendRequest_401ExposesStatusCode(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -60,6 +61,51 @@ func TestSendRequest_401EmptyJSONFallsBackToLoginHint(t *testing.T) {
 	_, err := ac.SendGetRequest("/api/test/")
 	assert.ErrorContains(t, err, "authentication failed")
 	assert.NotContains(t, err.Error(), "{}")
+}
+
+func TestSendRequest_404ExposesStatusCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail": "not found"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusNotFound, utils.HTTPStatusCode(err))
+}
+
+func TestSendRequest_404EmptyBodyExposesStatusCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusNotFound, utils.HTTPStatusCode(err))
+}
+
+func TestSendRequest_401ExposesStatusCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail": "invalid token"}`))
+	}))
+	defer ts.Close()
+
+	ac := newTestClient(ts.URL)
+	_, err := ac.SendGetRequest("/api/test/")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, utils.HTTPStatusCode(err))
+}
+
+func TestHTTPStatusCode_NonAPIErrorIsZero(t *testing.T) {
+	assert.Equal(t, 0, utils.HTTPStatusCode(errors.New("boom")))
+	assert.Equal(t, 0, utils.HTTPStatusCode(nil))
 }
 
 func TestSendRequest_403SurfacesServerDetail(t *testing.T) {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -17,7 +17,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultBaseDomain = "alpacon.io"
+const (
+	defaultBaseDomain = "alpacon.io"
+
+	// whoami verification outcomes (see classifyWhoamiVerification).
+	whoamiVerified = "verified"
+	whoamiFallback = "fallback"
+	whoamiFail     = "fail"
+)
 
 // knownCloudRegions are the Alpacon Cloud regions shown when --region is omitted.
 // Source: 10-alpacon-web constants.ts, 06-account settings.py. Update on release.
@@ -166,15 +173,17 @@ with the saved target as the default. Non-interactive login requires a HOST or
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
-		if config.IsServiceToken(token) {
-			// Service tokens are application principals with no user profile, so the
-			// preload would always 401. Skip it and report the credential directly.
-			utils.CliInfo("Authenticated with a service token. Service tokens are application principals and have no user profile, so user details are unavailable.")
-		} else if err := ac.LoadCurrentUser(); err != nil {
-			if shouldFailOnProfileError(token) {
-				utils.CliErrorWithExit("Login succeeded but failed to verify user profile: %s. Please try logging in again.", err)
+		who, whoErr := auth.GetWhoami(ac)
+		switch classifyWhoamiVerification(whoErr) {
+		case whoamiVerified:
+			if who.PrincipalType == auth.PrincipalTypeApplication && who.Application != nil {
+				utils.CliInfo("Authenticated as application '%s'.", who.Application.Name)
 			}
-			utils.CliInfo("Could not preload your user profile; continuing since the credential was verified.")
+		case whoamiFallback:
+			// Old server without whoami: fall back to legacy prefix-based verification.
+			verifyLoginLegacy(ac, token)
+		default:
+			utils.CliErrorWithExit("Login succeeded but failed to verify your credential: %s. Please try logging in again.", whoErr)
 		}
 
 		utils.CliSuccess("Login succeeded!")
@@ -479,6 +488,33 @@ func formatHostURL(host string) string {
 		}
 	}
 	return fmt.Sprintf("%s://%s", scheme, strings.TrimSuffix(host, "/"))
+}
+
+// classifyWhoamiVerification maps a whoami error to verified / fallback (404) /
+// fail (401 or any other error—never swallowed as a fallback).
+func classifyWhoamiVerification(whoErr error) string {
+	switch {
+	case whoErr == nil:
+		return whoamiVerified
+	case utils.HTTPStatusCode(whoErr) == http.StatusNotFound:
+		return whoamiFallback
+	default:
+		return whoamiFail
+	}
+}
+
+// verifyLoginLegacy is the pre-whoami verification used against servers without the whoami endpoint.
+func verifyLoginLegacy(ac *client.AlpaconClient, token string) {
+	if config.IsServiceToken(token) {
+		utils.CliInfo("Authenticated with a service token. Service tokens are application principals and have no user profile, so user details are unavailable.")
+		return
+	}
+	if err := ac.LoadCurrentUser(); err != nil {
+		if shouldFailOnProfileError(token) {
+			utils.CliErrorWithExit("Login succeeded but failed to verify user profile: %s. Please try logging in again.", err)
+		}
+		utils.CliInfo("Could not preload your user profile; continuing since the credential was verified.")
+	}
 }
 
 // shouldFailOnProfileError reports whether a failed user-profile load should abort

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
 	osexec "os/exec"
 	"path/filepath"
@@ -716,6 +717,19 @@ func TestValidateCloudFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+type stubStatusErr struct{ code int }
+
+func (e stubStatusErr) Error() string       { return "stub" }
+func (e stubStatusErr) HTTPStatusCode() int { return e.code }
+
+func TestClassifyWhoamiVerification(t *testing.T) {
+	assert.Equal(t, whoamiVerified, classifyWhoamiVerification(nil))
+	assert.Equal(t, whoamiFallback, classifyWhoamiVerification(stubStatusErr{code: http.StatusNotFound}))
+	// 401 must fail, never fall back, so an invalid token cannot slip through.
+	assert.Equal(t, whoamiFail, classifyWhoamiVerification(stubStatusErr{code: http.StatusUnauthorized}))
+	assert.Equal(t, whoamiFail, classifyWhoamiVerification(errors.New("network down")))
 }
 
 func TestShouldFailOnProfileError(t *testing.T) {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -16,66 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type activeWorkSessionSummary struct {
-	ID        string   `json:"id"`
-	Status    string   `json:"status"`
-	Scopes    []string `json:"scopes"`
-	Servers   []string `json:"servers"`
-	ExpiresAt string   `json:"expires_at,omitempty"`
-}
-
-type whoamiOutput struct {
-	Username           string                `json:"username,omitempty"`
-	Email              string                `json:"email,omitempty"`
-	Phone              string                `json:"phone,omitempty"`
-	WorkspaceName      string                `json:"workspace_name"`
-	WorkspaceURL       string                `json:"workspace_url"`
-	AuthMethod         string                `json:"auth_method"`
-	AuthClassification string                `json:"auth_classification"`
-	ExpiresAt          string                `json:"expires_at,omitempty"`
-	UID                int                   `json:"uid,omitempty"`
-	Shell              string                `json:"shell,omitempty"`
-	HomeDirectory      string                `json:"home_directory,omitempty"`
-	Role               string                `json:"role,omitempty"`
-	Groups             []iam.GroupMembership `json:"groups,omitempty"`
-	// Application-principal fields (service tokens). Empty for user principals.
-	PrincipalType       string   `json:"principal_type,omitempty"`
-	ApplicationName     string   `json:"application_name,omitempty"`
-	ServiceType         string   `json:"service_type,omitempty"`
-	ServiceAccount      string   `json:"service_account,omitempty"`
-	Scopes              []string `json:"scopes,omitempty"`
-	WorksessionRequired bool     `json:"work_session_required"`
-	// WorksessionRequiredForAccess and ActiveWorksessionCanonical are the
-	// machine-readable names. The legacy keys remain for compatibility.
-	WorksessionRequiredForAccess bool                      `json:"worksession_required_for_access"`
-	ActiveWorksession            *activeWorkSessionSummary `json:"active_work_session"`
-	ActiveWorksessionCanonical   *activeWorkSessionSummary `json:"active_worksession"`
-}
-
-func (o whoamiOutput) MarshalJSON() ([]byte, error) {
-	type wire whoamiOutput
-	normalized := o.normalized()
-	return json.Marshal(wire(normalized))
-}
-
-func (o whoamiOutput) normalized() whoamiOutput {
-	if o.AuthClassification == "" {
-		o.AuthClassification = authClassificationFromMethod(o.AuthMethod)
-	}
-
-	required := o.WorksessionRequired || o.WorksessionRequiredForAccess
-	o.WorksessionRequired = required
-	o.WorksessionRequiredForAccess = required
-
-	active := o.ActiveWorksession
-	if active == nil {
-		active = o.ActiveWorksessionCanonical
-	}
-	o.ActiveWorksession = active
-	o.ActiveWorksessionCanonical = active
-	return o
-}
-
 var whoamiCmd = &cobra.Command{
 	Use:   "whoami [flags]",
 	Short: "Display current authenticated identity",
@@ -171,6 +111,66 @@ commands, especially for AI agents and operators managing multiple workspaces.`,
 		warnIfExpiringSoon(cfg)
 		printWhoami(output)
 	},
+}
+
+type activeWorkSessionSummary struct {
+	ID        string   `json:"id"`
+	Status    string   `json:"status"`
+	Scopes    []string `json:"scopes"`
+	Servers   []string `json:"servers"`
+	ExpiresAt string   `json:"expires_at,omitempty"`
+}
+
+type whoamiOutput struct {
+	Username           string                `json:"username,omitempty"`
+	Email              string                `json:"email,omitempty"`
+	Phone              string                `json:"phone,omitempty"`
+	WorkspaceName      string                `json:"workspace_name"`
+	WorkspaceURL       string                `json:"workspace_url"`
+	AuthMethod         string                `json:"auth_method"`
+	AuthClassification string                `json:"auth_classification"`
+	ExpiresAt          string                `json:"expires_at,omitempty"`
+	UID                int                   `json:"uid,omitempty"`
+	Shell              string                `json:"shell,omitempty"`
+	HomeDirectory      string                `json:"home_directory,omitempty"`
+	Role               string                `json:"role,omitempty"`
+	Groups             []iam.GroupMembership `json:"groups,omitempty"`
+	// Application-principal fields (service tokens). Empty for user principals.
+	PrincipalType       string   `json:"principal_type,omitempty"`
+	ApplicationName     string   `json:"application_name,omitempty"`
+	ServiceType         string   `json:"service_type,omitempty"`
+	ServiceAccount      string   `json:"service_account,omitempty"`
+	Scopes              []string `json:"scopes,omitempty"`
+	WorksessionRequired bool     `json:"work_session_required"`
+	// WorksessionRequiredForAccess and ActiveWorksessionCanonical are the
+	// machine-readable names. The legacy keys remain for compatibility.
+	WorksessionRequiredForAccess bool                      `json:"worksession_required_for_access"`
+	ActiveWorksession            *activeWorkSessionSummary `json:"active_work_session"`
+	ActiveWorksessionCanonical   *activeWorkSessionSummary `json:"active_worksession"`
+}
+
+func (o whoamiOutput) MarshalJSON() ([]byte, error) {
+	type wire whoamiOutput
+	normalized := o.normalized()
+	return json.Marshal(wire(normalized))
+}
+
+func (o whoamiOutput) normalized() whoamiOutput {
+	if o.AuthClassification == "" {
+		o.AuthClassification = authClassificationFromMethod(o.AuthMethod)
+	}
+
+	required := o.WorksessionRequired || o.WorksessionRequiredForAccess
+	o.WorksessionRequired = required
+	o.WorksessionRequiredForAccess = required
+
+	active := o.ActiveWorksession
+	if active == nil {
+		active = o.ActiveWorksessionCanonical
+	}
+	o.ActiveWorksession = active
+	o.ActiveWorksessionCanonical = active
+	return o
 }
 
 func getExpiresAt(cfg config.Config) string {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alpacax/alpacon-cli/api/auth"
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/client"
 	wscmd "github.com/alpacax/alpacon-cli/cmd/worksession"
@@ -24,20 +25,26 @@ type activeWorkSessionSummary struct {
 }
 
 type whoamiOutput struct {
-	Username            string                `json:"username,omitempty"`
-	Email               string                `json:"email,omitempty"`
-	Phone               string                `json:"phone,omitempty"`
-	WorkspaceName       string                `json:"workspace_name"`
-	WorkspaceURL        string                `json:"workspace_url"`
-	AuthMethod          string                `json:"auth_method"`
-	AuthClassification  string                `json:"auth_classification"`
-	ExpiresAt           string                `json:"expires_at,omitempty"`
-	UID                 int                   `json:"uid,omitempty"`
-	Shell               string                `json:"shell,omitempty"`
-	HomeDirectory       string                `json:"home_directory,omitempty"`
-	Role                string                `json:"role,omitempty"`
-	Groups              []iam.GroupMembership `json:"groups,omitempty"`
-	WorksessionRequired bool                  `json:"work_session_required"`
+	Username           string                `json:"username,omitempty"`
+	Email              string                `json:"email,omitempty"`
+	Phone              string                `json:"phone,omitempty"`
+	WorkspaceName      string                `json:"workspace_name"`
+	WorkspaceURL       string                `json:"workspace_url"`
+	AuthMethod         string                `json:"auth_method"`
+	AuthClassification string                `json:"auth_classification"`
+	ExpiresAt          string                `json:"expires_at,omitempty"`
+	UID                int                   `json:"uid,omitempty"`
+	Shell              string                `json:"shell,omitempty"`
+	HomeDirectory      string                `json:"home_directory,omitempty"`
+	Role               string                `json:"role,omitempty"`
+	Groups             []iam.GroupMembership `json:"groups,omitempty"`
+	// Application-principal fields (service tokens). Empty for user principals.
+	PrincipalType       string   `json:"principal_type,omitempty"`
+	ApplicationName     string   `json:"application_name,omitempty"`
+	ServiceType         string   `json:"service_type,omitempty"`
+	ServiceAccount      string   `json:"service_account,omitempty"`
+	Scopes              []string `json:"scopes,omitempty"`
+	WorksessionRequired bool     `json:"work_session_required"`
 	// WorksessionRequiredForAccess and ActiveWorksessionCanonical are the
 	// machine-readable names. The legacy keys remain for compatibility.
 	WorksessionRequiredForAccess bool                      `json:"worksession_required_for_access"`
@@ -103,6 +110,17 @@ commands, especially for AI agents and operators managing multiple workspaces.`,
 			return
 		}
 
+		// Only a service token can be an application principal, so skip the whoami
+		// round-trip for user credentials, which fall through to the user path below.
+		if config.IsServiceToken(cfg.Token) {
+			if who, whoErr := auth.GetWhoami(ac); whoErr == nil && who.PrincipalType == auth.PrincipalTypeApplication {
+				output = applyApplicationPrincipal(output, who)
+				warnIfExpiringSoon(cfg)
+				printWhoami(output)
+				return
+			}
+		}
+
 		user, err := iam.GetCurrentUser(ac)
 		if err != nil {
 			utils.CliWarning("Could not fetch user info: %s", err)
@@ -160,6 +178,18 @@ func getExpiresAt(cfg config.Config) string {
 		return cfg.ExpiresAt
 	}
 	return ""
+}
+
+// applyApplicationPrincipal fills out's application fields from an application-principal whoami response.
+func applyApplicationPrincipal(out whoamiOutput, who *auth.WhoamiResponse) whoamiOutput {
+	out.PrincipalType = auth.PrincipalTypeApplication
+	if who.Application != nil {
+		out.ApplicationName = who.Application.Name
+		out.ServiceType = who.Application.ServiceType
+		out.ServiceAccount = who.Application.Username
+	}
+	out.Scopes = who.Auth.Scopes
+	return out
 }
 
 func getRole(isStaff, isSuperuser bool) string {
@@ -299,6 +329,10 @@ func printWhoami(output whoamiOutput) {
 		value string
 	}{
 		{"User", output.Username},
+		{"Application", output.ApplicationName},
+		{"Service type", output.ServiceType},
+		{"Service account", output.ServiceAccount},
+		{"Scopes", strings.Join(output.Scopes, ", ")},
 		{"Email", output.Email},
 		{"Phone", output.Phone},
 		{"Workspace", fmt.Sprintf("%s (%s)", output.WorkspaceName, output.WorkspaceURL)},

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -50,15 +50,22 @@ commands, especially for AI agents and operators managing multiple workspaces.`,
 			return
 		}
 
-		// Only a service token can be an application principal, so skip the whoami
-		// round-trip for user credentials, which fall through to the user path below.
+		// Only a service token can be an application principal. Service tokens have no
+		// user profile, so resolve identity via whoami and return without falling
+		// through to the user-only IAM endpoint, which would always fail for them.
 		if config.IsServiceToken(cfg.Token) {
-			if who, whoErr := auth.GetWhoami(ac); whoErr == nil && who.PrincipalType == auth.PrincipalTypeApplication {
+			who, whoErr := auth.GetWhoami(ac)
+			switch {
+			case whoErr != nil:
+				utils.CliWarning("Could not fetch application identity: %s", whoErr)
+			case who.PrincipalType == auth.PrincipalTypeApplication:
 				output = applyApplicationPrincipal(output, who)
-				warnIfExpiringSoon(cfg)
-				printWhoami(output)
-				return
+			default:
+				utils.CliWarning("Unexpected principal type %q for service token.", who.PrincipalType)
 			}
+			warnIfExpiringSoon(cfg)
+			printWhoami(output)
+			return
 		}
 
 		user, err := iam.GetCurrentUser(ac)

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -347,10 +347,22 @@ func printWhoami(output whoamiOutput) {
 		{"WS required", formatWSRequired(output.WorksessionRequiredForAccess, output.ActiveWorksessionCanonical)},
 	}
 
+	// Pad to the widest printed label so columns align regardless of which rows appear.
+	pad := 0
 	for _, l := range lines {
 		if l.value == "" || l.value == "0" {
 			continue
 		}
-		fmt.Fprintf(os.Stdout, "%-13s%s\n", l.label+":", l.value)
+		if n := len(l.label) + 1; n > pad {
+			pad = n
+		}
+	}
+	pad++ // guarantee at least one space after the widest label
+
+	for _, l := range lines {
+		if l.value == "" || l.value == "0" {
+			continue
+		}
+		fmt.Fprintf(os.Stdout, "%-*s%s\n", pad, l.label+":", l.value)
 	}
 }

--- a/cmd/whoami_test.go
+++ b/cmd/whoami_test.go
@@ -6,10 +6,40 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacax/alpacon-cli/api/auth"
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/config"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestApplyApplicationPrincipal(t *testing.T) {
+	who := &auth.WhoamiResponse{
+		PrincipalType: "application",
+		Auth:          auth.WhoamiAuth{Scopes: []string{"server:read", "command:create"}},
+		Application:   &auth.WhoamiApplication{Name: "ci-runner", ServiceType: "ci_cd", Username: "svc-ci"},
+	}
+
+	out := applyApplicationPrincipal(whoamiOutput{}, who)
+
+	assert.Equal(t, "application", out.PrincipalType)
+	assert.Equal(t, "ci-runner", out.ApplicationName)
+	assert.Equal(t, "ci_cd", out.ServiceType)
+	assert.Equal(t, "svc-ci", out.ServiceAccount)
+	assert.Equal(t, []string{"server:read", "command:create"}, out.Scopes)
+}
+
+func TestApplicationFieldsOmittedForUserPrincipal(t *testing.T) {
+	// A user principal's JSON must not carry application keys (output unchanged).
+	body, err := json.Marshal(whoamiOutput{Username: "alice", AuthMethod: "Browser login"})
+	assert.NoError(t, err)
+
+	var got map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(body, &got))
+	for _, k := range []string{"principal_type", "application_name", "service_type", "service_account", "scopes"} {
+		_, present := got[k]
+		assert.Falsef(t, present, "key %q must be absent for a user principal", k)
+	}
+}
 
 func TestGetAuthMethod(t *testing.T) {
 	tests := []struct {

--- a/utils/error.go
+++ b/utils/error.go
@@ -46,6 +46,20 @@ type codedError interface {
 	ErrorSource() string
 }
 
+type statusCoder interface {
+	HTTPStatusCode() int
+}
+
+// HTTPStatusCode returns the HTTP status carried by err, or 0 if none — lets callers tell 404 from 401.
+func HTTPStatusCode(err error) int {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if sc, ok := e.(statusCoder); ok {
+			return sc.HTTPStatusCode()
+		}
+	}
+	return 0
+}
+
 func ParseErrorResponse(err error) (string, string) {
 	for e := err; e != nil; e = errors.Unwrap(e) {
 		if coded, ok := e.(codedError); ok {

--- a/utils/error.go
+++ b/utils/error.go
@@ -50,7 +50,7 @@ type statusCoder interface {
 	HTTPStatusCode() int
 }
 
-// HTTPStatusCode returns the HTTP status carried by err, or 0 if none — lets callers tell 404 from 401.
+// HTTPStatusCode returns the HTTP status carried by err, or 0 if none—lets callers tell 404 from 401.
 func HTTPStatusCode(err error) int {
 	for e := err; e != nil; e = errors.Unwrap(e) {
 		if sc, ok := e.(statusCoder); ok {


### PR DESCRIPTION
## Background

The server now exposes a `GET /api/auth/whoami/` endpoint that distinguishes a credential's principal between user and application (service token) and lets us query that identity directly. The existing CLI inferred login verification from the token prefix, and the `whoami` command could only show a user profile. This PR wires the whoami endpoint into login verification and identity display.

## Changes

Propagate the HTTP status code through the API error chain. `withStatus` tags each error read from a response with its HTTP status: it sets `statusCode` on an `*apiError` in place, and wraps any other error (empty-body read failure, unexpected non-JSON Content-Type) in a `statusError` that also implements `HTTPStatusCode`. Both are exposed via `utils.HTTPStatusCode`, so callers can tell a 404 (endpoint absent) from a 401 (credential error) on every path.

Add `GetWhoami` and its response types (`WhoamiResponse`, etc.) to `api/auth`. Only the application branch is modeled in detail; user principals are still resolved through `iam.GetCurrentUser`.

Replace login verification with a whoami-based path. `classifyWhoamiVerification` is fail-closed: nil means verified, a literal 404 is treated as an old server without whoami and falls back to legacy prefix verification (`verifyLoginLegacy`), and 401 plus every other error (parse failure, network) aborts login.

The `whoami` command now shows application identity (application name, service type, service account, scopes) for a service token. The whoami round-trip is gated by `config.IsServiceToken`, so user credentials skip the call and flow through the existing user path unchanged. The table output pads labels to the widest printed label so columns stay aligned on both the user and application paths.

## Safety

Login verification is fail-closed. It falls back to legacy verification only when the whoami call returns 404; every other error, including 401, aborts login rather than being absorbed by the fallback. An invalid credential therefore cannot slip through the fallback path.

## Testing

`go build ./...` passes. `go test` passes for the `api/auth`, `cmd`, `client`, and `utils` packages. The added tests cover whoami response parsing (application/user principal), status-code propagation (404/401/non-API error), the fail-closed branches of `classifyWhoamiVerification`, and the whoami command's application field mapping plus field omission for a user principal.

Verified live against the dev server (`https://alpacax.dev.alpacon.io`) with both a browser login (user principal) and a service token (application principal). The service-token login logged `Authenticated as application 'alpacon'`, confirming the whoami-based verification path. Phone number below is masked; the raw output showed the real value.

User principal (`alpacon whoami`):

```
User:        chaejisung
Email:       js.chae@alpacax.com
Phone:       +82 10-XXXX-XXXX
Workspace:   alpacax (https://alpacax.dev.alpacon.io)
Auth:        Browser login
Auth class:  browser_login
UID:         2006
Shell:       /bin/bash
Home:        /home/chaejisung
Role:        superuser
Groups:      Alpacon users (member)
WS required: yes—run 'alpacon work-session list' to see available sessions
```

User principal (`alpacon whoami --output json`):

```json
{
  "username": "chaejisung",
  "email": "js.chae@alpacax.com",
  "phone": "+82 10-XXXX-XXXX",
  "workspace_name": "alpacax",
  "workspace_url": "https://alpacax.dev.alpacon.io",
  "auth_method": "Browser login",
  "auth_classification": "browser_login",
  "uid": 2006,
  "shell": "/bin/bash",
  "home_directory": "/home/chaejisung",
  "role": "superuser",
  "groups": [
    { "name": "Alpacon users", "role": "member" }
  ],
  "work_session_required": true,
  "worksession_required_for_access": true,
  "active_work_session": null,
  "active_worksession": null
}
```

Application principal (`alpacon whoami`):

```
Application:  alpacon
Service type: integration
Scopes:       server:read, uploaded_file:create, uploaded_file:upload, uploaded_file:status, uploaded_file:bulk, uploaded_file:bulk_upload, uploaded_file:read
Workspace:    alpacax (https://alpacax.dev.alpacon.io)
Auth:         Service token
Auth class:   service_token
WS required:  no
```

Application principal (`alpacon whoami --output json`):

```json
{
  "workspace_name": "alpacax",
  "workspace_url": "https://alpacax.dev.alpacon.io",
  "auth_method": "Service token",
  "auth_classification": "service_token",
  "principal_type": "application",
  "application_name": "alpacon",
  "service_type": "integration",
  "scopes": [
    "server:read",
    "uploaded_file:create",
    "uploaded_file:upload",
    "uploaded_file:status",
    "uploaded_file:bulk",
    "uploaded_file:bulk_upload",
    "uploaded_file:read"
  ],
  "work_session_required": false,
  "worksession_required_for_access": false,
  "active_work_session": null,
  "active_worksession": null
}
```

## Checklist

- [x] Build passes
- [x] Tests pass
- [x] gofmt / go vet clean

Closes #231

