### PR TITLE
refactor(utils): restructure next_actions into {command, description} for machine consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Next:
 Note: Tokens issued by Alpacon (service or personal API token) bypass this check.
 ```
 
-With `--output json`, the same refusal is a structured envelope on stderr—scripts and AI agents branch on `error_code` and run `next_actions` verbatim:
+With `--output json`, the same refusal is a structured envelope on stderr—scripts and AI agents branch on `error_code` and exec each `next_actions[].command` directly (the human hint, when present, is a separate `description` field):
 
 ```json
 {
@@ -261,10 +261,10 @@ With `--output json`, the same refusal is a structured envelope on stderr—scri
     "current_worksession": null
   },
   "next_actions": [
-    "alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>",
-    "alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
-    "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --use  # none active? create a new one (human)",
-    "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --requester-type agent  # none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)"
+    {"command": "alpacon work-session ls --status active", "description": "find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>"},
+    {"command": "alpacon work-session use <ID>", "description": "human: attach an existing session (rejects agent sessions)"},
+    {"command": "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --use", "description": "none active? create a new one (human)"},
+    {"command": "alpacon work-session create --scope command --server prod-1 --expires-in 1h --purpose \"<intent>\" --requester-type agent", "description": "none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)"}
   ]
 }
 ```

--- a/cmd/exec/pending_approval_test.go
+++ b/cmd/exec/pending_approval_test.go
@@ -108,17 +108,17 @@ func TestExecStatusAwaitingApprovalExits4WithJSONSignal(t *testing.T) {
 	assert.Equal(t, utils.ExitCodePendingApproval, exitErr.ExitCode(), "pending approval must exit 4")
 
 	var got struct {
-		OK          bool     `json:"ok"`
-		Status      string   `json:"status"`
-		ExitCode    int      `json:"exit_code"`
-		NextActions []string `json:"next_actions"`
+		OK          bool               `json:"ok"`
+		Status      string             `json:"status"`
+		ExitCode    int                `json:"exit_code"`
+		NextActions []utils.NextAction `json:"next_actions"`
 	}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got), "stdout: %s", stdout.String())
 	assert.False(t, got.OK)
 	assert.Equal(t, utils.PendingApprovalStatus, got.Status)
 	assert.Equal(t, utils.ExitCodePendingApproval, got.ExitCode)
 	require.NotEmpty(t, got.NextActions)
-	assert.Equal(t, "alpacon exec logs cmd-1", got.NextActions[0], "hint should point at exec logs for the held job")
+	assert.Equal(t, "alpacon exec logs cmd-1", got.NextActions[0].Command, "hint should point at exec logs for the held job")
 }
 
 func TestExecPendingApprovalExits4WithJSONSignal(t *testing.T) {
@@ -156,15 +156,15 @@ func TestExecPendingApprovalExits4WithJSONSignal(t *testing.T) {
 	assert.Equal(t, utils.ExitCodePendingApproval, exitErr.ExitCode(), "pending approval must exit 4")
 
 	var got struct {
-		OK          bool     `json:"ok"`
-		Status      string   `json:"status"`
-		ExitCode    int      `json:"exit_code"`
-		NextActions []string `json:"next_actions"`
+		OK          bool               `json:"ok"`
+		Status      string             `json:"status"`
+		ExitCode    int                `json:"exit_code"`
+		NextActions []utils.NextAction `json:"next_actions"`
 	}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got), "stdout: %s", stdout.String())
 	assert.False(t, got.OK)
 	assert.Equal(t, utils.PendingApprovalStatus, got.Status)
 	assert.Equal(t, utils.ExitCodePendingApproval, got.ExitCode)
 	require.NotEmpty(t, got.NextActions)
-	assert.Equal(t, "alpacon exec prod -- sudo reboot", got.NextActions[0], "re-run hint should reconstruct the invocation")
+	assert.Equal(t, "alpacon exec prod -- sudo reboot", got.NextActions[0].Command, "re-run hint should reconstruct the invocation")
 }

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -239,7 +239,7 @@ func HandlePendingApproval(err error, reRunHint string) bool {
 			"Approval required—this command is held for human approval in the Alpacon console (web). "+
 				"It runs automatically once approved; pass --wait to block until then.",
 			"", // the command detail carries no approval request id
-			fmt.Sprintf("alpacon exec logs %s", pendingErr.CommandID),
+			utils.NextAction{Command: fmt.Sprintf("alpacon exec logs %s", pendingErr.CommandID)},
 		)
 		os.Exit(utils.ExitCodePendingApproval)
 		return true
@@ -251,7 +251,7 @@ func HandlePendingApproval(err error, reRunHint string) bool {
 		"Approval required—a human must approve this sudo command in the Alpacon console (web). "+
 			"Re-run after approval, or use --wait to block until it is approved.",
 		"", // the exec sudo denial line carries no approval request id
-		reRunHint,
+		utils.NextAction{Command: reRunHint},
 	)
 	os.Exit(utils.ExitCodePendingApproval)
 	return true

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -233,7 +233,7 @@ so it is recorded and scoped accordingly.`,
 				utils.PrintPendingApproval(
 					fmt.Sprintf("Approval required—work session %s is pending. A human must approve it in the Alpacon console (web).", session.ID),
 					session.ApprovalRequestID,
-					fmt.Sprintf("alpacon work-session use %s  # after approval", session.ID),
+					utils.NextAction{Command: fmt.Sprintf("alpacon work-session use %s", session.ID), Description: "after approval"},
 				)
 				os.Exit(utils.ExitCodePendingApproval)
 			}

--- a/utils/output.go
+++ b/utils/output.go
@@ -23,13 +23,21 @@ const (
 var OutputFormat string
 
 type JSONErrorEnvelope[T any] struct {
-	OK          bool     `json:"ok"`
-	ExitCode    int      `json:"exit_code,omitempty"`
-	ErrorCode   string   `json:"error_code,omitempty"`
-	Message     string   `json:"message"`
-	Reason      string   `json:"reason,omitempty"`
-	Context     T        `json:"context"`
-	NextActions []string `json:"next_actions,omitempty"`
+	OK          bool         `json:"ok"`
+	ExitCode    int          `json:"exit_code,omitempty"`
+	ErrorCode   string       `json:"error_code,omitempty"`
+	Message     string       `json:"message"`
+	Reason      string       `json:"reason,omitempty"`
+	Context     T            `json:"context"`
+	NextActions []NextAction `json:"next_actions,omitempty"`
+}
+
+// NextAction is one actionable follow-up. Command is a pure, runnable command
+// (no inline comments) for machine consumers; Description carries the human hint
+// and is omitted when the command is self-explanatory.
+type NextAction struct {
+	Command     string `json:"command"`
+	Description string `json:"description,omitempty"`
 }
 
 func FormatJSON(value any) (string, error) {

--- a/utils/output.go
+++ b/utils/output.go
@@ -33,11 +33,26 @@ type JSONErrorEnvelope[T any] struct {
 }
 
 // NextAction is one actionable follow-up. Command is a pure, runnable command
-// (no inline comments) for machine consumers; Description carries the human hint
-// and is omitted when the command is self-explanatory.
+// (no inline comments) for machine consumers; Description carries the human hint.
+// Either may be empty—a pure command needs no hint, and a guidance-only pointer
+// (e.g. "approve it in the console") carries no runnable command—so both fields
+// are omitempty.
 type NextAction struct {
-	Command     string `json:"command"`
+	Command     string `json:"command,omitempty"`
 	Description string `json:"description,omitempty"`
+}
+
+// PlainText renders the action as a human-facing line: "command  # description",
+// or just the command or description when the other is empty.
+func (a NextAction) PlainText() string {
+	switch {
+	case a.Command != "" && a.Description != "":
+		return a.Command + "  # " + a.Description
+	case a.Command != "":
+		return a.Command
+	default:
+		return a.Description
+	}
 }
 
 func FormatJSON(value any) (string, error) {

--- a/utils/output_test.go
+++ b/utils/output_test.go
@@ -130,7 +130,7 @@ func TestPrintJSONError(t *testing.T) {
 		Context: map[string]string{
 			"required_scope": "command",
 		},
-		NextActions: []string{"alpacon work-session use <ID>"},
+		NextActions: []NextAction{{Command: "alpacon work-session use <ID>"}},
 	})
 
 	assert.JSONEq(t, `{
@@ -139,6 +139,6 @@ func TestPrintJSONError(t *testing.T) {
 		"error_code": "work_session_required",
 		"message": "command requires a work session",
 		"context": {"required_scope": "command"},
-		"next_actions": ["alpacon work-session use <ID>"]
+		"next_actions": [{"command": "alpacon work-session use <ID>"}]
 	}`, buf.String())
 }

--- a/utils/pending_approval.go
+++ b/utils/pending_approval.go
@@ -43,8 +43,9 @@ func pendingApprovalNextActions(retry NextAction) []NextAction {
 // --output json it writes a {"status":"pending_approval", ...} envelope to
 // stdout; otherwise it writes an actionable message to stderr. requestID may be
 // empty when the surface cannot supply one. retry is a surface-specific retry
-// action (e.g. the exact command to re-run); its Command stays a pure, execable
-// string so a machine consumer can run it directly, with any hint in Description.
+// action (e.g. the exact command to re-run); its Command stays a pure,
+// executable string so a machine consumer can run it directly, with any hint in
+// Description.
 // It never exits — the caller owns process exit so the exit-code contract stays
 // in one place.
 func PrintPendingApproval(message, requestID string, retry NextAction) {

--- a/utils/pending_approval.go
+++ b/utils/pending_approval.go
@@ -23,28 +23,31 @@ type pendingApprovalJSON struct {
 	Message     string             `json:"message"`
 	RequestID   string             `json:"request_id,omitempty"`
 	Context     pendingApprovalCtx `json:"context"`
-	NextActions []string           `json:"next_actions,omitempty"`
+	NextActions []NextAction       `json:"next_actions,omitempty"`
 }
 
-// pendingApprovalNextActions lists the actionable follow-ups for a human reading
-// the message. reRunHint is the surface-specific way to retry (re-run the
+// pendingApprovalNextActions lists the actionable follow-ups for a consumer
+// reading the message. retry is the surface-specific way to retry (re-run the
 // command, or attach the session); it leads, then the generic console pointer.
-func pendingApprovalNextActions(reRunHint string) []string {
-	actions := make([]string, 0, 2)
-	if reRunHint != "" {
-		actions = append(actions, reRunHint)
+// A zero-value retry is skipped.
+func pendingApprovalNextActions(retry NextAction) []NextAction {
+	actions := make([]NextAction, 0, 2)
+	if retry != (NextAction{}) {
+		actions = append(actions, retry)
 	}
-	return append(actions, "Approve it out of band in the Alpacon console (web/Slack). Where supported, pass --wait on the original command to block until approval.")
+	return append(actions, NextAction{Description: "Approve it out of band in the Alpacon console (web/Slack). Where supported, pass --wait on the original command to block until approval."})
 }
 
 // PrintPendingApproval emits the structured "pending approval" feedback for an
 // action that requires out-of-band human approval and was not waited on. Under
 // --output json it writes a {"status":"pending_approval", ...} envelope to
 // stdout; otherwise it writes an actionable message to stderr. requestID may be
-// empty when the surface cannot supply one. reRunHint is a surface-specific
-// retry instruction (e.g. the exact command to re-run). It never exits — the
-// caller owns process exit so the exit-code contract stays in one place.
-func PrintPendingApproval(message, requestID, reRunHint string) {
+// empty when the surface cannot supply one. retry is a surface-specific retry
+// action (e.g. the exact command to re-run); its Command stays a pure, execable
+// string so a machine consumer can run it directly, with any hint in Description.
+// It never exits — the caller owns process exit so the exit-code contract stays
+// in one place.
+func PrintPendingApproval(message, requestID string, retry NextAction) {
 	if OutputFormat == OutputFormatJSON {
 		envelope := pendingApprovalJSON{
 			OK:          false,
@@ -53,7 +56,7 @@ func PrintPendingApproval(message, requestID, reRunHint string) {
 			Message:     message,
 			RequestID:   requestID,
 			Context:     pendingApprovalCtx{RequestID: requestID},
-			NextActions: pendingApprovalNextActions(reRunHint),
+			NextActions: pendingApprovalNextActions(retry),
 		}
 		if err := PrintJSONValue(os.Stdout, envelope); err != nil {
 			// Fall back to a minimal, still-parseable object so a machine consumer
@@ -64,7 +67,7 @@ func PrintPendingApproval(message, requestID, reRunHint string) {
 	}
 
 	CliWarning("%s", message)
-	for _, action := range pendingApprovalNextActions(reRunHint) {
-		fmt.Fprintf(os.Stderr, "  %s\n", action)
+	for _, action := range pendingApprovalNextActions(retry) {
+		fmt.Fprintf(os.Stderr, "  %s\n", action.PlainText())
 	}
 }

--- a/utils/pending_approval_test.go
+++ b/utils/pending_approval_test.go
@@ -37,7 +37,7 @@ func TestPrintPendingApproval_JSONOutput(t *testing.T) {
 	assert.Equal(t, "apr-123", got.Context.RequestID)
 	assert.Equal(t, "needs approval", got.Message)
 	require.NotEmpty(t, got.NextActions)
-	// The re-run hint leads the next actions as a pure, execable command.
+	// The re-run hint leads the next actions as a pure, executable command.
 	assert.Equal(t, "alpacon exec srv -- sudo reboot", got.NextActions[0].Command)
 	// The console-approval pointer is guidance only—no runnable command.
 	last := got.NextActions[len(got.NextActions)-1]

--- a/utils/pending_approval_test.go
+++ b/utils/pending_approval_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ func TestPrintPendingApproval_JSONOutput(t *testing.T) {
 	var out string
 	withFormat(OutputFormatJSON, func() {
 		out = captureStdout(t, func() {
-			PrintPendingApproval("needs approval", "apr-123", "alpacon exec srv -- sudo reboot")
+			PrintPendingApproval("needs approval", "apr-123", NextAction{Command: "alpacon exec srv -- sudo reboot"})
 		})
 	})
 
@@ -25,7 +26,7 @@ func TestPrintPendingApproval_JSONOutput(t *testing.T) {
 		Context   struct {
 			RequestID string `json:"request_id"`
 		} `json:"context"`
-		NextActions []string `json:"next_actions"`
+		NextActions []NextAction `json:"next_actions"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(out), &got), "output: %s", out)
 
@@ -36,14 +37,32 @@ func TestPrintPendingApproval_JSONOutput(t *testing.T) {
 	assert.Equal(t, "apr-123", got.Context.RequestID)
 	assert.Equal(t, "needs approval", got.Message)
 	require.NotEmpty(t, got.NextActions)
-	assert.Equal(t, "alpacon exec srv -- sudo reboot", got.NextActions[0], "the re-run hint leads the next actions")
+	// The re-run hint leads the next actions as a pure, execable command.
+	assert.Equal(t, "alpacon exec srv -- sudo reboot", got.NextActions[0].Command)
+	// The console-approval pointer is guidance only—no runnable command.
+	last := got.NextActions[len(got.NextActions)-1]
+	assert.Empty(t, last.Command, "the console-approval pointer carries no command")
+	assert.Contains(t, last.Description, "Alpacon console")
+}
+
+func TestPrintPendingApproval_JSONOutput_OmitsEmptyCommand(t *testing.T) {
+	var out string
+	withFormat(OutputFormatJSON, func() {
+		out = captureStdout(t, func() {
+			PrintPendingApproval("needs approval", "apr-123", NextAction{Command: "alpacon exec srv -- sudo reboot"})
+		})
+	})
+
+	// command has omitempty, so the description-only console pointer must not
+	// serialize an empty "command" field. Only the leading re-run hint carries one.
+	assert.Equal(t, 1, strings.Count(out, `"command"`), "empty command must be omitted, not serialized as \"\"\noutput: %s", out)
 }
 
 func TestPrintPendingApproval_JSONOutput_OmitsEmptyRequestID(t *testing.T) {
 	var out string
 	withFormat(OutputFormatJSON, func() {
 		out = captureStdout(t, func() {
-			PrintPendingApproval("needs approval", "", "")
+			PrintPendingApproval("needs approval", "", NextAction{})
 		})
 	})
 
@@ -51,4 +70,23 @@ func TestPrintPendingApproval_JSONOutput_OmitsEmptyRequestID(t *testing.T) {
 	assert.NotContains(t, out, `"request_id"`, "empty request_id must be omitted, not serialized as \"\"")
 	// status stays present and stable even without a request id.
 	assert.Contains(t, out, `"status": "`+PendingApprovalStatus+`"`)
+}
+
+func TestPrintPendingApproval_JSONOutput_OmitsEmptyRetry(t *testing.T) {
+	var out string
+	withFormat(OutputFormatJSON, func() {
+		out = captureStdout(t, func() {
+			PrintPendingApproval("needs approval", "", NextAction{})
+		})
+	})
+
+	var got struct {
+		NextActions []NextAction `json:"next_actions"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "output: %s", out)
+	// An empty retry hint must not add a blank leading action; only the console
+	// pointer remains.
+	require.Len(t, got.NextActions, 1)
+	assert.Empty(t, got.NextActions[0].Command)
+	assert.Contains(t, got.NextActions[0].Description, "Alpacon console")
 }

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -66,7 +66,11 @@ func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeW
 	fmt.Fprintln(&sb)
 	fmt.Fprintln(&sb, "Next:")
 	for _, action := range workSessionNextActions(code, operation, serverName, activeWS) {
-		fmt.Fprintf(&sb, "  %s\n", action)
+		if action.Description != "" {
+			fmt.Fprintf(&sb, "  %s  # %s\n", action.Command, action.Description)
+		} else {
+			fmt.Fprintf(&sb, "  %s\n", action.Command)
+		}
 	}
 	fmt.Fprintln(&sb)
 	fmt.Fprint(&sb, "Note: Tokens issued by Alpacon (service or personal API token) bypass this check.")
@@ -102,7 +106,7 @@ func targetServerList(serverName string) []string {
 	return []string{serverName}
 }
 
-func workSessionNextActions(code, operation, serverName, activeWS string) []string {
+func workSessionNextActions(code, operation, serverName, activeWS string) []NextAction {
 	serverArg := serverName
 	if serverArg == "" {
 		// Some call sites have no target server (e.g. exec logs); keep the suggestion runnable.
@@ -118,26 +122,26 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	)
 	// Reuse an active session first (ls), then create as the fallback. Humans attach via `use`;
 	// agents can't `use` (it rejects agent sessions) and instead pass --work-session <ID> downstream.
-	createOrReuse := []string{
-		"alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>",
-		"alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)",
-		createCmd + "  # none active? create a new one (human)",
-		agentCreateCmd + "  # none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)",
+	createOrReuse := []NextAction{
+		{Command: "alpacon work-session ls --status active", Description: "find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>"},
+		{Command: "alpacon work-session use <ID>", Description: "human: attach an existing session (rejects agent sessions)"},
+		{Command: createCmd, Description: "none active? create a new one (human)"},
+		{Command: agentCreateCmd, Description: "none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)"},
 	}
 	switch code {
 	case WorkSessionRequired:
 		return createOrReuse
 	case WorkSessionNotActive:
 		// Activation is approval/server-driven, not user-run; guide toward an active session.
-		return append([]string{
-			"alpacon work-session current  # pending/approved: wait until active; completed/revoked: create or reuse below",
+		return append([]NextAction{
+			{Command: "alpacon work-session current", Description: "pending/approved: wait until active; completed/revoked: create or reuse below"},
 		}, createOrReuse...)
 	case WorkSessionExpired:
 		extendCmd := "alpacon work-session extend <ID>"
 		if activeWS != "" {
 			extendCmd = fmt.Sprintf("alpacon work-session extend %s", activeWS)
 		}
-		return []string{extendCmd, createCmd, agentCreateCmd}
+		return []NextAction{{Command: extendCmd}, {Command: createCmd}, {Command: agentCreateCmd}}
 	case WorkSessionAssigneeMismatch:
 		// Session belongs to another principal; reuse/create one owned by this caller.
 		// Agents can't `use`, so route through the agent-aware reuse+create path.
@@ -145,6 +149,6 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	case WorkSessionNotUsable:
 		return createOrReuse
 	default: // scope_not_allowed, server_not_allowed
-		return []string{createCmd, agentCreateCmd}
+		return []NextAction{{Command: createCmd}, {Command: agentCreateCmd}}
 	}
 }

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -66,11 +66,7 @@ func buildWorkSessionDiagnostic(code, operation, serverName, authMethod, activeW
 	fmt.Fprintln(&sb)
 	fmt.Fprintln(&sb, "Next:")
 	for _, action := range workSessionNextActions(code, operation, serverName, activeWS) {
-		if action.Description != "" {
-			fmt.Fprintf(&sb, "  %s  # %s\n", action.Command, action.Description)
-		} else {
-			fmt.Fprintf(&sb, "  %s\n", action.Command)
-		}
+		fmt.Fprintf(&sb, "  %s\n", action.PlainText())
 	}
 	fmt.Fprintln(&sb)
 	fmt.Fprint(&sb, "Note: Tokens issued by Alpacon (service or personal API token) bypass this check.")

--- a/utils/worksession_error_test.go
+++ b/utils/worksession_error_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -108,17 +107,25 @@ func TestBuildWorkSessionErrorEnvelope_WithActiveWS(t *testing.T) {
 	assert.NotNil(t, envelope.Context.CurrentWorksession)
 	assert.Equal(t, "abc-123-uuid", *envelope.Context.CurrentWorksession)
 	// Expired case: <ID> placeholder must be substituted with the known active UUID.
-	assert.Contains(t, envelope.NextActions, "alpacon work-session extend abc-123-uuid")
+	assert.Contains(t, nextActionCommands(envelope.NextActions), "alpacon work-session extend abc-123-uuid")
 	for _, action := range envelope.NextActions {
-		assert.NotContains(t, action, "<ID>")
+		assert.NotContains(t, action.Command, "<ID>")
 	}
+}
+
+func nextActionCommands(actions []NextAction) []string {
+	cmds := make([]string, len(actions))
+	for i, a := range actions {
+		cmds[i] = a.Command
+	}
+	return cmds
 }
 
 func TestBuildWorkSessionErrorEnvelope_ExpiredWithoutActiveWS(t *testing.T) {
 	// When activeWS is unknown, the placeholder must remain.
 	envelope := buildWorkSessionErrorEnvelope(WorkSessionExpired, "webftp", "srv-2", "Browser login", "")
 
-	assert.Contains(t, envelope.NextActions, "alpacon work-session extend <ID>")
+	assert.Contains(t, nextActionCommands(envelope.NextActions), "alpacon work-session extend <ID>")
 }
 
 func TestBuildWorkSessionErrorEnvelope_RequiredKeepsPlaceholder(t *testing.T) {
@@ -126,8 +133,7 @@ func TestBuildWorkSessionErrorEnvelope_RequiredKeepsPlaceholder(t *testing.T) {
 	// so the placeholder must NOT be substituted even when activeWS is known.
 	envelope := buildWorkSessionErrorEnvelope(WorkSessionRequired, "command", "srv-1", "Browser login", "abc-123-uuid")
 
-	// The use action carries an inline comment, so match as a substring.
-	assert.Contains(t, strings.Join(envelope.NextActions, "\n"), "alpacon work-session use <ID>")
+	assert.Contains(t, nextActionCommands(envelope.NextActions), "alpacon work-session use <ID>")
 }
 
 func TestHandleWorkSessionError_NoOp(t *testing.T) {


### PR DESCRIPTION
## Background

The `next_actions` list in gate-denial and pending-approval output is meant for machine consumers—an AI agent or CI job reads an entry and execs it to recover. Each entry previously packed a shell-style `# ...` hint into the command string. That is harmless in a shell (the `#` starts a comment) but trips a consumer that splits the string into argv, because the comment becomes trailing arguments. This was raised in the review of #241 (finding 3) and deferred as out of scope.

## Changes

The first commit restructures the WorkSession gate output (the original scope of #246):

- Add a `NextAction{Command, Description}` type and change `JSONErrorEnvelope.NextActions` from `[]string` to `[]NextAction` in `utils/output.go`.
- Convert `workSessionNextActions()` to return `[]NextAction` and re-join `command  # description` in the plain-text renderer, so human output is unchanged while JSON consumers get a clean `command` field.

The second commit unifies the other consumer of the same contract, `utils/pending_approval.go`, which carried its own `next_actions []string` and had one entry (`alpacon work-session use <ID>  # after approval`) with the exact inline comment that trips argv parsing:

- Change `pendingApprovalJSON.NextActions` to `[]NextAction`.
- Change `PrintPendingApproval` to take a structured `retry NextAction` instead of a raw `reRunHint string`, so the hint moves to `Description` instead of being inlined with `#`.
- Model the console-approval pointer as a description-only entry (no runnable command). `NextAction.Command` gains `omitempty` so guidance-only entries do not serialize an empty `command` field.
- Both surfaces now render their plain-text line through a shared `NextAction.PlainText()` helper.
- Update the three call sites in `cmd/exec/run.go` and `cmd/worksession/worksession_create.go`.

## Contract change

This is a breaking change to the `next_actions` JSON shape (`string[]` to `object[]`) on both the gate-denial and pending-approval envelopes. Any existing machine consumer that reads `next_actions[i]` as a string must switch to `next_actions[i].command`. This needs a callout in release notes.

`NextAction.Command` is `omitempty`, so a guidance-only entry emits `{"description": "..."}` with no `command` key; consumers should treat a missing `command` as "no runnable command, guidance only".

## Sample output

Captured from a rebuilt binary against a gated `exec` (server name masked as `my-server`).

Plain text (unchanged for humans; stderr):

```
Error: the command operation requires an active WorkSession on this authentication.

  auth          : Browser login (interactive)
  reason        : no WorkSession selected for this shell
  required scope: command
  target server : my-server

Next:
  alpacon work-session ls --status active  # find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>
  alpacon work-session use <ID>  # human: attach an existing session (rejects agent sessions)
  alpacon work-session create --scope command --server my-server --expires-in 1h --purpose "<intent>" --use  # none active? create a new one (human)
  alpacon work-session create --scope command --server my-server --expires-in 1h --purpose "<intent>" --requester-type agent  # none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)

Note: Tokens issued by Alpacon (service or personal API token) bypass this check.
```

`--output json` (new structured shape; stdout):

```json
{
  "ok": false,
  "exit_code": 3,
  "error_code": "work_session_required",
  "message": "the command operation requires an active WorkSession on this authentication.",
  "reason": "no WorkSession selected for this shell",
  "context": {
    "auth_method": "Browser login",
    "required_scope": "command",
    "target_servers": [
      "my-server"
    ],
    "current_worksession": null
  },
  "next_actions": [
    {
      "command": "alpacon work-session ls --status active",
      "description": "find an existing active session; AI agent: reuse it by prefixing the gated command with --work-session <ID>"
    },
    {
      "command": "alpacon work-session use <ID>",
      "description": "human: attach an existing session (rejects agent sessions)"
    },
    {
      "command": "alpacon work-session create --scope command --server my-server --expires-in 1h --purpose \"<intent>\" --use",
      "description": "none active? create a new one (human)"
    },
    {
      "command": "alpacon work-session create --scope command --server my-server --expires-in 1h --purpose \"<intent>\" --requester-type agent",
      "description": "none active? create a new one (AI agent; prefix the gated command with --work-session <ID>)"
    }
  ]
}
```

## Testing

- `go test -race ./...` passes.
- `go vet ./...` clean.
- `golangci-lint run ./...` reports 0 issues.

## Checklist

- [x] Plain-text human output unchanged on both surfaces
- [x] JSON `next_actions` entries expose a pure, execable `command`
- [x] All three `PrintPendingApproval` call sites updated
- [x] Tests updated for the new shape

Closes #246
