### PR TITLE
feat(worksession): surface approver adjustments and recommendations

### DIFF
--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -28,8 +28,7 @@ type WorkSession struct {
 	Recommendations   []Recommendation      `json:"recommendations,omitempty"`
 }
 
-// Adjustments is the approver's diff applied at approval time. Each dimension
-// is present only when the approver changed it; a nil Adjustments means no change.
+// Adjustments is the approver's diff; each dimension is set only when changed, nil when unchanged.
 type Adjustments struct {
 	Scopes  *ScopeDiff  `json:"scopes,omitempty"`
 	Servers *ServerDiff `json:"servers,omitempty"`

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -24,6 +24,34 @@ type WorkSession struct {
 	AddedAt           time.Time             `json:"added_at"`
 	UpdatedAt         time.Time             `json:"updated_at"`
 	SudoPolicies      []SudoPolicyInline    `json:"sudo_policies"`
+	Adjustments       *Adjustments          `json:"adjustments,omitempty"`
+	Recommendations   []Recommendation      `json:"recommendations,omitempty"`
+}
+
+// Adjustments is the approver's diff applied at approval time. Each dimension
+// is present only when the approver changed it; a nil Adjustments means no change.
+type Adjustments struct {
+	Scopes  *ScopeDiff  `json:"scopes,omitempty"`
+	Servers *ServerDiff `json:"servers,omitempty"`
+}
+
+type ScopeDiff struct {
+	Old []string `json:"old"`
+	New []string `json:"new"`
+}
+
+type ServerDiff struct {
+	Old []types.ServerSummary `json:"old"`
+	New []types.ServerSummary `json:"new"`
+}
+
+// Recommendation is an admin-confirmed note attached at approval time.
+type Recommendation struct {
+	ID            string `json:"id"`
+	Text          string `json:"text"`
+	Severity      string `json:"severity"`
+	Source        string `json:"source"`
+	AutoCheckable bool   `json:"auto_checkable"`
 }
 
 type WorkSessionAttributes struct {

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -34,11 +34,13 @@ type Adjustments struct {
 	Servers *ServerDiff `json:"servers,omitempty"`
 }
 
+// ScopeDiff holds the requested (old) and granted (new) scope lists.
 type ScopeDiff struct {
 	Old []string `json:"old"`
 	New []string `json:"new"`
 }
 
+// ServerDiff holds the requested (old) and granted (new) server lists.
 type ServerDiff struct {
 	Old []types.ServerSummary `json:"old"`
 	New []types.ServerSummary `json:"new"`

--- a/api/worksession/types.go
+++ b/api/worksession/types.go
@@ -24,8 +24,8 @@ type WorkSession struct {
 	AddedAt           time.Time             `json:"added_at"`
 	UpdatedAt         time.Time             `json:"updated_at"`
 	SudoPolicies      []SudoPolicyInline    `json:"sudo_policies"`
-	Adjustments       *Adjustments          `json:"adjustments,omitempty"`
-	Recommendations   []Recommendation      `json:"recommendations,omitempty"`
+	Adjustments       *Adjustments          `json:"adjustments"`
+	Recommendations   []Recommendation      `json:"recommendations"`
 }
 
 // Adjustments is the approver's diff; each dimension is set only when changed, nil when unchanged.

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -323,3 +323,42 @@ func TestUpdateWorkSession(t *testing.T) {
 }
 
 func newString(s string) *string { return &s }
+
+func TestWorkSessionUnmarshalAdjustmentsAndRecommendations(t *testing.T) {
+	body := []byte(`{
+		"id": "ses-1",
+		"status": "approved",
+		"adjustments": {
+			"scopes": {"old": ["command", "websh"], "new": ["command"]},
+			"servers": {
+				"old": [{"id": "srv-1", "name": "web-01"}, {"id": "srv-2", "name": "db-01"}],
+				"new": [{"id": "srv-1", "name": "web-01"}]
+			}
+		},
+		"recommendations": [
+			{"id": "r1", "text": "Rotate the key", "severity": "high", "source": "admin_added", "auto_checkable": false},
+			{"id": "r2", "text": "Prefer reload", "severity": "low", "source": "ai_suggested", "auto_checkable": true}
+		]
+	}`)
+
+	var ws WorkSession
+	assert.NoError(t, json.Unmarshal(body, &ws))
+
+	assert.NotNil(t, ws.Adjustments)
+	assert.Equal(t, []string{"command", "websh"}, ws.Adjustments.Scopes.Old)
+	assert.Equal(t, []string{"command"}, ws.Adjustments.Scopes.New)
+	assert.Equal(t, "web-01", ws.Adjustments.Servers.Old[0].Name)
+	assert.Len(t, ws.Adjustments.Servers.New, 1)
+
+	assert.Len(t, ws.Recommendations, 2)
+	assert.Equal(t, "high", ws.Recommendations[0].Severity)
+	assert.Equal(t, "Rotate the key", ws.Recommendations[0].Text)
+	assert.True(t, ws.Recommendations[1].AutoCheckable)
+}
+
+func TestWorkSessionUnmarshalNoAdjustments(t *testing.T) {
+	var ws WorkSession
+	assert.NoError(t, json.Unmarshal([]byte(`{"id":"ses-1","adjustments":null,"recommendations":[]}`), &ws))
+	assert.Nil(t, ws.Adjustments)
+	assert.Empty(t, ws.Recommendations)
+}

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -256,6 +256,7 @@ so it is recorded and scoped accordingly.`,
 				return
 			}
 			utils.CliSuccess("%s", message)
+			printSessionAdvisories(finalSession)
 			return
 		}
 
@@ -272,6 +273,7 @@ so it is recorded and scoped accordingly.`,
 			return
 		}
 		utils.CliSuccess("%s", message)
+		printSessionAdvisories(finalSession)
 	},
 }
 

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -206,6 +206,7 @@ so it is recorded and scoped accordingly.`,
 				return
 			}
 			utils.CliSuccess("%s", message)
+			printSessionAdvisories(activeSession)
 			return
 		case useDecisionSkipScheduled:
 			if !waitApproval {
@@ -214,6 +215,7 @@ so it is recorded and scoped accordingly.`,
 					return
 				}
 				utils.CliInfo("Session is scheduled to activate. Run 'alpacon work-session use %s' once active.", session.ID)
+				printSessionAdvisories(session)
 				return
 			}
 		case useDecisionErrorNeedsWait:
@@ -239,7 +241,9 @@ so it is recorded and scoped accordingly.`,
 			}
 			if utils.OutputFormat == utils.OutputFormatJSON {
 				printWorkSessionMutationJSON(newWorkSessionMutationOutput(opCreate, createSuccessMessage(session), session, nil))
+				return
 			}
+			printSessionAdvisories(session)
 			return
 		}
 

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -1,6 +1,8 @@
 package worksession
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -151,4 +153,42 @@ func TestDecideUseAction(t *testing.T) {
 			assert.Equal(t, tt.want, decideUseAction(tt.status, tt.useEnabled))
 		})
 	}
+}
+
+func TestWorkSessionCreateWaitPrintsAdvisories(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-1","name":"prod"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/work-sessions/sessions/":
+			_, _ = w.Write([]byte(`{"id":"ses-x","status":"pending","approval_request_id":"apr-1","expires_at":"2026-06-01T12:00:00Z"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/work-sessions/sessions/ses-x/":
+			_, _ = w.Write([]byte(`{
+				"id":"ses-x","status":"approved","expires_at":"2026-06-01T12:00:00Z",
+				"adjustments":{"scopes":{"old":["command","websh"],"new":["command"]}},
+				"recommendations":[{"id":"r1","text":"Rotate the key","severity":"high"}]
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	setupWorkSessionCommandConfig(t, ts.URL)
+	resetCreateCommandState(t)
+	purpose = "incident"
+	createScopes = []string{"command", "websh"}
+	createServers = []string{"prod"}
+	expiresAt = "2026-06-01T12:00:00Z"
+	waitApproval = true
+
+	_, stderr := captureWorkSessionCommandOutput(t, func() {
+		workSessionCreateCmd.Run(workSessionCreateCmd, nil)
+	})
+
+	assert.Contains(t, stderr, "approved")
+	assert.Contains(t, stderr, "Approver adjusted your request")
+	assert.Contains(t, stderr, "command, websh → command")
+	assert.Contains(t, stderr, "[HIGH] Rotate the key")
 }

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -1,6 +1,7 @@
 package worksession
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseExpiryFlag_ExpiresIn(t *testing.T) {
@@ -191,4 +193,55 @@ func TestWorkSessionCreateWaitPrintsAdvisories(t *testing.T) {
 	assert.Contains(t, stderr, "Approver adjusted your request")
 	assert.Contains(t, stderr, "command, websh → command")
 	assert.Contains(t, stderr, "[HIGH] Rotate the key")
+}
+
+func TestWorkSessionCreateWaitJSONOutputIncludesAdjustments(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-1","name":"prod"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/work-sessions/sessions/":
+			_, _ = w.Write([]byte(`{"id":"ses-x","status":"pending","approval_request_id":"apr-1","expires_at":"2026-06-01T12:00:00Z"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/work-sessions/sessions/ses-x/":
+			_, _ = w.Write([]byte(`{
+				"id":"ses-x","status":"approved","expires_at":"2026-06-01T12:00:00Z",
+				"adjustments":{"scopes":{"old":["command","websh"],"new":["command"]}},
+				"recommendations":[{"id":"r1","text":"Rotate the key","severity":"high"}]
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	setupWorkSessionCommandConfig(t, ts.URL)
+	withWorkSessionCommandJSONMode(t)
+	resetCreateCommandState(t)
+	purpose = "incident"
+	createScopes = []string{"command", "websh"}
+	createServers = []string{"prod"}
+	expiresAt = "2026-06-01T12:00:00Z"
+	waitApproval = true
+
+	stdout, _ := captureWorkSessionCommandOutput(t, func() {
+		workSessionCreateCmd.Run(workSessionCreateCmd, nil)
+	})
+
+	var got struct {
+		WorkSession struct {
+			Adjustments struct {
+				Scopes struct {
+					New []string `json:"new"`
+				} `json:"scopes"`
+			} `json:"adjustments"`
+			Recommendations []struct {
+				Severity string `json:"severity"`
+			} `json:"recommendations"`
+		} `json:"work_session"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.Equal(t, []string{"command"}, got.WorkSession.Adjustments.Scopes.New)
+	require.Len(t, got.WorkSession.Recommendations, 1)
+	assert.Equal(t, "high", got.WorkSession.Recommendations[0].Severity)
 }

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -195,6 +195,40 @@ func TestWorkSessionCreateWaitPrintsAdvisories(t *testing.T) {
 	assert.Contains(t, stderr, "[HIGH] Rotate the key")
 }
 
+func TestWorkSessionCreateAutoApprovedPrintsAdvisories(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-1","name":"prod"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/work-sessions/sessions/":
+			_, _ = w.Write([]byte(`{
+				"id":"ses-x","status":"approved","expires_at":"2026-06-01T12:00:00Z",
+				"adjustments":{"scopes":{"old":["command","websh"],"new":["command"]}},
+				"recommendations":[{"id":"r1","text":"Rotate the key","severity":"high"}]
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	setupWorkSessionCommandConfig(t, ts.URL)
+	resetCreateCommandState(t)
+	purpose = "incident"
+	createScopes = []string{"command", "websh"}
+	createServers = []string{"prod"}
+	expiresAt = "2026-06-01T12:00:00Z"
+
+	_, stderr := captureWorkSessionCommandOutput(t, func() {
+		workSessionCreateCmd.Run(workSessionCreateCmd, nil)
+	})
+
+	assert.Contains(t, stderr, "Approver adjusted your request")
+	assert.Contains(t, stderr, "command, websh → command")
+	assert.Contains(t, stderr, "[HIGH] Rotate the key")
+}
+
 func TestWorkSessionCreateWaitJSONOutputIncludesAdjustments(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/worksession/worksession_describe.go
+++ b/cmd/worksession/worksession_describe.go
@@ -1,6 +1,7 @@
 package worksession
 
 import (
+	"fmt"
 	"strings"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
@@ -79,5 +80,12 @@ var workSessionDescribeCmd = &cobra.Command{
 		}
 
 		utils.PrintTable(rows)
+
+		if block := formatAdjustments(session.Adjustments); block != "" {
+			fmt.Printf("\nAdjustments:\n%s\n", block)
+		}
+		if block := formatRecommendations(session.Recommendations); block != "" {
+			fmt.Printf("\nRecommendations:\n%s\n", block)
+		}
 	},
 }

--- a/cmd/worksession/worksession_describe_test.go
+++ b/cmd/worksession/worksession_describe_test.go
@@ -1,0 +1,36 @@
+package worksession
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkSessionDescribePrintsAdvisories(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/api/work-sessions/sessions/ses-x/" {
+			_, _ = w.Write([]byte(`{
+				"id":"ses-x","status":"approved","expires_at":"2026-06-01T12:00:00Z","added_at":"2026-05-30T00:00:00Z",
+				"adjustments":{"servers":{"old":[{"name":"web-01"},{"name":"db-01"}],"new":[{"name":"web-01"}]}},
+				"recommendations":[{"id":"r1","text":"Rotate the key","severity":"high"}]
+			}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	setupWorkSessionCommandConfig(t, ts.URL)
+
+	stdout, _ := captureWorkSessionCommandOutput(t, func() {
+		workSessionDescribeCmd.Run(workSessionDescribeCmd, []string{"ses-x"})
+	})
+
+	assert.Contains(t, stdout, "Adjustments:")
+	assert.Contains(t, stdout, "servers: web-01, db-01 → web-01")
+	assert.Contains(t, stdout, "Recommendations:")
+	assert.Contains(t, stdout, "[HIGH] Rotate the key")
+}

--- a/cmd/worksession/worksession_output.go
+++ b/cmd/worksession/worksession_output.go
@@ -79,7 +79,6 @@ func printWorkSessionMutationJSON(output workSessionMutationOutput) {
 	}
 }
 
-// formatAdjustments renders the approver's scope/server diff, or "" when there was no adjustment.
 func formatAdjustments(adj *wsapi.Adjustments) string {
 	if adj == nil {
 		return ""
@@ -96,7 +95,6 @@ func formatAdjustments(adj *wsapi.Adjustments) string {
 	return strings.Join(lines, "\n")
 }
 
-// formatRecommendations renders one "[SEVERITY] text" line per recommendation, or "" when there are none.
 func formatRecommendations(recs []wsapi.Recommendation) string {
 	if len(recs) == 0 {
 		return ""
@@ -108,7 +106,7 @@ func formatRecommendations(recs []wsapi.Recommendation) string {
 	return strings.Join(lines, "\n")
 }
 
-// printSessionAdvisories prints adjustments/recommendations; text mode only, JSON callers return earlier.
+// Text mode only — JSON callers return before reaching this.
 func printSessionAdvisories(session *wsapi.WorkSession) {
 	if block := formatAdjustments(session.Adjustments); block != "" {
 		utils.CliWarning("Approver adjusted your request:\n%s", block)

--- a/cmd/worksession/worksession_output.go
+++ b/cmd/worksession/worksession_output.go
@@ -79,8 +79,7 @@ func printWorkSessionMutationJSON(output workSessionMutationOutput) {
 	}
 }
 
-// formatAdjustments renders the approver's scope/server diff as an indented
-// multi-line block, or "" when there was no adjustment.
+// formatAdjustments renders the approver's scope/server diff, or "" when there was no adjustment.
 func formatAdjustments(adj *wsapi.Adjustments) string {
 	if adj == nil {
 		return ""
@@ -97,8 +96,7 @@ func formatAdjustments(adj *wsapi.Adjustments) string {
 	return strings.Join(lines, "\n")
 }
 
-// formatRecommendations renders approver recommendations, one "[SEVERITY] text"
-// line each in server-provided order, or "" when there are none.
+// formatRecommendations renders one "[SEVERITY] text" line per recommendation, or "" when there are none.
 func formatRecommendations(recs []wsapi.Recommendation) string {
 	if len(recs) == 0 {
 		return ""
@@ -110,9 +108,7 @@ func formatRecommendations(recs []wsapi.Recommendation) string {
 	return strings.Join(lines, "\n")
 }
 
-// printSessionAdvisories surfaces the approver's adjustments (as a warning,
-// since requested access may have been reduced) and recommendations. Text mode
-// only — JSON callers return before reaching this.
+// printSessionAdvisories prints adjustments/recommendations; text mode only, JSON callers return earlier.
 func printSessionAdvisories(session *wsapi.WorkSession) {
 	if block := formatAdjustments(session.Adjustments); block != "" {
 		utils.CliWarning("Approver adjusted your request:\n%s", block)

--- a/cmd/worksession/worksession_output.go
+++ b/cmd/worksession/worksession_output.go
@@ -110,6 +110,18 @@ func formatRecommendations(recs []wsapi.Recommendation) string {
 	return strings.Join(lines, "\n")
 }
 
+// printSessionAdvisories surfaces the approver's adjustments (as a warning,
+// since requested access may have been reduced) and recommendations. Text mode
+// only — JSON callers return before reaching this.
+func printSessionAdvisories(session *wsapi.WorkSession) {
+	if block := formatAdjustments(session.Adjustments); block != "" {
+		utils.CliWarning("Approver adjusted your request:\n%s", block)
+	}
+	if block := formatRecommendations(session.Recommendations); block != "" {
+		utils.CliInfo("Recommendations from approver:\n%s", block)
+	}
+}
+
 func joinOrNone(items []string) string {
 	if len(items) == 0 {
 		return "none"

--- a/cmd/worksession/worksession_output.go
+++ b/cmd/worksession/worksession_output.go
@@ -3,8 +3,10 @@ package worksession
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/alpacax/alpacon-cli/api/types"
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/utils"
 )
@@ -75,4 +77,53 @@ func printWorkSessionMutationJSON(output workSessionMutationOutput) {
 		// Keeps stderr structured; PrintJSONError falls back to minimal JSON if marshalling fails again.
 		utils.CliErrorEnvelopeWithExit(output.Operation, err, "Failed to marshal work-session result: %s", err)
 	}
+}
+
+// formatAdjustments renders the approver's scope/server diff as an indented
+// multi-line block, or "" when there was no adjustment.
+func formatAdjustments(adj *wsapi.Adjustments) string {
+	if adj == nil {
+		return ""
+	}
+	var lines []string
+	if adj.Scopes != nil {
+		lines = append(lines, fmt.Sprintf("  scopes:  %s → %s",
+			joinOrNone(adj.Scopes.Old), joinOrNone(adj.Scopes.New)))
+	}
+	if adj.Servers != nil {
+		lines = append(lines, fmt.Sprintf("  servers: %s → %s",
+			joinServerNames(adj.Servers.Old), joinServerNames(adj.Servers.New)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// formatRecommendations renders approver recommendations, one "[SEVERITY] text"
+// line each in server-provided order, or "" when there are none.
+func formatRecommendations(recs []wsapi.Recommendation) string {
+	if len(recs) == 0 {
+		return ""
+	}
+	lines := make([]string, len(recs))
+	for i, r := range recs {
+		lines[i] = fmt.Sprintf("  [%s] %s", strings.ToUpper(r.Severity), r.Text)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func joinOrNone(items []string) string {
+	if len(items) == 0 {
+		return "none"
+	}
+	return strings.Join(items, ", ")
+}
+
+func joinServerNames(servers []types.ServerSummary) string {
+	if len(servers) == 0 {
+		return "none"
+	}
+	names := make([]string, len(servers))
+	for i, s := range servers {
+		names[i] = s.Name
+	}
+	return strings.Join(names, ", ")
 }

--- a/cmd/worksession/worksession_output.go
+++ b/cmd/worksession/worksession_output.go
@@ -101,7 +101,11 @@ func formatRecommendations(recs []wsapi.Recommendation) string {
 	}
 	lines := make([]string, len(recs))
 	for i, r := range recs {
-		lines[i] = fmt.Sprintf("  [%s] %s", strings.ToUpper(r.Severity), r.Text)
+		sev := r.Severity
+		if sev == "" {
+			sev = "info"
+		}
+		lines[i] = fmt.Sprintf("  [%s] %s", strings.ToUpper(sev), r.Text)
 	}
 	return strings.Join(lines, "\n")
 }

--- a/cmd/worksession/worksession_output_test.go
+++ b/cmd/worksession/worksession_output_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacax/alpacon-cli/api/types"
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/config"
 	"github.com/alpacax/alpacon-cli/utils"
@@ -246,6 +247,53 @@ func TestWorkSessionExtendCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
 	assert.Equal(t, "extend", got.Operation)
 	assert.Equal(t, "ses-active", got.WorkSessionID)
 	assert.Equal(t, "2026-06-01T12:00:00Z", got.ExpiresAt)
+}
+
+func TestFormatAdjustments(t *testing.T) {
+	tests := []struct {
+		name string
+		adj  *wsapi.Adjustments
+		want string
+	}{
+		{"nil", nil, ""},
+		{
+			"scopes only",
+			&wsapi.Adjustments{Scopes: &wsapi.ScopeDiff{Old: []string{"command", "websh"}, New: []string{"command"}}},
+			"  scopes:  command, websh → command",
+		},
+		{
+			"servers only",
+			&wsapi.Adjustments{Servers: &wsapi.ServerDiff{
+				Old: []types.ServerSummary{{Name: "web-01"}, {Name: "db-01"}},
+				New: []types.ServerSummary{{Name: "web-01"}},
+			}},
+			"  servers: web-01, db-01 → web-01",
+		},
+		{
+			"both",
+			&wsapi.Adjustments{
+				Scopes:  &wsapi.ScopeDiff{Old: []string{"command"}, New: []string{}},
+				Servers: &wsapi.ServerDiff{Old: []types.ServerSummary{{Name: "web-01"}}, New: []types.ServerSummary{{Name: "web-01"}}},
+			},
+			"  scopes:  command → none\n  servers: web-01 → web-01",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatAdjustments(tt.adj))
+		})
+	}
+}
+
+func TestFormatRecommendations(t *testing.T) {
+	assert.Equal(t, "", formatRecommendations(nil))
+	assert.Equal(t, "", formatRecommendations([]wsapi.Recommendation{}))
+
+	got := formatRecommendations([]wsapi.Recommendation{
+		{Severity: "high", Text: "Rotate the key"},
+		{Severity: "low", Text: "Prefer reload"},
+	})
+	assert.Equal(t, "  [HIGH] Rotate the key\n  [LOW] Prefer reload", got)
 }
 
 func setupWorkSessionCommandConfig(t *testing.T, workspaceURL string) {

--- a/cmd/worksession/worksession_output_test.go
+++ b/cmd/worksession/worksession_output_test.go
@@ -292,8 +292,9 @@ func TestFormatRecommendations(t *testing.T) {
 	got := formatRecommendations([]wsapi.Recommendation{
 		{Severity: "high", Text: "Rotate the key"},
 		{Severity: "low", Text: "Prefer reload"},
+		{Severity: "", Text: "No severity set"},
 	})
-	assert.Equal(t, "  [HIGH] Rotate the key\n  [LOW] Prefer reload", got)
+	assert.Equal(t, "  [HIGH] Rotate the key\n  [LOW] Prefer reload\n  [INFO] No severity set", got)
 }
 
 func setupWorkSessionCommandConfig(t *testing.T, workspaceURL string) {


### PR DESCRIPTION
## Background

When a work session is approved, the approver can reduce the requested scopes/servers or attach recommendations. The server already returns this data on the work session, but the CLI's `WorkSession` struct had no matching fields, so it was silently dropped during unmarshal.

The main risk: a non-interactive caller (an AI agent running `exec`) assumes the approved session matches what it requested, then hits unexpected denials later because the actual grant was narrower.

## Changes

- `api/worksession/types.go` — add `Adjustments` (`Scopes`/`Servers` diffs, each `{Old, New}`) and `Recommendations` (`{ID, Text, Severity, Source, AutoCheckable}`) to `WorkSession`. Both are `omitempty`; `Adjustments` is a pointer so an absent diff round-trips as `nil`.
- `cmd/worksession/worksession_output.go` — add `formatAdjustments`/`formatRecommendations` to render the diff as a text block. Rendered as a separate block rather than inline in table cells, since `text/tabwriter` breaks column alignment on embedded newlines.
- `cmd/worksession/worksession_create.go` — after `--wait` approval completes (both the plain and `--use` paths), print adjustments via `utils.CliWarning` (this is the risk case) and recommendations via `utils.CliInfo`, text mode only. JSON output gets the fields automatically through the struct.
- `cmd/worksession/worksession_describe.go` — print the same blocks below the key-value table (stdout, since this is detail data, not status). `describe -o json` is unchanged — it already passes the raw server response through.

## Testing

- `api/worksession/worksession_test.go` — unmarshal cases for adjustments (scopes only / servers only / both / null) and recommendations (empty / multiple severities)
- `cmd/worksession/worksession_output_test.go` — `formatAdjustments`/`formatRecommendations` unit tests (nil / empty / populated)
- `cmd/worksession/worksession_create_test.go` — advisories print in `--wait` text mode; `--output json` includes the adjustments field
- `cmd/worksession/worksession_describe_test.go` — advisories print below the describe table

`go test -race -v ./...` and `go vet ./...` pass on the branch.

## Verification

Ran end-to-end against a real workspace: requested `webftp` scope on one server, and the approver expanded it to add the `editor` scope and a second server before approving.

`work-session create --wait` (text mode, stderr):

```
Success: Work session created: a0d24f3e-7342-4ae7-8224-3c5fdae4b226 (status: pending, approval request: b864f6b1-3b27-4c40-8c18-ce0a9fac079c)
Info: Waiting for approval... (attempt 1/30)
Info: Waiting for approval... (attempt 2/30)
Success: Work session a0d24f3e-7342-4ae7-8224-3c5fdae4b226 approved.
Warning: Approver adjusted your request:
  scopes:  webftp → webftp, editor
  servers: test-disable-connect-e3649d → test-disable-connect-e3649d, web-editor
```

`work-session describe` (text mode, stdout):

```
Adjustments:
  scopes:  webftp → webftp, editor
  servers: test-disable-connect-e3649d → test-disable-connect-e3649d, web-editor
```

`work-session describe --output json` (excerpt):

```json
"adjustments": {
  "scopes": {
    "old": ["webftp"],
    "new": ["webftp", "editor"]
  },
  "servers": {
    "old": [{"id": "7528558d-668e-4a8b-b2e3-868786762c96", "name": "test-disable-connect-e3649d", "os": "ubuntu", "is_connected": true, "is_deleted": false}],
    "new": [
      {"id": "7528558d-668e-4a8b-b2e3-868786762c96", "name": "test-disable-connect-e3649d", "os": "ubuntu", "is_connected": true, "is_deleted": false},
      {"id": "7e6cf167-eb9d-4bb5-b38e-2048d695f1fa", "name": "web-editor", "os": "ubuntu", "is_connected": true, "is_deleted": false}
    ]
  }
}
```

`recommendations` was `[]` on this session (approver left none), which correctly renders no block in either mode.

Closes #214
