### PR TITLE
ci: enforce Go formatting, add govulncheck, and bump Go to 1.25.11

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -31,6 +31,11 @@ jobs:
       - name: Allow Go toolchain auto-download
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
+      - name: Verify go.mod and go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
       - name: Build
         run: go build -v .
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,3 +33,16 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Allow Go toolchain auto-download
+        run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: '1.25.x'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,3 +17,11 @@ linters:
   exclusions:
     paths:
       - docs
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    paths:
+      - docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ _ = json.NewEncoder(w).Encode(resp)
 
 ## Important notes
 
-- **Go version**: 1.25.10 (specified in go.mod)
+- **Go version**: 1.25.11 (specified in go.mod)
 - **Linter**: golangci-lint v2 with errcheck, govet, ineffassign, staticcheck, unused (see `.golangci.yml`)
 - **Config file**: `~/.alpacon/config.json` (dir `0700`, file `0600`)
 - **Alias**: `alpacon` can also be invoked as `ac`

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -54,18 +54,18 @@ type sudoMFAEvent struct {
 // http.Client is concurrency-safe. Token refresh and grant verification are
 // serialized by mfaMu so only one MFA flow runs at a time.
 type SudoListener struct {
-	ac           *client.AlpaconClient
-	serverName   string
-	wsURL        string
-	wsHeader     http.Header
-	done         chan struct{}
-	stopped      chan struct{} // closed when listenLoop exits
-	connected    chan struct{} // closed after first successful WebSocket connection
-	connectOnce  sync.Once
-	closeOnce    sync.Once
-	mu           sync.Mutex
-	conn         *websocket.Conn
-	mfaMu        sync.Mutex // serializes handleSudoMFA so only one MFA flow runs at a time
+	ac          *client.AlpaconClient
+	serverName  string
+	wsURL       string
+	wsHeader    http.Header
+	done        chan struct{}
+	stopped     chan struct{} // closed when listenLoop exits
+	connected   chan struct{} // closed after first successful WebSocket connection
+	connectOnce sync.Once
+	closeOnce   sync.Once
+	mu          sync.Mutex
+	conn        *websocket.Conn
+	mfaMu       sync.Mutex // serializes handleSudoMFA so only one MFA flow runs at a time
 }
 
 // NewSudoListener creates a SudoListener but does not connect yet.

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/approval/approval_describe.go
+++ b/cmd/approval/approval_describe.go
@@ -15,7 +15,7 @@ type describeRow struct {
 var approvalDescribeCmd = &cobra.Command{
 	Use:     "describe REQUEST_ID",
 	Aliases: []string{"desc"},
-	Short: "Show details of an approval request",
+	Short:   "Show details of an approval request",
 	Long: `Show all fields of an approval request.
 
 Use --output json to see the full raw response including nested

--- a/cmd/approval/approval_list.go
+++ b/cmd/approval/approval_list.go
@@ -92,4 +92,4 @@ func validateEnumFlag(flag, value string, valid []string) error {
 }
 
 func validateStatusFilter(s string) error { return validateEnumFlag("status", s, validStatuses) }
-func validateTypeFilter(s string) error    { return validateEnumFlag("type", s, validTypes) }
+func validateTypeFilter(s string) error   { return validateEnumFlag("type", s, validTypes) }

--- a/cmd/authority/authority.go
+++ b/cmd/authority/authority.go
@@ -2,6 +2,7 @@ package authority
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cert/cert.go
+++ b/cmd/cert/cert.go
@@ -2,6 +2,7 @@ package cert
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/csr/csr.go
+++ b/cmd/csr/csr.go
@@ -2,6 +2,7 @@ package csr
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/iam/group.go
+++ b/cmd/iam/group.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/iam/member.go
+++ b/cmd/iam/member.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/iam/user.go
+++ b/cmd/iam/user.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/note/note.go
+++ b/cmd/note/note.go
@@ -2,6 +2,7 @@ package note
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/packages/packages.go
+++ b/cmd/packages/packages.go
@@ -2,6 +2,7 @@ package packages
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/packages/python.go
+++ b/cmd/packages/python.go
@@ -2,6 +2,7 @@ package packages
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/packages/system.go
+++ b/cmd/packages/system.go
@@ -2,6 +2,7 @@ package packages
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/revoke/revoke.go
+++ b/cmd/revoke/revoke.go
@@ -2,6 +2,7 @@ package revoke
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/token/token.go
+++ b/cmd/token/token.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alpacax/alpacon-cli
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Background

The lint workflow ran golangci-lint with a correctness-only linter set (errcheck, govet, ineffassign, staticcheck, unused) and no formatters, so gofmt/goimports drift passed CI unnoticed. CI also had no vulnerability scanning and no guard against an untidy go.mod/go.sum. This PR closes those three gaps and bumps the Go toolchain to the patch release that fixes the vulnerabilities govulncheck surfaces.

## Changes

Split into three commits by concern:

1. build(go): bump the go directive from 1.25.10 to 1.25.11. This pulls in the standard library fixes for GO-2026-5039 (net/textproto header escaping) and GO-2026-5037 (crypto/x509 hostname parsing), both reachable from the websh WebSocket dial path. CLAUDE.md's version reference is synced.
2. style(lint): add a formatters section to .golangci.yml enabling gofmt and goimports, and reformat the 18 files already out of compliance. The reformatting is struct field alignment and stdlib/third-party import grouping only, with no behavioral changes. goimports local-prefixes grouping was intentionally left off because it would rewrite import blocks across roughly 190 files for a purely cosmetic regrouping.
3. ci: add a govulncheck job to lint.yaml and a go mod tidy verification step to build-and-test.yaml.

## Safety

govulncheck is placed in lint.yaml, not build-and-test.yaml. release.yaml calls build-and-test.yaml via workflow_call, so putting the scan there would let a newly disclosed standard library or transitive CVE block an urgent release. Keeping it in the push/PR-only lint workflow catches vulnerabilities during development without gating the release path.

## Tests

Verified locally under go1.25.11 (the version CI resolves via setup-go's 1.25.x):

- go build and go test -race ./... pass.
- golangci-lint run ./... reports 0 issues.
- golangci-lint config verify passes and both workflow YAML files parse.
- govulncheck ./... reports zero reachable vulnerabilities (2 findings under 1.25.10, resolved by the bump).
- go mod tidy produces no changes.

## Checklist

- [x] Formatting enforced and existing violations fixed
- [x] govulncheck passes under the bumped toolchain
- [x] go.mod/go.sum tidy
- [x] No product code behavior changed