### PR TITLE
Warn when nesting powershell -Command against Windows targets

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -94,7 +94,7 @@ func getServerByName(ac *client.AlpaconClient, serverName string) (ServerDetails
 		return ServerDetails{}, err
 	}
 
-	if response.Count == 0 {
+	if len(response.Results) == 0 {
 		return ServerDetails{}, errors.New("no server found with the given name")
 	}
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -79,26 +79,42 @@ func DeleteServer(ac *client.AlpaconClient, serverName string) error {
 	return nil
 }
 
-func GetServerIDByName(ac *client.AlpaconClient, serverName string) (string, error) {
+func getServerByName(ac *client.AlpaconClient, serverName string) (ServerDetails, error) {
 	params := map[string]string{
 		"name": serverName,
 	}
 	body, err := ac.SendGetRequest(utils.BuildURL(serverURL, "", params))
 	if err != nil {
-		return "", err
+		return ServerDetails{}, err
 	}
 
 	var response api.ListResponse[ServerDetails]
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		return "", err
+		return ServerDetails{}, err
 	}
 
 	if response.Count == 0 {
-		return "", errors.New("no server found with the given name")
+		return ServerDetails{}, errors.New("no server found with the given name")
 	}
 
-	return response.Results[0].ID, nil
+	return response.Results[0], nil
+}
+
+func GetServerIDByName(ac *client.AlpaconClient, serverName string) (string, error) {
+	srv, err := getServerByName(ac, serverName)
+	if err != nil {
+		return "", err
+	}
+	return srv.ID, nil
+}
+
+func GetServerOSByName(ac *client.AlpaconClient, serverName string) (string, error) {
+	srv, err := getServerByName(ac, serverName)
+	if err != nil {
+		return "", err
+	}
+	return srv.OSName, nil
 }
 
 // ResolveServerNames converts a list of server names to their UUIDs via sequential API calls (one per name).

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -137,6 +137,52 @@ func TestGetServerIDByName(t *testing.T) {
 	}
 }
 
+func TestGetServerOSByName(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverName string
+		count      int
+		osName     string
+		wantOS     string
+		wantErr    bool
+	}{
+		{"windows", "win-server", 1, "Windows", "Windows", false},
+		{"linux", "lin-server", 1, "Ubuntu", "Ubuntu", false},
+		{"not found", "ghost", 0, "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var results []ServerDetails
+				if tt.count > 0 {
+					results = append(results, ServerDetails{ID: "id", Name: tt.serverName, OSName: tt.osName})
+				}
+				resp := api.ListResponse[ServerDetails]{Count: tt.count, Results: results}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			os, err := GetServerOSByName(ac, tt.serverName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if os != tt.wantOS {
+					t.Errorf("expected os %q, got %q", tt.wantOS, os)
+				}
+			}
+		})
+	}
+}
+
 func TestCreateRegistrationToken(t *testing.T) {
 	want := RegistrationTokenCreatedResponse{
 		ID:   "token-uuid-abc",

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alpacax/alpacon-cli/api/event"
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/api/mfa"
+	"github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/cmd/worksession"
 	"github.com/alpacax/alpacon-cli/config"
@@ -112,6 +113,13 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 			return
+		}
+
+		// Best-effort hint; skips silently on lookup failure and never blocks execution.
+		if osName, osErr := server.GetServerOSByName(alpaconClient, parsed.Server); osErr == nil {
+			if warning := powershellNestingWarning(osName, parsed.Command); warning != "" {
+				utils.CliWarning("%s", warning)
+			}
 		}
 
 		env := make(map[string]string)

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -115,10 +115,14 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			return
 		}
 
-		// Best-effort hint; skips silently on lookup failure and never blocks execution.
-		if osName, osErr := server.GetServerOSByName(alpaconClient, parsed.Server); osErr == nil {
-			if warning := powershellNestingWarning(osName, parsed.Command); warning != "" {
-				utils.CliWarning("%s", warning)
+		// Best-effort hint; the OS lookup runs only when the command actually re-nests
+		// PowerShell, so the common path skips the extra API call. Skips silently on
+		// lookup failure and never blocks execution.
+		if commandNestsPowershell(parsed.Command) {
+			if osName, osErr := server.GetServerOSByName(alpaconClient, parsed.Server); osErr == nil {
+				if warning := powershellNestingWarning(osName, parsed.Command); warning != "" {
+					utils.CliWarning("%s", warning)
+				}
 			}
 		}
 

--- a/cmd/exec/powershell_warn_test.go
+++ b/cmd/exec/powershell_warn_test.go
@@ -1,0 +1,96 @@
+package exec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPowershellNestingWarning(t *testing.T) {
+	tests := []struct {
+		name     string
+		osName   string
+		command  string
+		wantWarn bool
+	}{
+		{
+			name:     "windows nested powershell -Command warns",
+			osName:   "Windows Server 2019",
+			command:  `powershell -Command 'Write-Output "a|b"'`,
+			wantWarn: true,
+		},
+		{
+			name:     "powershell.exe with -NoProfile then -Command warns",
+			osName:   "Windows",
+			command:  `powershell.exe -NoProfile -Command 'Write-Output "a"'`,
+			wantWarn: true,
+		},
+		{
+			name:     "pwsh -c warns",
+			osName:   "windows",
+			command:  `pwsh -c 'Get-Service'`,
+			wantWarn: true,
+		},
+		{
+			name:     "pwsh.exe -Command warns",
+			osName:   "Windows 11",
+			command:  `pwsh.exe -Command 'Get-Service'`,
+			wantWarn: true,
+		},
+		{
+			name:     "case-insensitive command and flag",
+			osName:   "Windows",
+			command:  `POWERSHELL -COMMAND 'Get-Service'`,
+			wantWarn: true,
+		},
+		{
+			name:     "no powershell prefix does not warn",
+			osName:   "Windows",
+			command:  `Get-Service | Where-Object Name -match "a|b"`,
+			wantWarn: false,
+		},
+		{
+			name:     "powershell without -Command does not warn",
+			osName:   "Windows",
+			command:  `powershell script.ps1`,
+			wantWarn: false,
+		},
+		{
+			name:     "non-windows does not warn",
+			osName:   "Ubuntu 22.04",
+			command:  `powershell -Command 'Get-Service'`,
+			wantWarn: false,
+		},
+		{
+			name:     "empty os does not warn",
+			osName:   "",
+			command:  `powershell -Command 'Get-Service'`,
+			wantWarn: false,
+		},
+		{
+			name:     "empty command does not warn",
+			osName:   "Windows",
+			command:  ``,
+			wantWarn: false,
+		},
+		{
+			name:     "powershell substring in real command does not warn",
+			osName:   "Windows",
+			command:  `Get-Item C:\powershell\notes.txt`,
+			wantWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := powershellNestingWarning(tt.osName, tt.command)
+			if tt.wantWarn {
+				assert.NotEmpty(t, got)
+				assert.True(t, strings.Contains(got, "PowerShell"), "warning should mention PowerShell")
+			} else {
+				assert.Empty(t, got)
+			}
+		})
+	}
+}

--- a/cmd/exec/powershell_warn_test.go
+++ b/cmd/exec/powershell_warn_test.go
@@ -80,6 +80,12 @@ func TestPowershellNestingWarning(t *testing.T) {
 			command:  `Get-Item C:\powershell\notes.txt`,
 			wantWarn: false,
 		},
+		{
+			name:     "-c as script argument does not warn",
+			osName:   "Windows",
+			command:  `powershell script.ps1 -c foo`,
+			wantWarn: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -109,6 +115,7 @@ func TestCommandNestsPowershell(t *testing.T) {
 		{"powershell without -Command", `powershell script.ps1`, false},
 		{"empty command", ``, false},
 		{"powershell substring in path", `Get-Item C:\powershell\notes.txt`, false},
+		{"-c as script argument after script path", `powershell script.ps1 -c foo`, false},
 	}
 
 	for _, tt := range tests {

--- a/cmd/exec/powershell_warn_test.go
+++ b/cmd/exec/powershell_warn_test.go
@@ -86,6 +86,12 @@ func TestPowershellNestingWarning(t *testing.T) {
 			command:  `powershell script.ps1 -c foo`,
 			wantWarn: false,
 		},
+		{
+			name:     "value-taking flag before -Command warns",
+			osName:   "Windows",
+			command:  `powershell -ExecutionPolicy Bypass -Command 'Get-Service'`,
+			wantWarn: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,6 +122,8 @@ func TestCommandNestsPowershell(t *testing.T) {
 		{"empty command", ``, false},
 		{"powershell substring in path", `Get-Item C:\powershell\notes.txt`, false},
 		{"-c as script argument after script path", `powershell script.ps1 -c foo`, false},
+		{"value-taking flag before -Command", `powershell -ExecutionPolicy Bypass -Command 'x'`, true},
+		{"switch flag before script path", `powershell -NoProfile script.ps1 -c foo`, false},
 	}
 
 	for _, tt := range tests {

--- a/cmd/exec/powershell_warn_test.go
+++ b/cmd/exec/powershell_warn_test.go
@@ -94,3 +94,26 @@ func TestPowershellNestingWarning(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandNestsPowershell(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"powershell -Command", `powershell -Command 'Get-Service'`, true},
+		{"powershell.exe -NoProfile -Command", `powershell.exe -NoProfile -Command 'x'`, true},
+		{"pwsh -c", `pwsh -c 'x'`, true},
+		{"case-insensitive", `POWERSHELL -COMMAND 'x'`, true},
+		{"no powershell prefix", `Get-Service | Where-Object Name -match "a|b"`, false},
+		{"powershell without -Command", `powershell script.ps1`, false},
+		{"empty command", ``, false},
+		{"powershell substring in path", `Get-Item C:\powershell\notes.txt`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, commandNestsPowershell(tt.command))
+		})
+	}
+}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -101,7 +101,12 @@ func commandNestsPowershell(command string) bool {
 		return false
 	}
 
+	// Scan only the leading flags; stop at the first positional (typically a
+	// script path), so a `-c` passed as that script's own argument isn't misread.
 	for _, f := range fields[1:] {
+		if !strings.HasPrefix(f, "-") {
+			break
+		}
 		if lf := strings.ToLower(f); lf == "-command" || lf == "-c" {
 			return true
 		}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -86,6 +86,24 @@ func sudoDenialHint(output string) string {
 	return ""
 }
 
+// powershellValueFlags are PowerShell CLI options that consume the next token as
+// their value (e.g. -ExecutionPolicy Bypass), so that token must be skipped when
+// scanning—otherwise it reads as the script path and cuts the scan short before
+// a trailing -Command. Switch flags (-NoProfile, -NonInteractive) are absent by
+// design: they take no value. Names are lowercase for case-insensitive lookup.
+var powershellValueFlags = map[string]bool{
+	"-version": true, "-v": true,
+	"-configurationname": true,
+	"-custompipename":    true,
+	"-executionpolicy":   true, "-ex": true, "-ep": true,
+	"-inputformat": true, "-inp": true, "-if": true,
+	"-outputformat": true, "-of": true,
+	"-settingsfile": true,
+	"-windowstyle":  true, "-w": true,
+	"-workingdirectory": true, "-wd": true,
+	"-psconsolefile": true,
+}
+
 // commandNestsPowershell reports whether command re-invokes PowerShell with an
 // inline script (-Command/-c)—a cheap, OS-independent pre-check callers use to
 // skip the server OS lookup on the common non-nested path.
@@ -101,12 +119,16 @@ func commandNestsPowershell(command string) bool {
 		return false
 	}
 
-	for _, f := range fields[1:] {
-		if !strings.HasPrefix(f, "-") {
-			break
-		}
-		if lf := strings.ToLower(f); lf == "-command" || lf == "-c" {
+	for i := 1; i < len(fields); i++ {
+		lf := strings.ToLower(fields[i])
+		if lf == "-command" || lf == "-c" {
 			return true
+		}
+		if !strings.HasPrefix(lf, "-") {
+			break // script-path positional; the rest are its own arguments
+		}
+		if powershellValueFlags[lf] {
+			i++ // skip the flag's value so it isn't read as the script path
 		}
 	}
 	return false

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -86,6 +86,34 @@ func sudoDenialHint(output string) string {
 	return ""
 }
 
+// powershellNestingWarning flags redundant `powershell -Command` nesting on Windows (drops embedded quotes on WinPS 5.1); returns "" when inapplicable.
+func powershellNestingWarning(osName, command string) string {
+	if !strings.Contains(strings.ToLower(osName), "windows") {
+		return ""
+	}
+
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	switch strings.ToLower(fields[0]) {
+	case "powershell", "powershell.exe", "pwsh", "pwsh.exe":
+	default:
+		return ""
+	}
+
+	for _, f := range fields[1:] {
+		if lf := strings.ToLower(f); lf == "-command" || lf == "-c" {
+			return "the remote shell is already PowerShell. Nesting 'powershell -Command' can drop " +
+				"embedded double quotes on Windows PowerShell 5.1. Pass the whole script as a single " +
+				"quoted argument instead:\n" +
+				`  alpacon exec <server> -- 'Get-Service | Where-Object DisplayName -match "azure|batch"'`
+		}
+	}
+	return ""
+}
+
 // hasSudoPresenceDenial reports whether output carries the non-interactive sudo
 // presence denial (SUDO_PRESENCE_REQUIRED), the only denial the CLI can resolve
 // in-flow via an MFA step-up.

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -86,32 +86,41 @@ func sudoDenialHint(output string) string {
 	return ""
 }
 
-// powershellNestingWarning flags redundant `powershell -Command` nesting on Windows (drops embedded quotes on WinPS 5.1); returns "" when inapplicable.
-func powershellNestingWarning(osName, command string) string {
-	if !strings.Contains(strings.ToLower(osName), "windows") {
-		return ""
-	}
-
+// commandNestsPowershell reports whether command re-invokes PowerShell with an
+// inline script (-Command/-c) — a cheap, OS-independent pre-check callers use to
+// skip the server OS lookup on the common non-nested path.
+func commandNestsPowershell(command string) bool {
 	fields := strings.Fields(command)
 	if len(fields) == 0 {
-		return ""
+		return false
 	}
 
 	switch strings.ToLower(fields[0]) {
 	case "powershell", "powershell.exe", "pwsh", "pwsh.exe":
 	default:
-		return ""
+		return false
 	}
 
 	for _, f := range fields[1:] {
 		if lf := strings.ToLower(f); lf == "-command" || lf == "-c" {
-			return "the remote shell is already PowerShell. Nesting 'powershell -Command' can drop " +
-				"embedded double quotes on Windows PowerShell 5.1. Pass the whole script as a single " +
-				"quoted argument instead:\n" +
-				`  alpacon exec <server> -- 'Get-Service | Where-Object DisplayName -match "azure|batch"'`
+			return true
 		}
 	}
-	return ""
+	return false
+}
+
+// powershellNestingWarning flags redundant `powershell -Command` nesting on Windows (drops embedded quotes on WinPS 5.1); returns "" when inapplicable.
+func powershellNestingWarning(osName, command string) string {
+	if !strings.Contains(strings.ToLower(osName), "windows") {
+		return ""
+	}
+	if !commandNestsPowershell(command) {
+		return ""
+	}
+	return "the remote shell is already PowerShell. Nesting 'powershell -Command' can drop " +
+		"embedded double quotes on Windows PowerShell 5.1. Pass the whole script as a single " +
+		"quoted argument instead:\n" +
+		`  alpacon exec <server> -- 'Get-Service | Where-Object DisplayName -match "azure|batch"'`
 }
 
 // hasSudoPresenceDenial reports whether output carries the non-interactive sudo

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -87,7 +87,7 @@ func sudoDenialHint(output string) string {
 }
 
 // commandNestsPowershell reports whether command re-invokes PowerShell with an
-// inline script (-Command/-c) — a cheap, OS-independent pre-check callers use to
+// inline script (-Command/-c)—a cheap, OS-independent pre-check callers use to
 // skip the server OS lookup on the common non-nested path.
 func commandNestsPowershell(command string) bool {
 	fields := strings.Fields(command)
@@ -117,7 +117,7 @@ func powershellNestingWarning(osName, command string) string {
 	if !commandNestsPowershell(command) {
 		return ""
 	}
-	return "the remote shell is already PowerShell. Nesting 'powershell -Command' can drop " +
+	return "The remote shell is already PowerShell. Nesting 'powershell -Command' can drop " +
 		"embedded double quotes on Windows PowerShell 5.1. Pass the whole script as a single " +
 		"quoted argument instead:\n" +
 		`  alpacon exec <server> -- 'Get-Service | Where-Object DisplayName -match "azure|batch"'`

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -101,8 +101,6 @@ func commandNestsPowershell(command string) bool {
 		return false
 	}
 
-	// Scan only the leading flags; stop at the first positional (typically a
-	// script path), so a `-c` passed as that script's own argument isn't misread.
 	for _, f := range fields[1:] {
 		if !strings.HasPrefix(f, "-") {
 			break


### PR DESCRIPTION
## Background

On Windows servers, Alpamon already runs each command inside a PowerShell wrapper. So when a user re-wraps their command in `powershell -Command` again—as in `alpacon exec <windows-server> -- powershell -Command '...'`—the nesting is not only redundant, it also triggers a Windows PowerShell 5.1 limitation: it fails to escape inner double quotes when invoking native commands, breaking commands like `-match "a|b"` or `@{N="Hash";...}` (alpacax/alpamon#342).

Passing the whole script as a single quoted argument works correctly.

## What changed

Before submitting the command, `exec` prints a hint to stderr when both of the following hold:

- The target server OS is Windows
- The first token after `--` is `powershell`/`powershell.exe`/`pwsh`/`pwsh.exe`, followed by `-Command` or `-c` (all case-insensitive)

The decision logic is isolated in a pure function `powershellNestingWarning(osName, command)` and placed in `cmd/exec/run.go`, matching the package convention for hint helpers (`sudoDenialHint`).

OS information is looked up via `GetServerOSByName`, added to `api/server`. A `getServerByName` helper was extracted so it shares the lookup with the existing `GetServerIDByName`. The existing lookup already fetched the full `ServerDetails` but used only the ID and discarded the rest.

## Safety

- The hint is best-effort. If the OS lookup fails, it is silently skipped and never blocks command execution.
- Prefixes are not stripped automatically. Flags like `-NoProfile` and `-ExecutionPolicy` would lose their meaning, so we only surface a warning and a hint.
- The warning message is a static string, printed via `utils.CliWarning("%s", warning)`, so user input is never interpreted as a format string.

## Removal condition

This is a temporary client-side workaround for the Windows PowerShell 5.1 quoting limitation. The real fix belongs in Alpamon (alpacax/alpamon#342). Once every Windows-supporting Alpamon release in the field carries that fix, this warning becomes dead weight and should be removed—delete `commandNestsPowershell`/`powershellNestingWarning` in `cmd/exec/run.go`, the OS lookup call in `cmd/exec/exec.go`, and their tests. Track the minimum patched Alpamon version before removing.

## Note

The issue described reusing the OS information from a server lookup that `exec` already performs, but in practice `exec` does not look up the OS directly—it only calls `GetServerIDByName` inside `SubmitCommand`. So the OS lookup for the hint was added as a separate best-effort call. It is one bounded extra GET on the interactive path; eliminating it would require threading the serverID through the entire `SubmitCommand`/streaming/retry path, which is invasive, so this is an accepted cost.

## Tests

- 11 unit-test cases for `powershellNestingWarning` (all path combinations, including full-path/abbreviated non-detection boundaries)
- 3 unit-test cases for `GetServerOSByName` (windows/linux/not-found)
- `go test -race ./...` fully passing, `golangci-lint run` with 0 issues

## Manual verification

Verified end-to-end against a real Windows server (`test-win-7c09b9`).

- `alpacon exec test-win-7c09b9 -- powershell -Command 'Get-Service'` printed the nesting warning on stderr before submitting the command, as expected.
- The recommended non-nested form `alpacon exec test-win-7c09b9 -- 'Get-Service | Where-Object ...'` printed no warning.

Both invocations then failed with `server_username_groupname_invalid` because no execution user was passed—that is unrelated to this change. The warning fires right after the Windows OS lookup and before command submission, so it surfaces regardless of the later execution outcome.

Closes #248

