### PR TITLE
docs(readme): fix stale work-session and group member commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,8 @@ $ alpacon work-session ls --user all --status all  # all sessions
 $ alpacon work-session current
 $ alpacon work-session use <session-id>          # set active session
 $ alpacon work-session use --unset
-$ alpacon work-session approve <session-id>      # superuser
-$ alpacon work-session reject <session-id>       # superuser
 $ alpacon work-session revoke <session-id>       # superuser
+# Approving/rejecting a session happens in the Alpacon console (web), not the CLI.
 ```
 
 Override the active session per command with `--work-session <id>` or `ALPACON_WORK_SESSION=<id>`. Resolution order: `--work-session` flag > env var > active session.
@@ -184,8 +183,8 @@ $ alpacon user ls
 $ alpacon user describe <username>
 $ alpacon user create / update / rm
 $ alpacon group ls
-$ alpacon group member add --group <group> --member <user> --role <role>
-$ alpacon group member rm --group <group> --member <user>
+$ alpacon group member add --group <group> -u <user> --role <role>
+$ alpacon group member rm --group <group> -u <user>
 ```
 
 ### API tokens


### PR DESCRIPTION
## Background

Two spots in the README no longer matched the CLI's actual behavior.

The work-sessions command block listed `work-session approve/reject <session-id>` as working superuser commands, but since ADR 0015 (#221) both are stubs. Running either prints a message saying approval must happen in the Alpacon console (web) and that the CLI is an execution/request surface only, then exits non-zero (`cmd/worksession/worksession_approve.go`, `worksession_reject.go`). The README's own "Exit codes" section already describes approval as out of band, so the document contradicted itself.

The identity block documented `group member add/rm --group <g> --member <user>`, but the real flag is `-u`/`--user` (`cmd/iam/member_add.go:42`, `member_delete.go:46`). Passing `--member` fails with `unknown flag`.

## Changes

- Removed the `approve`/`reject` lines from the work-sessions block and replaced them with a one-line note that approval/rejection happens in the Alpacon console. `revoke` still works from the CLI, so it stays.
- Fixed the group member examples from `--member <user>` to `-u <user>` (both add and rm).

## Scope checked

Cross-checked every command and flag in the README against the actual cobra definitions. The rest — `websh --share`/`join`, the `token acl` flags, `token create`, `exec --env`, `log --tail`, and exit code `4` (`ExitCodePendingApproval` in `utils/error.go`) — all match the code. No stale entries beyond the two above.

## Testing

Docs-only change; no build or test impact.

Closes #255