### PR TITLE
feat(cli): add work-session cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ What each refusal code means and what to do next:
 | `error_code` | Meaning | Next |
 |---|---|---|
 | `work_session_required` | no session selected for this shell | `work-session create --use` or `work-session use <ID>` |
-| `work_session_not_active` | session not active (pending, approved, completed, or revoked) | if pending or approved, wait; otherwise create or reuse a session |
+| `work_session_not_active` | session not active (pending, approved, completed, revoked, or cancelled) | if pending or approved, wait; otherwise create or reuse a session |
 | `work_session_expired` | session has expired | `work-session extend <ID>` or create a new one |
 | `work_session_scope_not_allowed` | operation not in session scopes | create a session with the right `--scope` |
 | `work_session_server_not_allowed` | target server not in session | create a session with the right `--server` |

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ $ alpacon work-session use --unset
 $ alpacon work-session approve <session-id>      # superuser
 $ alpacon work-session reject <session-id>       # superuser
 $ alpacon work-session revoke <session-id>       # superuser
+$ alpacon work-session cancel <session-id>       # requester withdraws own pending request
 ```
 
 Override the active session per command with `--work-session <id>` or `ALPACON_WORK_SESSION=<id>`. Resolution order: `--work-session` flag > env var > active session.

--- a/api/worksession/worksession.go
+++ b/api/worksession/worksession.go
@@ -124,6 +124,12 @@ func RevokeWorkSession(ac *client.AlpaconClient, id string) error {
 	return err
 }
 
+// CancelWorkSession withdraws the requester's own pending session; the server restricts it to the creator/superuser and rejects non-pending sessions (unlike superuser-only RevokeWorkSession).
+func CancelWorkSession(ac *client.AlpaconClient, id string) error {
+	_, err := ac.SendPostRequest(utils.BuildURL(workSessionURL, path.Join(id, "cancel"), nil), struct{}{})
+	return err
+}
+
 func GetWorkSessionRaw(ac *client.AlpaconClient, id string) ([]byte, error) {
 	return ac.SendGetRequest(utils.BuildURL(workSessionURL, id, nil))
 }

--- a/api/worksession/worksession_test.go
+++ b/api/worksession/worksession_test.go
@@ -219,6 +219,19 @@ func TestRevokeWorkSession(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestCancelWorkSession(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "ses-abc/cancel/"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkSession{ID: "ses-abc", Status: "cancelled"})
+	}))
+	defer ts.Close()
+
+	err := CancelWorkSession(newTestClient(ts), "ses-abc")
+	assert.NoError(t, err)
+}
+
 func TestApproveWorkSession_NoAdjustments(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -47,7 +47,7 @@ Gated operations (require an active WorkSession under interactive auth):
 
 Bypass: Token auth (API token or Service token) skips the requirement.
 
-Lifecycle:  pending → approved → active → complete | expired | revoked
+Lifecycle:  pending → approved → active → complete | expired | revoked | cancelled
 
 Error codes returned when a session check fails:
   work_session_required           no session selected for this shell

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -9,6 +9,7 @@ import (
 // Operation identifiers carried in JSON outputs: success "operation" and error context.operation.
 const (
 	opActivate  = "activate"
+	opCancel    = "cancel"
 	opComplete  = "complete"
 	opCreate    = "create"
 	opCurrent   = "current"
@@ -62,7 +63,7 @@ Run 'alpacon whoami' to check your WorkSession requirement and active session.`,
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session update', 'alpacon work-session approve', 'alpacon work-session reject', 'alpacon work-session revoke', 'alpacon work-session timeline', or 'alpacon work-session recording'. Run 'alpacon work-session --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon work-session ls', 'alpacon work-session create', 'alpacon work-session describe', 'alpacon work-session use', 'alpacon work-session current', 'alpacon work-session activate', 'alpacon work-session complete', 'alpacon work-session extend', 'alpacon work-session update', 'alpacon work-session approve', 'alpacon work-session reject', 'alpacon work-session revoke', 'alpacon work-session cancel', 'alpacon work-session timeline', or 'alpacon work-session recording'. Run 'alpacon work-session --help' for more information")
 	},
 }
 
@@ -81,4 +82,5 @@ func init() {
 	WorkSessionCmd.AddCommand(workSessionApproveCmd)
 	WorkSessionCmd.AddCommand(workSessionRejectCmd)
 	WorkSessionCmd.AddCommand(workSessionRevokeCmd)
+	WorkSessionCmd.AddCommand(workSessionCancelCmd)
 }

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -47,7 +47,7 @@ Gated operations (require an active WorkSession under interactive auth):
 
 Bypass: Token auth (API token or Service token) skips the requirement.
 
-Lifecycle:  pending → approved → active → complete | expired | revoked | cancelled
+Lifecycle:  pending → approved → active → complete | expired | revoked  (pending only → rejected | cancelled)
 
 Error codes returned when a session check fails:
   work_session_required           no session selected for this shell

--- a/cmd/worksession/worksession.go
+++ b/cmd/worksession/worksession.go
@@ -51,7 +51,7 @@ Lifecycle:  pending → approved → active → complete | expired | revoked | c
 
 Error codes returned when a session check fails:
   work_session_required           no session selected for this shell
-  work_session_not_active         session not active (pending, approved, completed, or revoked)
+  work_session_not_active         session not active (pending, approved, completed, revoked, or cancelled)
   work_session_expired            session has expired
   work_session_scope_not_allowed  operation not in session scopes
   work_session_server_not_allowed target server not in session

--- a/cmd/worksession/worksession_cancel.go
+++ b/cmd/worksession/worksession_cancel.go
@@ -23,6 +23,11 @@ var workSessionCancelCmd = &cobra.Command{
 			utils.CliErrorEnvelopeWithExit(opCancel, err, "Failed to cancel work session: %s.", err)
 		}
 
-		utils.CliSuccess("Work session %s cancelled.", args[0])
+		output := newWorkSessionCancelOutput(args[0])
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			printWorkSessionMutationJSON(output)
+			return
+		}
+		utils.CliSuccess("%s", output.Message)
 	},
 }

--- a/cmd/worksession/worksession_cancel.go
+++ b/cmd/worksession/worksession_cancel.go
@@ -1,0 +1,28 @@
+package worksession
+
+import (
+	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var workSessionCancelCmd = &cobra.Command{
+	Use:     "cancel SESSION_ID",
+	Short:   "Withdraw your own pending work session request",
+	Long:    "Withdraw a pending work session you requested before it is reviewed. Restricted to the session's requester (or a superuser); only pending sessions can be cancelled.",
+	Args:    cobra.ExactArgs(1),
+	Example: `  alpacon work-session cancel ses-abc123`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorEnvelopeWithExit(opCancel, err, "Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		if err := wsapi.CancelWorkSession(ac, args[0]); err != nil {
+			utils.CliErrorEnvelopeWithExit(opCancel, err, "Failed to cancel work session: %s.", err)
+		}
+
+		utils.CliSuccess("Work session %s cancelled.", args[0])
+	},
+}

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	pollMaxAttempts   = 30
+	pollInterval      = 10 * time.Second
 	waitMsgApproval   = "Waiting for approval..."
 	waitMsgActivation = "Waiting for activation..."
 )
@@ -33,9 +34,6 @@ const (
 )
 
 var validScopePresets = []string{"command", "editor", "sudo", "tunnel", "webftp", "websh"}
-
-// pollInterval is a var (not const) so tests can shrink it.
-var pollInterval = 10 * time.Second
 
 var (
 	purpose          string
@@ -250,7 +248,7 @@ so it is recorded and scoped accordingly.`,
 		}
 
 		// Phase 2: poll. With --use we wait for active; otherwise approved is enough.
-		finalSession, err := pollForApproval(ac, session.ID, useAfterCreate)
+		finalSession, err := pollForApproval(ac, session.ID, useAfterCreate, pollInterval)
 		if err != nil {
 			utils.CliErrorEnvelopeWithExit(opCreate, err, "%s", err)
 		}
@@ -378,10 +376,10 @@ func buildSudoPolicies(specs []string, reason string) []wsapi.SudoPolicyInline {
 	return policies
 }
 
-// pollForApproval polls every 10 seconds until the session reaches a terminal state.
+// pollForApproval polls at interval until the session reaches a terminal state.
 // untilActive=false returns on approved or active; untilActive=true returns only on
 // active (continues polling on approved until the server auto-activates).
-func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) (*wsapi.WorkSession, error) {
+func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool, interval time.Duration) (*wsapi.WorkSession, error) {
 	for attempt := 1; attempt <= pollMaxAttempts; attempt++ {
 		s, err := wsapi.GetWorkSession(ac, id)
 		if err != nil {
@@ -411,7 +409,7 @@ func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) (*ws
 		}
 		utils.CliInfo("%s (attempt %d/%d)", waitMsg, attempt, pollMaxAttempts)
 		if attempt < pollMaxAttempts {
-			time.Sleep(pollInterval)
+			time.Sleep(interval)
 		}
 	}
 	return nil, fmt.Errorf("timed out waiting for approval after %d attempts", pollMaxAttempts)

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -19,10 +19,12 @@ import (
 
 const (
 	pollMaxAttempts   = 30
-	pollInterval      = 10 * time.Second
 	waitMsgApproval   = "Waiting for approval..."
 	waitMsgActivation = "Waiting for activation..."
 )
+
+// pollInterval is a var (not const) so tests can shrink it.
+var pollInterval = 10 * time.Second
 
 type useDecision int
 
@@ -398,6 +400,8 @@ func pollForApproval(ac *client.AlpaconClient, id string, untilActive bool) (*ws
 			return nil, errors.New("work session expired while waiting for approval")
 		case revokedWorkSessionStatus:
 			return nil, errors.New("work session was revoked")
+		case cancelledWorkSessionStatus:
+			return nil, errors.New("work session was cancelled")
 		case completedWorkSessionStatus:
 			return nil, errors.New("work session was completed unexpectedly")
 		}

--- a/cmd/worksession/worksession_create.go
+++ b/cmd/worksession/worksession_create.go
@@ -23,9 +23,6 @@ const (
 	waitMsgActivation = "Waiting for activation..."
 )
 
-// pollInterval is a var (not const) so tests can shrink it.
-var pollInterval = 10 * time.Second
-
 type useDecision int
 
 const (
@@ -36,6 +33,9 @@ const (
 )
 
 var validScopePresets = []string{"command", "editor", "sudo", "tunnel", "webftp", "websh"}
+
+// pollInterval is a var (not const) so tests can shrink it.
+var pollInterval = 10 * time.Second
 
 var (
 	purpose          string

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -14,10 +14,6 @@ import (
 )
 
 func TestPollForApprovalCancelled(t *testing.T) {
-	orig := pollInterval
-	pollInterval = 0
-	t.Cleanup(func() { pollInterval = orig })
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"ses-c","status":"cancelled"}`))
@@ -25,7 +21,7 @@ func TestPollForApprovalCancelled(t *testing.T) {
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	_, err := pollForApproval(ac, "ses-c", false)
+	_, err := pollForApproval(ac, "ses-c", false, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cancelled")
 }

--- a/cmd/worksession/worksession_create_test.go
+++ b/cmd/worksession/worksession_create_test.go
@@ -8,9 +8,27 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacax/alpacon-cli/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPollForApprovalCancelled(t *testing.T) {
+	orig := pollInterval
+	pollInterval = 0
+	t.Cleanup(func() { pollInterval = orig })
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"ses-c","status":"cancelled"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	_, err := pollForApproval(ac, "ses-c", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+}
 
 func TestParseExpiryFlag_ExpiresIn(t *testing.T) {
 	before := time.Now()

--- a/cmd/worksession/worksession_list.go
+++ b/cmd/worksession/worksession_list.go
@@ -97,7 +97,7 @@ var workSessionListCmd = &cobra.Command{
 }
 
 func init() {
-	workSessionListCmd.Flags().StringVar(&statusFilter, "status", "active", "Filter by status (pending, approved, active, completed, rejected, expired, revoked); use \"all\" for any status")
+	workSessionListCmd.Flags().StringVar(&statusFilter, "status", "active", "Filter by status (pending, approved, active, completed, rejected, expired, revoked, cancelled); use \"all\" for any status")
 	workSessionListCmd.Flags().StringVar(&requesterFilter, "requester-type", "", "Filter by requester type (user, agent)")
 	workSessionListCmd.Flags().StringVar(&userFilter, "user", "", "Filter by assigned user: default is self, \"all\" for everyone, or a user uuid")
 }

--- a/cmd/worksession/worksession_output.go
+++ b/cmd/worksession/worksession_output.go
@@ -50,6 +50,16 @@ func newWorkSessionExtendOutput(id, expiresAt string) workSessionMutationOutput 
 	}
 }
 
+func newWorkSessionCancelOutput(id string) workSessionMutationOutput {
+	return workSessionMutationOutput{
+		OK:            true,
+		Operation:     opCancel,
+		Message:       fmt.Sprintf("Work session %s cancelled.", id),
+		WorkSessionID: id,
+		Status:        cancelledWorkSessionStatus,
+	}
+}
+
 func formatMutationExpiresAt(expiresAt time.Time) string {
 	if expiresAt.IsZero() {
 		return ""

--- a/cmd/worksession/worksession_output_test.go
+++ b/cmd/worksession/worksession_output_test.go
@@ -77,6 +77,21 @@ func TestWorkSessionExtendOutput(t *testing.T) {
 	}`, string(body))
 }
 
+func TestWorkSessionCancelOutput(t *testing.T) {
+	output := newWorkSessionCancelOutput("ses-abc")
+	body, err := json.Marshal(output)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"ok": true,
+		"operation": "cancel",
+		"message": "Work session ses-abc cancelled.",
+		"work_session_id": "ses-abc",
+		"status": "cancelled",
+		"active_worksession": null
+	}`, string(body))
+}
+
 func TestWorkSessionCreateCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -247,6 +262,43 @@ func TestWorkSessionExtendCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
 	assert.Equal(t, "extend", got.Operation)
 	assert.Equal(t, "ses-active", got.WorkSessionID)
 	assert.Equal(t, "2026-06-01T12:00:00Z", got.ExpiresAt)
+}
+
+func TestWorkSessionCancelCommandJSONOutput_NoHumanSuccessText(t *testing.T) {
+	var sawCancel bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost || r.URL.Path != "/api/work-sessions/sessions/ses-pending/cancel/" {
+			http.NotFound(w, r)
+			return
+		}
+		sawCancel = true
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	setupWorkSessionCommandConfig(t, ts.URL)
+	withWorkSessionCommandJSONMode(t)
+
+	stdout, stderr := captureWorkSessionCommandOutput(t, func() {
+		workSessionCancelCmd.Run(workSessionCancelCmd, []string{"ses-pending"})
+	})
+
+	assert.True(t, sawCancel)
+	assert.Empty(t, stderr)
+	assert.NotContains(t, stdout, "Success:")
+
+	var got struct {
+		OK            bool   `json:"ok"`
+		Operation     string `json:"operation"`
+		WorkSessionID string `json:"work_session_id"`
+		Status        string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.True(t, got.OK)
+	assert.Equal(t, "cancel", got.Operation)
+	assert.Equal(t, "ses-pending", got.WorkSessionID)
+	assert.Equal(t, "cancelled", got.Status)
 }
 
 func TestFormatAdjustments(t *testing.T) {

--- a/cmd/worksession/worksession_use.go
+++ b/cmd/worksession/worksession_use.go
@@ -16,6 +16,7 @@ const (
 	rejectedWorkSessionStatus  = "rejected"
 	expiredWorkSessionStatus   = "expired"
 	revokedWorkSessionStatus   = "revoked"
+	cancelledWorkSessionStatus = "cancelled"
 	completedWorkSessionStatus = "completed"
 )
 

--- a/utils/worksession_error.go
+++ b/utils/worksession_error.go
@@ -130,7 +130,7 @@ func workSessionNextActions(code, operation, serverName, activeWS string) []stri
 	case WorkSessionNotActive:
 		// Activation is approval/server-driven, not user-run; guide toward an active session.
 		return append([]string{
-			"alpacon work-session current  # pending/approved: wait until active; completed/revoked: create or reuse below",
+			"alpacon work-session current  # pending/approved: wait until active; completed/revoked/cancelled: create or reuse below",
 		}, createOrReuse...)
 	case WorkSessionExpired:
 		extendCmd := "alpacon work-session extend <ID>"


### PR DESCRIPTION
## Background

The web console already lets a requester cancel their own pending work session before approval, flipping it to `cancelled` (POST `.../cancel/`). The CLI had no equivalent, so a requester who created a session from the CLI had no way to withdraw it there.

This is not the same as `work-session revoke`, which force-terminates an already approved or active session and is superuser-only. Cancel is a self-request action, the requester pulling back their own pending request, so it sits inside the range the CLI is allowed to carry under ADR 0015.

## Changes

Add `alpacon work-session cancel SESSION_ID`. The command mirrors the existing `revoke`/`complete` leaf commands: it posts to the session's `cancel` action via the new `CancelWorkSession` API client, then prints a success line. Registration, the `opCancel` operation identifier for JSON envelopes, the no-subcommand help string, and the README were updated alongside it.

The CLI delegates all authorization and state checks to the server rather than pre-validating, matching the sibling commands.

## Permissions

The server gates the two termination actions differently, which is why cancel is allowed from the CLI while approve/reject are not:

| Action | Server permission | CLI |
| --- | --- | --- |
| `approve` / `reject` | superuser + approval-channel | blocked (ADR 0015) |
| `revoke` | superuser | allowed |
| `cancel` | session creator or superuser (no approval-channel) | allowed |

Cancel additionally accepts only `pending` sessions; a non-pending session is rejected server-side with `work_session_not_pending`.

## Testing

- `go build`, `go test -race ./...`, and `golangci-lint run` all pass.
- Added `TestCancelWorkSession` asserting the POST path suffix `.../{id}/cancel/`.
- Verified end-to-end against dev (`alpacax.dev.alpacon.io`): created a pending session on `web-editor`, cancelled it (`status: pending` to `cancelled`, `completed_at` set), then re-cancelled the same session and got `Failed to cancel work session: code: work_session_not_pending.` with exit code 1.

## Checklist

- [x] Build, tests, and lint pass
- [x] Unit test for the new API client
- [x] End-to-end verification against a live workspace
- [x] README updated

Closes #256