### PR TITLE
feat(websh): add session-record search command

### DIFF
--- a/api/websh/types.go
+++ b/api/websh/types.go
@@ -95,8 +95,7 @@ type SessionRecord struct {
 	Record  string `json:"record"   table:"Record"`
 }
 
-// recordCursorPage is the ESCursorPagination envelope for session records.
-// ListResponse[T] can't be reused: its Next is an int, this is a cursor token.
+// recordCursorPage decodes the cursor-pagination response; ListResponse[T] can't be reused (its Next is an int, not a cursor token).
 type recordCursorPage struct {
 	Next    string          `json:"next"`
 	Results []SessionRecord `json:"results"`

--- a/api/websh/types.go
+++ b/api/websh/types.go
@@ -89,3 +89,15 @@ type ConnectRequest struct {
 	IsMaster bool   `json:"is_master"`
 	ReadOnly bool   `json:"read_only"`
 }
+
+type SessionRecord struct {
+	AddedAt string `json:"added_at" table:"Added At"`
+	Record  string `json:"record"   table:"Record"`
+}
+
+// recordCursorPage is the ESCursorPagination envelope for session records.
+// ListResponse[T] can't be reused: its Next is an int, this is a cursor token.
+type recordCursorPage struct {
+	Next    string          `json:"next"`
+	Results []SessionRecord `json:"results"`
+}

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -58,6 +59,48 @@ func GetSessionList(ac *client.AlpaconClient) ([]SessionListItem, error) {
 
 func GetSessionDetail(ac *client.AlpaconClient, sessionID string) ([]byte, error) {
 	return ac.SendGetRequest(utils.BuildURL(sessionsBaseURL, sessionID, nil))
+}
+
+func GetSessionRecords(ac *client.AlpaconClient, sessionID, query string, limit int) ([]SessionRecord, error) {
+	action := "records"
+	if query != "" {
+		action = "search"
+	}
+
+	var records []SessionRecord
+	cursor := ""
+	for len(records) < limit {
+		params := map[string]string{
+			"page_size": strconv.Itoa(min(100, limit-len(records))),
+		}
+		if query != "" {
+			params["q"] = query
+		}
+		if cursor != "" {
+			params["cursor"] = cursor
+		}
+
+		body, err := ac.SendGetRequest(utils.BuildURL(sessionsBaseURL, path.Join(sessionID, action), params))
+		if err != nil {
+			return nil, err
+		}
+
+		var page recordCursorPage
+		if err = json.Unmarshal(body, &page); err != nil {
+			return nil, err
+		}
+
+		records = append(records, page.Results...)
+		if page.Next == "" || len(page.Results) == 0 {
+			break
+		}
+		cursor = page.Next
+	}
+
+	if len(records) > limit {
+		records = records[:limit]
+	}
+	return records, nil
 }
 
 func CloseSession(ac *client.AlpaconClient, sessionID string) error {

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -266,6 +266,39 @@ func TestGetSessionRecords_LimitCaps(t *testing.T) {
 	assert.Len(t, records, 2)
 }
 
+func TestGetSessionRecords_PageSize(t *testing.T) {
+	tests := []struct {
+		name         string
+		limit        int
+		wantPageSize string
+	}{
+		{"limit above page cap", 250, "100"},
+		{"limit below page cap", 3, "3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPageSize string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if gotPageSize == "" {
+					gotPageSize = r.URL.Query().Get("page_size")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(recordCursorPage{
+					Next:    "",
+					Results: []SessionRecord{{Record: "a"}, {Record: "b"}, {Record: "c"}},
+				})
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			_, err := GetSessionRecords(ac, "sess-1", "", tt.limit)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPageSize, gotPageSize)
+		})
+	}
+}
+
 func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
 	var gotQuery string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -220,3 +220,68 @@ func TestBuildSessionRequest_IncludesWorkSession(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"work_session":"ses-abc"`)
 }
+
+func TestGetSessionRecords_FollowsCursor(t *testing.T) {
+	var gotCursors []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/records/"))
+		gotCursors = append(gotCursors, r.URL.Query().Get("cursor"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_ = json.NewEncoder(w).Encode(recordCursorPage{
+				Next:    "TOKEN2",
+				Results: []SessionRecord{{AddedAt: "t1", Record: "docker ps"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(recordCursorPage{
+			Next:    "",
+			Results: []SessionRecord{{AddedAt: "t2", Record: "ls -la"}},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	records, err := GetSessionRecords(ac, "sess-1", "", 100)
+	require.NoError(t, err)
+
+	assert.Len(t, records, 2)
+	assert.Equal(t, []string{"", "TOKEN2"}, gotCursors)
+	assert.Equal(t, "ls -la", records[1].Record)
+}
+
+func TestGetSessionRecords_LimitCaps(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(recordCursorPage{
+			Next:    "MORE",
+			Results: []SessionRecord{{Record: "a"}, {Record: "b"}, {Record: "c"}},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	records, err := GetSessionRecords(ac, "sess-1", "", 2)
+	require.NoError(t, err)
+	assert.Len(t, records, 2)
+}
+
+func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
+	var gotQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/search/"))
+		gotQuery = r.URL.Query().Get("q")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(recordCursorPage{
+			Next:    "",
+			Results: []SessionRecord{{Record: "docker ps -a"}},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	records, err := GetSessionRecords(ac, "sess-1", "docker", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "docker", gotQuery)
+	assert.Len(t, records, 1)
+}

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -287,9 +287,6 @@ func init() {
 	WebshCmd.AddCommand(webshInviteCmd)
 	WebshCmd.AddCommand(webshWatchCmd)
 	WebshCmd.AddCommand(webshRecordsCmd)
-
-	webshRecordsCmd.Flags().StringP("query", "q", "", "Search records by command text (fuzzy match)")
-	webshRecordsCmd.Flags().IntP("limit", "n", 100, "Maximum number of records to fetch")
 }
 
 func extractValue(args []string, i int) (string, int) {

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -286,6 +286,10 @@ func init() {
 	WebshCmd.AddCommand(webshForceCloseCmd)
 	WebshCmd.AddCommand(webshInviteCmd)
 	WebshCmd.AddCommand(webshWatchCmd)
+	WebshCmd.AddCommand(webshRecordsCmd)
+
+	webshRecordsCmd.Flags().StringP("query", "q", "", "Search records by command text (fuzzy match)")
+	webshRecordsCmd.Flags().IntP("limit", "n", 100, "Maximum number of records to fetch")
 }
 
 func extractValue(args []string, i int) (string, int) {

--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -10,10 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	ansiEscapeRE    = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
-	whitespaceRunRE = regexp.MustCompile(`\s+`)
-)
+var whitespaceRunRE = regexp.MustCompile(`\s+`)
 
 var webshRecordsCmd = &cobra.Command{
 	Use:     "records SESSION_ID",
@@ -64,8 +61,9 @@ Use --query to search records by command text (fuzzy match).`,
 }
 
 func sanitizeRecord(s string, width int) string {
-	s = ansiEscapeRE.ReplaceAllString(s, "")
+	s = utils.StripANSIEscapes(s)
 	s = whitespaceRunRE.ReplaceAllString(s, " ")
+	s = utils.StripControlChars(s)
 	s = strings.TrimSpace(s)
 	return utils.TruncateString(s, width)
 }

--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -10,10 +10,10 @@ import (
 )
 
 var webshRecordsCmd = &cobra.Command{
-	Use:     "records SESSION_ID",
+	Use:     "records [flags] SESSION_ID",
 	Aliases: []string{"rec"},
-	Short:   "Retrieve or search records within a websh session",
-	Long: `Retrieve masked terminal records for a websh session, optionally
+	Short:   "Retrieve or search records within a Websh session",
+	Long: `Retrieve masked terminal records for a Websh session, optionally
 filtering by command text. Available on paid plans only.
 
 Use --query to search records by command text (fuzzy match).`,
@@ -36,7 +36,7 @@ Use --query to search records by command text (fuzzy match).`,
 
 		records, err := websh.GetSessionRecords(alpaconClient, sessionID, query, limit)
 		if err != nil {
-			utils.CliErrorWithExit("Failed to retrieve websh session records: %s.", err)
+			utils.CliErrorWithExit("Failed to retrieve Websh session records: %s.", err)
 		}
 
 		// JSON keeps records verbatim; table sanitizes so terminal control chars don't break the layout.

--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -1,0 +1,71 @@
+package websh
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/alpacax/alpacon-cli/api/websh"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ansiEscapeRE    = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+	whitespaceRunRE = regexp.MustCompile(`\s+`)
+)
+
+var webshRecordsCmd = &cobra.Command{
+	Use:     "records SESSION_ID",
+	Aliases: []string{"rec"},
+	Short:   "Retrieve or search records within a websh session",
+	Long: `Retrieve masked terminal records for a websh session, optionally
+filtering by command text. Available on paid plans only.
+
+Use --query to search records by command text (fuzzy match).`,
+	Example: `  alpacon websh records abc123
+  alpacon websh records abc123 --query docker
+  alpacon websh rec abc123 -q "sudo reboot" -n 50`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		sessionID := args[0]
+		query, _ := cmd.Flags().GetString("query")
+		limit, _ := cmd.Flags().GetInt("limit")
+		if limit <= 0 {
+			utils.CliErrorWithExit("--limit must be a positive integer.")
+		}
+
+		alpaconClient, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		records, err := websh.GetSessionRecords(alpaconClient, sessionID, query, limit)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to retrieve websh session records: %s.", err)
+		}
+
+		// JSON output keeps records verbatim; table output sanitizes the
+		// terminal recording so control chars don't break the layout.
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			utils.PrintTable(records)
+			return
+		}
+
+		display := make([]websh.SessionRecord, len(records))
+		for i, r := range records {
+			display[i] = websh.SessionRecord{
+				AddedAt: r.AddedAt,
+				Record:  sanitizeRecord(r.Record, 80),
+			}
+		}
+		utils.PrintTable(display)
+	},
+}
+
+func sanitizeRecord(s string, width int) string {
+	s = ansiEscapeRE.ReplaceAllString(s, "")
+	s = whitespaceRunRE.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+	return utils.TruncateString(s, width)
+}

--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -67,3 +67,8 @@ func sanitizeRecord(s string, width int) string {
 	s = strings.TrimSpace(s)
 	return utils.TruncateString(s, width)
 }
+
+func init() {
+	webshRecordsCmd.Flags().StringP("query", "q", "", "Search records by command text (fuzzy match)")
+	webshRecordsCmd.Flags().IntP("limit", "n", 100, "Maximum number of records to fetch")
+}

--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -1,7 +1,6 @@
 package websh
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/alpacax/alpacon-cli/api/websh"
@@ -9,8 +8,6 @@ import (
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
-
-var whitespaceRunRE = regexp.MustCompile(`\s+`)
 
 var webshRecordsCmd = &cobra.Command{
 	Use:     "records SESSION_ID",
@@ -42,8 +39,7 @@ Use --query to search records by command text (fuzzy match).`,
 			utils.CliErrorWithExit("Failed to retrieve websh session records: %s.", err)
 		}
 
-		// JSON output keeps records verbatim; table output sanitizes the
-		// terminal recording so control chars don't break the layout.
+		// JSON keeps records verbatim; table sanitizes so terminal control chars don't break the layout.
 		if utils.OutputFormat == utils.OutputFormatJSON {
 			utils.PrintTable(records)
 			return
@@ -62,9 +58,14 @@ Use --query to search records by command text (fuzzy match).`,
 
 func sanitizeRecord(s string, width int) string {
 	s = utils.StripANSIEscapes(s)
-	s = whitespaceRunRE.ReplaceAllString(s, " ")
-	s = utils.StripControlChars(s)
-	s = strings.TrimSpace(s)
+	// Map control chars to spaces so they separate tokens instead of merging them.
+	s = strings.Map(func(r rune) rune {
+		if utils.IsControlRune(r) {
+			return ' '
+		}
+		return r
+	}, s)
+	s = strings.Join(strings.Fields(s), " ")
 	return utils.TruncateString(s, width)
 }
 

--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -56,17 +56,17 @@ Use --query to search records by command text (fuzzy match).`,
 	},
 }
 
-func sanitizeRecord(s string, width int) string {
-	s = utils.StripANSIEscapes(s)
+func sanitizeRecord(record string, width int) string {
+	record = utils.StripANSIEscapes(record)
 	// Map control chars to spaces so they separate tokens instead of merging them.
-	s = strings.Map(func(r rune) rune {
+	record = strings.Map(func(r rune) rune {
 		if utils.IsControlRune(r) {
 			return ' '
 		}
 		return r
-	}, s)
-	s = strings.Join(strings.Fields(s), " ")
-	return utils.TruncateString(s, width)
+	}, record)
+	record = strings.Join(strings.Fields(record), " ")
+	return utils.TruncateString(record, width)
 }
 
 func init() {

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -364,4 +364,7 @@ func TestSanitizeRecord(t *testing.T) {
 
 	// Truncation applies after cleaning.
 	assert.Equal(t, "docke...", sanitizeRecord("docker ps", 5))
+
+	// OSC window-title sequences are stripped, not leaked into output.
+	assert.Equal(t, "bar", sanitizeRecord("\x1b]0;t\x07bar", 100))
 }

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -367,4 +367,10 @@ func TestSanitizeRecord(t *testing.T) {
 
 	// OSC window-title sequences are stripped, not leaked into output.
 	assert.Equal(t, "bar", sanitizeRecord("\x1b]0;t\x07bar", 100))
+
+	// A control char removed from between two spaces leaves no double space.
+	assert.Equal(t, "foo bar", sanitizeRecord("foo \x07 bar", 100))
+
+	// C1 control (U+0085) separates tokens rather than leaking to the terminal.
+	assert.Equal(t, "foo bar", sanitizeRecord("foo"+string(rune(0x85))+"bar", 100))
 }

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -356,3 +356,12 @@ func TestParseWebshArgs_CommandAfterServerNotConsumed(t *testing.T) {
 	assert.Equal(t, "", got.WorkSessionID)
 	assert.Equal(t, []string{"ls", "--work-session", "fake"}, got.CommandArgs)
 }
+
+func TestSanitizeRecord(t *testing.T) {
+	// ANSI color codes stripped, newlines collapsed to single spaces.
+	in := "\x1b[31mdocker\x1b[0m ps\n  -a\tfoo"
+	assert.Equal(t, "docker ps -a foo", sanitizeRecord(in, 100))
+
+	// Truncation applies after cleaning.
+	assert.Equal(t, "docke...", sanitizeRecord("docker ps", 5))
+}

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -2,16 +2,12 @@ package worksession
 
 import (
 	"fmt"
-	"regexp"
 
 	wsapi "github.com/alpacax/alpacon-cli/api/worksession"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
-
-// ansiEscape matches ANSI/VT escape sequences: CSI, OSC (BEL or ST), DCS/SOS/PM/APC string controls (ST), and Fe/Fs/nF sequences.
-var ansiEscape = regexp.MustCompile(`\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[\x20-\x2f]*[\x40-\x7e])`)
 
 var recordingIndex int
 
@@ -79,7 +75,7 @@ func printRecordingHeader(target *wsapi.TimelineItem, idx int, total int) {
 }
 
 func printRecordingContent(raw string) {
-	content := ansiEscape.ReplaceAllString(raw, "")
+	content := utils.StripANSIEscapes(raw)
 	fmt.Print(content)
 	if len(content) > 0 && content[len(content)-1] != '\n' {
 		fmt.Println()

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -139,7 +139,7 @@ func recordingPreview(raw string) string {
 	scanner := bufio.NewScanner(strings.NewReader(raw))
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for i := 0; i < 50 && scanner.Scan(); i++ {
-		line := ansiEscape.ReplaceAllString(scanner.Text(), "")
+		line := utils.StripANSIEscapes(scanner.Text())
 		// Strip trailing CR from CRLF line endings before overwrite handling.
 		line = strings.TrimRight(line, "\r")
 		// \r moves cursor to line start; take only the last overwritten segment
@@ -148,7 +148,7 @@ func recordingPreview(raw string) string {
 		}
 		line = strings.TrimSpace(line)
 		if line != "" {
-			return utils.TruncateString(stripControlChars(line), 60)
+			return utils.TruncateString(utils.StripControlChars(line), 60)
 		}
 	}
 	return ""
@@ -251,19 +251,6 @@ func formatType(t string) string {
 	}
 }
 
-func ansiStrip(s string) string {
-	return ansiEscape.ReplaceAllString(s, "")
-}
-
-func stripControlChars(s string) string {
-	return strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return -1
-		}
-		return r
-	}, s)
-}
-
 func formatDetails(item *wsapi.TimelineItem) string {
 	switch item.Type {
 	case "command":
@@ -277,7 +264,7 @@ func formatDetails(item *wsapi.TimelineItem) string {
 				status = "failed"
 			}
 		}
-		return fmt.Sprintf("[%s] %s", status, utils.TruncateString(stripControlChars(ansiStrip(item.Line)), 60))
+		return fmt.Sprintf("[%s] %s", status, utils.TruncateString(utils.StripControlChars(utils.StripANSIEscapes(item.Line)), 60))
 
 	case "websh_session":
 		state := sessionState(item.ClosedAt)
@@ -297,15 +284,15 @@ func formatDetails(item *wsapi.TimelineItem) string {
 		return sessionState(item.ClosedAt)
 
 	case "file_upload":
-		return fmt.Sprintf("↑ %s (%s)", stripControlChars(ansiStrip(item.Name)), formatSize(item.Size))
+		return fmt.Sprintf("↑ %s (%s)", utils.StripControlChars(utils.StripANSIEscapes(item.Name)), formatSize(item.Size))
 
 	case "file_download":
-		return fmt.Sprintf("↓ %s (%s)", stripControlChars(ansiStrip(item.Name)), formatSize(item.Size))
+		return fmt.Sprintf("↓ %s (%s)", utils.StripControlChars(utils.StripANSIEscapes(item.Name)), formatSize(item.Size))
 
 	case "sudo_grant":
 		detail := fmt.Sprintf("%s: %s", item.GrantType, item.Status)
 		if item.Command != nil && *item.Command != "" {
-			detail += fmt.Sprintf(" — %s", utils.TruncateString(stripControlChars(ansiStrip(*item.Command)), 40))
+			detail += fmt.Sprintf(" — %s", utils.TruncateString(utils.StripControlChars(utils.StripANSIEscapes(*item.Command)), 40))
 		}
 		return detail
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -466,8 +466,26 @@ var uuidRegex = regexp.MustCompile(
 		`|^[0-9a-fA-F]{32}$`,
 )
 
+// ansiEscapeRE matches ANSI/VT escape sequences: CSI, OSC (BEL or ST), DCS/SOS/PM/APC string controls (ST), and Fe/Fs/nF sequences.
+var ansiEscapeRE = regexp.MustCompile(`\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[\x20-\x2f]*[\x40-\x7e])`)
+
 func IsUUID(str string) bool {
 	return uuidRegex.MatchString(str)
+}
+
+// StripANSIEscapes removes ANSI/VT escape sequences from s.
+func StripANSIEscapes(s string) string {
+	return ansiEscapeRE.ReplaceAllString(s, "")
+}
+
+// StripControlChars removes non-printable control characters from s.
+func StripControlChars(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 // ProcessEditedData facilitates user modifications to original data,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,6 +21,16 @@ import (
 	"golang.org/x/term"
 )
 
+var (
+	uuidRegex = regexp.MustCompile(
+		`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$` +
+			`|^[0-9a-fA-F]{32}$`,
+	)
+
+	// ansiEscapeRE matches ANSI/VT escape sequences: CSI, OSC (BEL or ST), DCS/SOS/PM/APC string controls (ST), and Fe/Fs/nF sequences.
+	ansiEscapeRE = regexp.MustCompile(`\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[\x20-\x2f]*[\x40-\x7e])`)
+)
+
 // ShowLogo renders the Pacabot mascot with up to 3 lines of text. When the
 // terminal is wide enough the text sits to the right of the art (lines 1-3
 // align with art rows 1-3); otherwise it falls back to rendering text below
@@ -460,14 +470,6 @@ func BuildURL(basePath, relativePath string, params map[string]string) string {
 	u.RawQuery = q.Encode()
 	return u.String()
 }
-
-var uuidRegex = regexp.MustCompile(
-	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$` +
-		`|^[0-9a-fA-F]{32}$`,
-)
-
-// ansiEscapeRE matches ANSI/VT escape sequences: CSI, OSC (BEL or ST), DCS/SOS/PM/APC string controls (ST), and Fe/Fs/nF sequences.
-var ansiEscapeRE = regexp.MustCompile(`\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|\[[\x30-\x3f]*[\x20-\x2f]*[@-~]|[\x20-\x2f]*[\x40-\x7e])`)
 
 func IsUUID(str string) bool {
 	return uuidRegex.MatchString(str)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -473,15 +473,18 @@ func IsUUID(str string) bool {
 	return uuidRegex.MatchString(str)
 }
 
-// StripANSIEscapes removes ANSI/VT escape sequences from s.
 func StripANSIEscapes(s string) string {
 	return ansiEscapeRE.ReplaceAllString(s, "")
 }
 
-// StripControlChars removes non-printable control characters from s.
+// IsControlRune reports whether r is a C0, DEL, or C1 control character (the last can introduce CSI/OSC on 8-bit terminals).
+func IsControlRune(r rune) bool {
+	return r < 0x20 || (r >= 0x7f && r <= 0x9f)
+}
+
 func StripControlChars(s string) string {
 	return strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
+		if IsControlRune(r) {
 			return -1
 		}
 		return r

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -360,5 +360,8 @@ func TestStripANSIEscapes(t *testing.T) {
 }
 
 func TestStripControlChars(t *testing.T) {
+	// C0, DEL, and C1 (rune 0x85 = NEL) are removed; printable Unicode (é = 0xE9) is kept.
 	assert.Equal(t, "abc", StripControlChars("a\x00b\x7fc"))
+	assert.Equal(t, "ab", StripControlChars("a\u0085b"))
+	assert.Equal(t, "abé", StripControlChars("a\u0085bé"))
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -350,7 +350,10 @@ func TestStripANSIEscapes(t *testing.T) {
 		want  string
 	}{
 		{"CSI color codes", "\x1b[31mfoo\x1b[0m", "foo"},
+		{"CSI erase line", "abc\x1b[2Kdef", "abcdef"},
 		{"OSC BEL-terminated window title", "\x1b]0;title\x07bar", "bar"},
+		{"OSC ST-terminated window title", "\x1b]0;title\x1b\\baz", "baz"},
+		{"DCS string terminated by ST", "\x1bPq123\x1b\\qux", "qux"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -342,3 +342,23 @@ func TestSplitAndTrim(t *testing.T) {
 		})
 	}
 }
+
+func TestStripANSIEscapes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"CSI color codes", "\x1b[31mfoo\x1b[0m", "foo"},
+		{"OSC BEL-terminated window title", "\x1b]0;title\x07bar", "bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, StripANSIEscapes(tt.input))
+		})
+	}
+}
+
+func TestStripControlChars(t *testing.T) {
+	assert.Equal(t, "abc", StripControlChars("a\x00b\x7fc"))
+}


### PR DESCRIPTION
## Background

The web can search a session's records by command text (`websh/sessions/{id}/search/`, `useSearchRecordQuery`), but the CLI had no equivalent. `audit` only offers the `--tail`/`--user`/`--app`/`--model` field filters, with no way to find command text inside a session. This is the gap flagged by the alpacon-handbook CLI parity sweep (Finding 9). The server API already exists, so this is a pure client-side change.

## What changed

Adds `alpacon websh records SESSION_ID [-q TEXT] [-n LIMIT]` (alias `rec`).

- Without `-q`/`--query` it calls `sessions/{id}/records/` (list all); with a query it calls `sessions/{id}/search/?q=` (fuzzy command-text search).
- It follows the `next` cursor up to `-n`/`--limit` (default 100). The server uses cursor-token pagination, so `api.FetchAllPages` (integer page-based) can't be reused; a dedicated `GetSessionRecords` and `recordCursorPage` type were added in `api/websh`.
- Output honors the global `--output` flag. `json` emits records verbatim (for machine/script consumers); the default table output is cleaned by `sanitizeRecord`.
- Refactor: the ANSI/control-char stripping helpers were promoted from `cmd/worksession` to `utils` (`StripANSIEscapes`, `StripControlChars`, `IsControlRune`), and worksession was converged onto the shared helpers. This removes duplication and preserves behavior.

## Access control

Both `records` and `search` endpoints are gated server-side by `IsPaidPlan`. The free plan returns 403, and the CLI surfaces the server error message as-is. No client-side pre-guard was added, since the server is the authority on authorization.

## Safety

Records are secret-masked terminal recordings. In shared or invited sessions a lower-privileged participant can influence their content, which another user later renders. Given that input path:

- Table output strips ANSI escapes (CSI/OSC/DCS/Fe) and sanitizes control characters across C0, DEL, and C1 (U+0080 to U+009F). C1 can act as a CSI/OSC introducer on 8-bit terminals. Control characters are replaced with spaces so tokens do not merge, then collapsed with `strings.Fields`.
- `json` output is verbatim by contract. `encoding/json` escapes ESC (0x1b), which blocks sequence reconstruction, and sanitizing it would corrupt data consumers rely on and diverge from other commands, so sanitization is applied to the table path only.
- The server timestamp (`added_at`) is rendered raw, consistent with how server timestamps are handled across the codebase.

## Tests

- `api/websh/websh_test.go`: cursor following, `--limit` capping, `page_size` value (`min(100, limit-len)`), and `search/` endpoint routing when `-q` is set.
- `cmd/websh/websh_test.go`: `sanitizeRecord` cases for ANSI, OSC, C1, and the double-space edge.
- `utils/utils_test.go`: `StripANSIEscapes` (CSI/OSC-BEL/OSC-ST/DCS branches) and `StripControlChars` (C0/DEL/C1).
- Local CI-equivalent checks pass: `go build -v .`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `govulncheck` (0 affecting), and go.mod/go.sum tidy.

Manual E2E verification against an Alpacon Cloud workspace (paid plan, Auth0 browser login). Created a websh session on `web-editor`, ran `ls -al` / `docker ps` / `echo`, then queried its records by session ID:

- `websh records SESSION_ID` returned the session record with the table path sanitized — ANSI escapes, SGR colors, and backspace/autocomplete replay stripped, then truncated at the column width.
- `--output json` returned the record verbatim, with ESC emitted as its JSON unicode escape by `encoding/json`, confirming the sequence-reconstruction block described in Safety.
- Search filtering confirmed by positive/negative contrast on the same session: `-q docker` and `-q reboot` returned the matching record, while `-q zzzznope` returned an empty result. This proves the query is routed to `sessions/{id}/search/` and filtered server-side, not ignored.
- `rec -n 20` exercised the alias and `--limit`.

## Checklist

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Existing behavior preserved (worksession sanitizer convergence is behavior-neutral)
- [x] Manual E2E verified on `web-editor` (list, search, json, alias/limit)

Closes #258

