### PR TITLE
feat(exec): add --env to keep credentials off the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ What each refusal code means and what to do next:
 | `1`  | General error (network failure, server error, etc.) |
 | `2`  | Usage error (invalid flags or arguments) |
 | `3`  | WorkSession gate denied—the active session does not authorize this action |
-| `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. For `exec`, re-run the command after approval (or pass `--wait` on the original command to block); for `work-session create` the session already exists—after approval attach it with `alpacon work-session use <id>` (or pass `--wait` on the original create to block). Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending |
+| `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. For `exec`, re-run the command after approval (or pass `--wait` on the original command to block); for `work-session create` the session already exists—after approval attach it with `alpacon work-session use <id>` (or pass `--wait` on the original create to block). Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` (and `websh` when running a command) on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ What each refusal code means and what to do next:
 | `1`  | General error (network failure, server error, etc.) |
 | `2`  | Usage error (invalid flags or arguments) |
 | `3`  | WorkSession gate denied—the active session does not authorize this action |
-| `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. For `exec`, re-run the command after approval (or pass `--wait` on the original command to block); for `work-session create` the session already exists—after approval attach it with `alpacon work-session use <id>` (or pass `--wait` on the original create to block). Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` (and `websh` when running a command) on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending |
+| `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. For `exec`, re-run the command after approval (or pass `--wait` on the original command to block); `websh` command mode has no `--wait`, so re-run via `alpacon exec --wait` to block; for `work-session create` the session already exists—after approval attach it with `alpacon work-session use <id>` (or pass `--wait` on the original create to block). Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` (and `websh` when running a command) on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending |
 
 ## Contributing
 

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -201,10 +201,10 @@ func RunRemoteExec(parsed RemoteExecArgs) {
 	HandleCommandResult(err)
 }
 
-// reRunHint reconstructs the exec invocation (server, optional user/group, and
-// command) so the pending-approval message can tell a human exactly what to
-// re-run once the request is approved. It uses -- before the command so remote
-// flags are never re-parsed as alpacon flags.
+// reRunHint reconstructs the exec invocation (server, command, and any
+// user/group, work-session, or --env keys) so the pending-approval message can
+// tell a human exactly what to re-run once the request is approved. It uses --
+// before the command so remote flags are never re-parsed as alpacon flags.
 func reRunHint(parsed RemoteExecArgs) string {
 	parts := []string{"alpacon exec"}
 	if parsed.Username != "" {

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -110,88 +110,94 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			return
 		}
 
-		if parsed.OutputFormat != "" {
-			if parsed.OutputFormat != utils.OutputFormatTable && parsed.OutputFormat != utils.OutputFormatJSON {
-				utils.CliErrorWithExit("invalid --output value %q: must be 'table' or 'json'", parsed.OutputFormat)
-			}
-			utils.OutputFormat = parsed.OutputFormat
+		RunRemoteExec(parsed)
+	},
+}
+
+// RunRemoteExec executes a parsed remote command—the shared post-parse path for
+// exec and websh command mode. Requires Server and Command to be non-empty.
+func RunRemoteExec(parsed RemoteExecArgs) {
+	if parsed.OutputFormat != "" {
+		if parsed.OutputFormat != utils.OutputFormatTable && parsed.OutputFormat != utils.OutputFormatJSON {
+			utils.CliErrorWithExit("invalid --output value %q: must be 'table' or 'json'", parsed.OutputFormat)
 		}
+		utils.OutputFormat = parsed.OutputFormat
+	}
 
-		workSessionID := worksession.ResolveOrExit(parsed.WorkSessionID)
+	workSessionID := worksession.ResolveOrExit(parsed.WorkSessionID)
 
-		authMethod := config.ResolveAuthMethod()
+	authMethod := config.ResolveAuthMethod()
 
-		alpaconClient, err := client.NewAlpaconAPIClient()
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		return
+	}
+
+	env := parsed.Env
+
+	if parsed.Detach {
+		resp, err := event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
 		if err != nil {
-			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+			err = utils.HandleCommonErrors(err, parsed.Server, utils.ErrorHandlerCallbacks{
+				OnMFARequired: func(srv string) error {
+					return mfa.HandleMFAError(alpaconClient, srv)
+				},
+				OnUsernameRequired: func() error {
+					_, err := iam.HandleUsernameRequired()
+					return err
+				},
+				CheckMFACompleted: func() (bool, error) {
+					return mfa.CheckMFACompletion(alpaconClient)
+				},
+				RefreshToken: alpaconClient.RefreshToken,
+				RetryOperation: func() error {
+					resp, err = event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
+					return err
+				},
+			})
+		}
+		if err != nil {
+			utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
+			utils.CliErrorWithExit("failed to submit command on '%s': %s", parsed.Server, err)
 			return
 		}
-
-		env := parsed.Env
-
-		if parsed.Detach {
-			resp, err := event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
+		if utils.OutputFormat == utils.OutputFormatJSON {
+			data, err := json.Marshal(map[string]string{"job_id": resp.ID})
 			if err != nil {
-				err = utils.HandleCommonErrors(err, parsed.Server, utils.ErrorHandlerCallbacks{
-					OnMFARequired: func(srv string) error {
-						return mfa.HandleMFAError(alpaconClient, srv)
-					},
-					OnUsernameRequired: func() error {
-						_, err := iam.HandleUsernameRequired()
-						return err
-					},
-					CheckMFACompleted: func() (bool, error) {
-						return mfa.CheckMFACompletion(alpaconClient)
-					},
-					RefreshToken: alpaconClient.RefreshToken,
-					RetryOperation: func() error {
-						resp, err = event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)
-						return err
-					},
-				})
-			}
-			if err != nil {
-				utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
-				utils.CliErrorWithExit("failed to submit command on '%s': %s", parsed.Server, err)
+				utils.CliErrorWithExit("failed to marshal JSON: %s", err)
 				return
 			}
-			if utils.OutputFormat == utils.OutputFormatJSON {
-				data, err := json.Marshal(map[string]string{"job_id": resp.ID})
-				if err != nil {
-					utils.CliErrorWithExit("failed to marshal JSON: %s", err)
-					return
-				}
-				utils.PrintJson(data)
-			} else {
-				line1, line2 := detachResultLines(resp.ID)
-				fmt.Println(line1)
-				fmt.Fprintln(os.Stderr, line2)
-			}
-			return
+			utils.PrintJson(data)
+		} else {
+			line1, line2 := detachResultLines(resp.ID)
+			fmt.Println(line1)
+			fmt.Fprintln(os.Stderr, line2)
 		}
+		return
+	}
 
-		// JSON mode buffers output to keep stdout clean for a pending-approval
-		// signal; it is flushed below on success or plain failure. Table mode streams live.
-		var out io.Writer = os.Stdout
-		var buf *bytes.Buffer
-		if utils.OutputFormat == utils.OutputFormatJSON {
-			buf = &bytes.Buffer{}
-			out = buf
-		}
+	// JSON mode buffers output to keep stdout clean for a pending-approval
+	// signal; it is flushed below on success or plain failure. Table mode streams live.
+	var out io.Writer = os.Stdout
+	var buf *bytes.Buffer
+	if utils.OutputFormat == utils.OutputFormatJSON {
+		buf = &bytes.Buffer{}
+		out = buf
+	}
 
-		err = RunExecWithApprovalWait(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID, parsed.Wait, out)
-		utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
-		// A sudo command pending human approval (SUDO_APPROVAL_REQUIRED) that we did
-		// not --wait on emits a machine-readable pending signal and exits before the
-		// normal result handling treats the denial as a plain failure.
-		if HandlePendingApproval(err, reRunHint(parsed)) {
-			return
-		}
-		if buf != nil {
-			_, _ = os.Stdout.Write(buf.Bytes())
-		}
-		HandleCommandResult(err)
-	},
+	err = RunExecWithApprovalWait(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID, parsed.Wait, out)
+	utils.HandleWorkSessionError(err, "command", parsed.Server, authMethod, workSessionID)
+	// A sudo command pending human approval (SUDO_APPROVAL_REQUIRED) that we did
+	// not --wait on emits a machine-readable pending signal and exits before the
+	// normal result handling treats the denial as a plain failure.
+	if HandlePendingApproval(err, reRunHint(parsed)) {
+		return
+	}
+	if buf != nil {
+		_, _ = os.Stdout.Write(buf.Bytes())
+	}
+	HandleCommandResult(err)
 }
 
 // reRunHint reconstructs the exec invocation (server, optional user/group, and

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/alpacax/alpacon-cli/api/event"
@@ -214,6 +215,16 @@ func reRunHint(parsed RemoteExecArgs) string {
 	}
 	if parsed.WorkSessionID != "" {
 		parts = append(parts, "--work-session "+parsed.WorkSessionID)
+	}
+	// Emit env keys only (never values): the rerun re-reads each value from the
+	// shell, so the secret stays off this hint on stderr and out of the logs.
+	keys := make([]string, 0, len(parsed.Env))
+	for k := range parsed.Env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		parts = append(parts, "--env="+k)
 	}
 	parts = append(parts, parsed.Server, "--", parsed.Command)
 	return strings.Join(parts, " ")

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -41,8 +41,8 @@ Flags:
   -g, --groupname [GROUP_NAME]  Specify the group name for command execution.
   --env="KEY"                   Pass an environment variable to the remote command,
                                 reading its value from the current shell. This keeps
-                                the value off the command line and out of the audit
-                                log—use it for secrets such as passwords or tokens.
+                                the value off the alpacon command line and out of the
+                                audit log—use it for secrets such as passwords or tokens.
   --env="KEY=VALUE"             Set 'KEY' to a literal value. Discouraged: the value
                                 is written on the command line and recorded verbatim
                                 in the audit log. Never pass credentials this way.
@@ -74,9 +74,9 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   alpacon exec -u root prod-docker systemctl status nginx
   alpacon exec -g docker user@server docker images
 
-  # Pass a secret via the shell env; the value stays off every command line.
-  # psql reads PGPASSWORD from the environment, so it never lands in the remote
-  # process's argv either.
+  # Pass a secret via the shell env; the value stays off the alpacon command line
+  # and out of the audit log. psql reads PGPASSWORD from the environment, so it
+  # never lands in the remote process's argv either.
   export PGPASSWORD=hunter2
   alpacon exec --env="PGPASSWORD" db-server -- psql -h localhost -U app -c 'SELECT 1'
 

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -38,6 +38,13 @@ To send a literal metacharacter, wrap the argument in quotes:
 Flags:
   -u, --username [USER_NAME]    Specify the username for command execution.
   -g, --groupname [GROUP_NAME]  Specify the group name for command execution.
+  --env="KEY"                   Pass an environment variable to the remote command,
+                                reading its value from the current shell. This keeps
+                                the value off the command line and out of the audit
+                                log—use it for secrets such as passwords or tokens.
+  --env="KEY=VALUE"             Set 'KEY' to a literal value. Discouraged: the value
+                                is written on the command line and recorded verbatim
+                                in the audit log. Never pass credentials this way.
   --work-session [UUID]         Attach this command to a work-session.
                                 Overrides the workspace's active session set via
                                 'alpacon work-session use'.
@@ -65,6 +72,12 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   # Specify user and group with flags
   alpacon exec -u root prod-docker systemctl status nginx
   alpacon exec -g docker user@server docker images
+
+  # Pass a secret via the shell env; the value stays off every command line.
+  # psql reads PGPASSWORD from the environment, so it never lands in the remote
+  # process's argv either.
+  export PGPASSWORD=hunter2
+  alpacon exec --env="PGPASSWORD" db-server -- psql -h localhost -U app -c 'SELECT 1'
 
   # Submit a command asynchronously and retrieve the result later
   alpacon exec --detach web-server -- apt-get update

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -114,7 +114,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 			return
 		}
 
-		env := make(map[string]string)
+		env := parsed.Env
 
 		if parsed.Detach {
 			resp, err := event.SubmitCommand(alpaconClient, parsed.Server, parsed.Command, parsed.Username, parsed.Groupname, env, workSessionID)

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -205,7 +205,11 @@ func RunRemoteExec(parsed RemoteExecArgs) {
 // user/group, work-session, or --env keys) so the pending-approval message can
 // tell a human exactly what to re-run once the request is approved. It uses --
 // before the command so remote flags are never re-parsed as alpacon flags.
-func reRunHint(parsed RemoteExecArgs) string {
+// The Command stays a pure, executable string; when --env keys are present the
+// caveat rides in Description, since the rerun re-reads each value from the
+// shell and a machine consumer replaying Command verbatim would otherwise
+// submit without those keys.
+func reRunHint(parsed RemoteExecArgs) utils.NextAction {
 	parts := []string{"alpacon exec"}
 	if parsed.Username != "" {
 		parts = append(parts, "-u "+parsed.Username)
@@ -227,5 +231,10 @@ func reRunHint(parsed RemoteExecArgs) string {
 		parts = append(parts, "--env="+k)
 	}
 	parts = append(parts, parsed.Server, "--", parsed.Command)
-	return strings.Join(parts, " ")
+
+	action := utils.NextAction{Command: strings.Join(parts, " ")}
+	if len(keys) > 0 {
+		action.Description = "--env values are re-read from your shell; export them before re-running"
+	}
+	return action
 }

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -114,8 +114,8 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 	},
 }
 
-// RunRemoteExec executes a parsed remote command—the shared post-parse path for
-// exec and websh command mode. Requires Server and Command to be non-empty.
+// RunRemoteExec is the shared post-parse execution path for exec and websh
+// command mode. Requires Server and Command to be non-empty.
 func RunRemoteExec(parsed RemoteExecArgs) {
 	if parsed.OutputFormat != "" {
 		if parsed.OutputFormat != utils.OutputFormatTable && parsed.OutputFormat != utils.OutputFormatJSON {

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -155,7 +155,7 @@ func ParseEnvArg(arg string, env map[string]string) string {
 	var key, value string
 	var hasValue bool
 	if ok {
-		key, value, hasValue = strings.Cut(strings.Trim(body, "\""), "=")
+		key, value, hasValue = strings.Cut(trimMatchedQuotes(body), "=")
 	}
 	if !ok || key == "" {
 		// Never echo arg: a malformed token like --env="=secret" would leak the value.
@@ -187,6 +187,16 @@ func ShellJoin(parts []string) string {
 		out[i] = shellQuote(p)
 	}
 	return strings.Join(out, " ")
+}
+
+// trimMatchedQuotes strips one matched leading+trailing double-quote pair only.
+// A real shell already strips wrappers, so leaving unbalanced quotes intact
+// avoids silently corrupting a value that legitimately ends in ".
+func trimMatchedQuotes(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
 }
 
 // shellQuote wraps s in single quotes if it contains whitespace or a single quote.

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -1,6 +1,8 @@
 package exec
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/alpacax/alpacon-cli/utils"
@@ -14,6 +16,7 @@ type RemoteExecArgs struct {
 	OutputFormat  string
 	Server        string
 	Command       string
+	Env           map[string]string
 	Detach        bool
 	Wait          bool
 	ShowHelp      bool
@@ -40,6 +43,7 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 		detach                                                   bool
 		wait                                                     bool
 	)
+	env := map[string]string{}
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -98,6 +102,10 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 			if outputFormat == "" {
 				return RemoteExecArgs{Err: "--output requires a value (table|json)"}
 			}
+		case strings.HasPrefix(arg, "--env"):
+			if errMsg := ParseEnvArg(arg, env); errMsg != "" {
+				return RemoteExecArgs{Err: errMsg}
+			}
 		case arg == "--detach":
 			detach = true
 		case strings.HasPrefix(arg, "--detach="):
@@ -135,9 +143,36 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 		OutputFormat:  outputFormat,
 		Server:        server,
 		Command:       ShellJoin(commandParts),
+		Env:           env,
 		Detach:        detach,
 		Wait:          wait,
 	}
+}
+
+// ParseEnvArg parses a --env=KEY or --env=KEY=VALUE token into env, returning an
+// error message on malformed input. A bare KEY reads the shell's value, warning
+// and skipping if it is unset.
+func ParseEnvArg(arg string, env map[string]string) string {
+	body, ok := strings.CutPrefix(arg, "--env=")
+	var key, value string
+	var hasValue bool
+	if ok {
+		key, value, hasValue = strings.Cut(strings.Trim(body, "\""), "=")
+	}
+	if !ok || key == "" {
+		return fmt.Sprintf("invalid --env argument %q: use --env=KEY or --env=KEY=VALUE", arg)
+	}
+	if hasValue {
+		env[key] = value
+		return ""
+	}
+	v, exists := os.LookupEnv(key)
+	if !exists {
+		utils.CliWarning("no environment variable found for key '%s'", key)
+		return ""
+	}
+	env[key] = v
+	return ""
 }
 
 // ShellJoin reassembles tokenized command parts into a single string.

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -101,7 +101,7 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 			if outputFormat == "" {
 				return RemoteExecArgs{Err: "--output requires a value (table|json)"}
 			}
-		case strings.HasPrefix(arg, "--env"):
+		case arg == "--env" || strings.HasPrefix(arg, "--env="):
 			if errMsg := ParseEnvArg(arg, env); errMsg != "" {
 				return RemoteExecArgs{Err: errMsg}
 			}

--- a/cmd/exec/parse.go
+++ b/cmd/exec/parse.go
@@ -1,7 +1,6 @@
 package exec
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -149,9 +148,8 @@ func ParseRemoteExecArgs(args []string) RemoteExecArgs {
 	}
 }
 
-// ParseEnvArg parses a --env=KEY or --env=KEY=VALUE token into env, returning an
-// error message on malformed input. A bare KEY reads the shell's value, warning
-// and skipping if it is unset.
+// ParseEnvArg parses a --env token into env. A bare KEY reads the shell value,
+// warning and skipping if unset; malformed input returns an error message.
 func ParseEnvArg(arg string, env map[string]string) string {
 	body, ok := strings.CutPrefix(arg, "--env=")
 	var key, value string
@@ -160,7 +158,8 @@ func ParseEnvArg(arg string, env map[string]string) string {
 		key, value, hasValue = strings.Cut(strings.Trim(body, "\""), "=")
 	}
 	if !ok || key == "" {
-		return fmt.Sprintf("invalid --env argument %q: use --env=KEY or --env=KEY=VALUE", arg)
+		// Never echo arg: a malformed token like --env="=secret" would leak the value.
+		return "invalid --env argument: use --env=KEY or --env=KEY=VALUE"
 	}
 	if hasValue {
 		env[key] = value

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -686,6 +686,21 @@ func TestParseRemoteExecArgs_EnvFlag(t *testing.T) {
 			wantCommand: "ls",
 		},
 		{
+			name:        "value ending in a quote is not corrupted",
+			args:        []string{"--env=PW=trailing\"", "server", "ls"},
+			wantEnv:     map[string]string{"PW": "trailing\""},
+			wantServer:  "server",
+			wantCommand: "ls",
+		},
+		{
+			// Quotes wrap only the value, not the whole token—no matched pair to strip.
+			name:        "inner-quoted value passes through verbatim",
+			args:        []string{"--env=KEY=\"VAL\"", "server", "ls"},
+			wantEnv:     map[string]string{"KEY": "\"VAL\""},
+			wantServer:  "server",
+			wantCommand: "ls",
+		},
+		{
 			name:        "--env=KEY for an unset variable warns and skips",
 			args:        []string{"--env=DEFINITELY_UNSET", "server", "ls"},
 			absentEnv:   []string{"DEFINITELY_UNSET"},

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -747,6 +747,12 @@ func TestParseRemoteExecArgs_EnvFlag(t *testing.T) {
 	}
 }
 
+func TestParseRemoteExecArgs_EnvErrorHidesSecret(t *testing.T) {
+	result := ParseRemoteExecArgs([]string{"--env=\"=hunter2\"", "server", "ls"})
+	assert.NotEmpty(t, result.Err)
+	assert.NotContains(t, result.Err, "hunter2", "malformed --env error must not echo the value")
+}
+
 func TestParseRemoteExecArgs_Errors(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -723,6 +723,11 @@ func TestParseRemoteExecArgs_EnvFlag(t *testing.T) {
 			args:    []string{"--env=", "server", "ls"},
 			wantErr: true,
 		},
+		{
+			name:    "--env-file is an unknown flag, not a malformed --env",
+			args:    []string{"--env-file=secrets", "server", "ls"},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -751,6 +756,12 @@ func TestParseRemoteExecArgs_EnvErrorHidesSecret(t *testing.T) {
 	result := ParseRemoteExecArgs([]string{"--env=\"=hunter2\"", "server", "ls"})
 	assert.NotEmpty(t, result.Err)
 	assert.NotContains(t, result.Err, "hunter2", "malformed --env error must not echo the value")
+}
+
+func TestParseRemoteExecArgs_EnvPrefixIsExact(t *testing.T) {
+	// --env-file must not be swallowed by --env matching; it is an unknown flag.
+	result := ParseRemoteExecArgs([]string{"--env-file=secrets", "server", "ls"})
+	assert.Contains(t, result.Err, "unknown flag")
 }
 
 func TestParseRemoteExecArgs_Errors(t *testing.T) {

--- a/cmd/exec/parse_test.go
+++ b/cmd/exec/parse_test.go
@@ -651,6 +651,102 @@ func TestParseRemoteExecArgs_DetachFlag(t *testing.T) {
 	}
 }
 
+func TestParseRemoteExecArgs_EnvFlag(t *testing.T) {
+	t.Setenv("DB_PASS", "hunter2")
+
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     bool
+		wantEnv     map[string]string
+		absentEnv   []string
+		wantServer  string
+		wantCommand string
+	}{
+		{
+			name:        "--env=KEY=VALUE literal form",
+			args:        []string{"--env=DB_PASS=literal", "server", "ls"},
+			wantEnv:     map[string]string{"DB_PASS": "literal"},
+			wantServer:  "server",
+			wantCommand: "ls",
+		},
+		{
+			// Exact command match proves the value never lands on the command line.
+			name:        "--env=KEY reads shell value and keeps it off the command",
+			args:        []string{"--env=DB_PASS", "server", "echo", "hi"},
+			wantEnv:     map[string]string{"DB_PASS": "hunter2"},
+			wantServer:  "server",
+			wantCommand: "echo hi",
+		},
+		{
+			name:        "quoted --env value is unwrapped",
+			args:        []string{"--env=\"DB_PASS=quoted\"", "server", "ls"},
+			wantEnv:     map[string]string{"DB_PASS": "quoted"},
+			wantServer:  "server",
+			wantCommand: "ls",
+		},
+		{
+			name:        "--env=KEY for an unset variable warns and skips",
+			args:        []string{"--env=DEFINITELY_UNSET", "server", "ls"},
+			absentEnv:   []string{"DEFINITELY_UNSET"},
+			wantServer:  "server",
+			wantCommand: "ls",
+		},
+		{
+			name:        "multiple --env flags accumulate",
+			args:        []string{"--env=A=1", "--env=B=2", "server", "ls"},
+			wantEnv:     map[string]string{"A": "1", "B": "2"},
+			wantServer:  "server",
+			wantCommand: "ls",
+		},
+		{
+			name:        "--env=KEY= sets an empty value",
+			args:        []string{"--env=EMPTY=", "server", "ls"},
+			wantEnv:     map[string]string{"EMPTY": ""},
+			wantServer:  "server",
+			wantCommand: "ls",
+		},
+		{
+			name:        "--env after server is a command arg, not a flag",
+			args:        []string{"server", "--env=X=1"},
+			absentEnv:   []string{"X"},
+			wantServer:  "server",
+			wantCommand: "--env=X=1",
+		},
+		{
+			name:    "bare --env with no value is an error",
+			args:    []string{"--env", "server", "ls"},
+			wantErr: true,
+		},
+		{
+			name:    "--env= with empty key is an error",
+			args:    []string{"--env=", "server", "ls"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseRemoteExecArgs(tt.args)
+			if tt.wantErr {
+				assert.NotEmpty(t, result.Err)
+				assert.Empty(t, result.Server)
+				return
+			}
+			assert.Empty(t, result.Err)
+			for k, v := range tt.wantEnv {
+				assert.Equal(t, v, result.Env[k], "Env[%s]", k)
+			}
+			for _, k := range tt.absentEnv {
+				_, ok := result.Env[k]
+				assert.False(t, ok, "Env[%s] should be absent", k)
+			}
+			assert.Equal(t, tt.wantServer, result.Server, "Server")
+			assert.Equal(t, tt.wantCommand, result.Command, "Command")
+		})
+	}
+}
+
 func TestParseRemoteExecArgs_Errors(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -108,8 +108,8 @@ func hasSudoApprovalDenial(output string) bool {
 // terminal, offers an MFA step-up and retries once. Non-interactive callers
 // (scripts, CI, AI agents) fall through unchanged so HandleCommandResult prints
 // the static denial hint; non-interactive humans additionally get the
-// verification link they can complete out of band. Only exec uses this; websh
-// keeps its own sudo MFA flow.
+// verification link they can complete out of band. Reached via RunRemoteExec by
+// exec and websh command mode; interactive websh keeps its own sudo MFA flow.
 func RunExecWithPresenceStepUp(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer) error {
 	err := RunCommandWithRetry(ac, serverName, command, username, groupname, env, workSessionID, out)
 	// A real presence denial makes sudo exit non-zero, so it always surfaces as a
@@ -258,7 +258,7 @@ func HandlePendingApproval(err error, reRunHint string) bool {
 }
 
 // RunCommandWithRetry executes a remote command with MFA/username-required error
-// handling and retry logic, streaming output to out. Used by exec and websh.
+// handling and retry logic, streaming output to out.
 // workSessionID is forwarded as the work_session field; pass "" to omit it.
 func RunCommandWithRetry(ac *client.AlpaconClient, serverName, command, username, groupname string, env map[string]string, workSessionID string, out io.Writer) error {
 	err := event.RunCommandStreaming(ac, serverName, command, username, groupname, env, workSessionID, out)

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -229,9 +229,9 @@ func RunExecWithApprovalWait(ac *client.AlpaconClient, serverName, command, user
 // then exits with ExitCodePendingApproval. It reports true when it handled the
 // err; the caller skips its normal result handling on true. The exec denial line
 // carries no approval request id, so the machine signal omits it. reRunHint is
-// the exact command the caller invoked, so a human can copy-paste it once the
-// request is approved.
-func HandlePendingApproval(err error, reRunHint string) bool {
+// the exact command the caller invoked (with any --env caveat in its
+// Description), so a human can copy-paste it once the request is approved.
+func HandlePendingApproval(err error, reRunHint utils.NextAction) bool {
 	// Status-hold: held job runs automatically once approved, so point at exec logs.
 	var pendingErr *event.PendingApprovalError
 	if errors.As(err, &pendingErr) {
@@ -251,7 +251,7 @@ func HandlePendingApproval(err error, reRunHint string) bool {
 		"Approval required—a human must approve this sudo command in the Alpacon console (web). "+
 			"Re-run after approval, or use --wait to block until it is approved.",
 		"", // the exec sudo denial line carries no approval request id
-		utils.NextAction{Command: reRunHint},
+		reRunHint,
 	)
 	os.Exit(utils.ExitCodePendingApproval)
 	return true

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -158,7 +158,8 @@ func TestIsApprovalDenial(t *testing.T) {
 func TestReRunHint(t *testing.T) {
 	t.Run("minimal: server and command only", func(t *testing.T) {
 		got := reRunHint(RemoteExecArgs{Server: "web-01", Command: "sudo reboot"})
-		assert.Equal(t, "alpacon exec web-01 -- sudo reboot", got)
+		assert.Equal(t, "alpacon exec web-01 -- sudo reboot", got.Command)
+		assert.Empty(t, got.Description, "no --env keys means no caveat")
 	})
 
 	t.Run("includes user, group, and work-session", func(t *testing.T) {
@@ -169,17 +170,19 @@ func TestReRunHint(t *testing.T) {
 			Server:        "web-01",
 			Command:       "sudo reboot",
 		})
-		assert.Equal(t, "alpacon exec -u root -g docker --work-session ses-1 web-01 -- sudo reboot", got)
+		assert.Equal(t, "alpacon exec -u root -g docker --work-session ses-1 web-01 -- sudo reboot", got.Command)
 	})
 
-	t.Run("emits env keys sorted, never values", func(t *testing.T) {
+	t.Run("emits env keys sorted, never values, with a shell-reread caveat", func(t *testing.T) {
 		got := reRunHint(RemoteExecArgs{
 			Server:  "web-01",
 			Command: "sudo reboot",
 			Env:     map[string]string{"PGPASSWORD": "hunter2", "API_TOKEN": "sk-secret"},
 		})
-		assert.Equal(t, "alpacon exec --env=API_TOKEN --env=PGPASSWORD web-01 -- sudo reboot", got)
-		assert.NotContains(t, got, "hunter2")
-		assert.NotContains(t, got, "sk-secret")
+		assert.Equal(t, "alpacon exec --env=API_TOKEN --env=PGPASSWORD web-01 -- sudo reboot", got.Command)
+		assert.NotContains(t, got.Command, "hunter2")
+		assert.NotContains(t, got.Command, "sk-secret")
+		// Caveat rides in Description so a machine consumer replaying Command isn't misled.
+		assert.Contains(t, got.Description, "re-read from your shell")
 	})
 }

--- a/cmd/exec/sudo_hint_test.go
+++ b/cmd/exec/sudo_hint_test.go
@@ -171,4 +171,15 @@ func TestReRunHint(t *testing.T) {
 		})
 		assert.Equal(t, "alpacon exec -u root -g docker --work-session ses-1 web-01 -- sudo reboot", got)
 	})
+
+	t.Run("emits env keys sorted, never values", func(t *testing.T) {
+		got := reRunHint(RemoteExecArgs{
+			Server:  "web-01",
+			Command: "sudo reboot",
+			Env:     map[string]string{"PGPASSWORD": "hunter2", "API_TOKEN": "sk-secret"},
+		})
+		assert.Equal(t, "alpacon exec --env=API_TOKEN --env=PGPASSWORD web-01 -- sudo reboot", got)
+		assert.NotContains(t, got, "hunter2")
+		assert.NotContains(t, got, "sk-secret")
+	})
 }

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -120,7 +120,9 @@ Shell metacharacters (;, |, &, $) pass through unquoted to the remote shell.
 To send a literal metacharacter, wrap the argument in quotes:
   alpacon websh server 'echo hello;world'
 
-Executing a command (SERVER followed by COMMAND) behaves exactly like 'alpacon exec'.
+Executing a command (SERVER followed by COMMAND) runs through the same executor
+as 'alpacon exec'—identical output, exit codes, and sudo-approval handling.
+Command execution does not accept exec-only flags such as --detach or --wait.
 
 Exit code 3 indicates a WorkSession gate denial; run with --output json to
 parse a machine-readable diagnostic on stderr.
@@ -220,9 +222,9 @@ Note: All flags must be placed before the server name.
 			serverName = sshTarget.Host
 		}
 
-		// Command mode is an alias for exec: delegate to its shared runner so
-		// behavior (approval wait, pending-approval exit code, JSON buffering)
-		// stays identical across the two commands.
+		// Command mode is an alias for exec: delegate to the shared runner so the
+		// pending-approval exit code, sudo-denial hints, and JSON buffering match
+		// exec. Wait is left false—websh has no --wait, so the blocking wait never runs.
 		if len(commandArgs) > 0 {
 			execCmd.RunRemoteExec(execCmd.RemoteExecArgs{
 				Username:      username,

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -54,7 +54,7 @@ func ParseWebshArgs(args []string) (WebshArgs, error) {
 			res.Groupname, i = extractValue(args, i)
 		case strings.HasPrefix(args[i], "--env"):
 			if errMsg := execCmd.ParseEnvArg(args[i], res.Env); errMsg != "" {
-				utils.CliErrorWithExit("%s", errMsg)
+				return res, errors.New(errMsg)
 			}
 		case strings.HasPrefix(args[i], "--read-only"):
 			if strings.Contains(args[i], "=") {

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -138,8 +138,10 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   alpacon websh my-server "ls -la /var/log"
   alpacon websh root@my-server "systemctl status nginx"
 
-  # Set environment variables
-  alpacon websh --env="KEY1=VALUE1" --env="KEY2=VALUE2" my-server "echo $KEY1"
+  # Pass a secret via the shell env; the value stays off every command line and
+  # out of the session recording. psql reads PGPASSWORD directly from the env.
+  export PGPASSWORD=hunter2
+  alpacon websh --env="PGPASSWORD" my-server 'psql -h localhost -U app -c "SELECT 1"'
 
   # Share terminal session
   alpacon websh --share my-server
@@ -159,8 +161,14 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 Flags:
   -u, --username [USER_NAME]         Specify the username for command execution.
   -g, --groupname [GROUP_NAME]       Specify the group name for command execution.
-  --env="KEY=VALUE"                  Set environment variable 'KEY' to 'VALUE'.
-  --env="KEY"                        Use the current shell's value for 'KEY'.
+  --env="KEY"                        Pass an environment variable, reading its value
+                                     from the current shell. This keeps the value off
+                                     the command line and out of the audit log—use it
+                                     for secrets such as passwords or tokens.
+  --env="KEY=VALUE"                  Set 'KEY' to a literal value. Discouraged: the
+                                     value is written on the command line and recorded
+                                     verbatim in the audit log. Never pass credentials
+                                     this way.
   -s, --share                        Share the terminal via a temporary link.
   --read-only=[true|false]           Set shared session to read-only (default: false).
   --work-session [UUID]              Attach this session to a work-session.

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -3,7 +3,6 @@ package websh
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -121,8 +120,12 @@ Shell metacharacters (;, |, &, $) pass through unquoted to the remote shell.
 To send a literal metacharacter, wrap the argument in quotes:
   alpacon websh server 'echo hello;world'
 
+Executing a command (SERVER followed by COMMAND) behaves exactly like 'alpacon exec'.
+
 Exit code 3 indicates a WorkSession gate denial; run with --output json to
 parse a machine-readable diagnostic on stderr.
+Exit code 4 indicates the sudo command is pending human approval; approve it in
+the Alpacon console (web), then re-run—or use 'alpacon exec --wait' to block.
 Requires an active WorkSession when using Browser login (Auth0); Token auth (API token or Service token) bypasses this requirement.`,
 	Example: `  # Open a websh terminal
   alpacon websh my-server
@@ -217,6 +220,22 @@ Note: All flags must be placed before the server name.
 			serverName = sshTarget.Host
 		}
 
+		// Command mode is an alias for exec: delegate to its shared runner so
+		// behavior (approval wait, pending-approval exit code, JSON buffering)
+		// stays identical across the two commands.
+		if len(commandArgs) > 0 {
+			execCmd.RunRemoteExec(execCmd.RemoteExecArgs{
+				Username:      username,
+				Groupname:     groupname,
+				WorkSessionID: parsed.WorkSessionID,
+				OutputFormat:  parsed.OutputFormat,
+				Server:        serverName,
+				Command:       execCmd.ShellJoin(commandArgs),
+				Env:           env,
+			})
+			return
+		}
+
 		if parsed.OutputFormat != "" {
 			if parsed.OutputFormat != utils.OutputFormatTable && parsed.OutputFormat != utils.OutputFormatJSON {
 				utils.CliErrorWithExit("invalid --output value %q: must be 'table' or 'json'", parsed.OutputFormat)
@@ -233,58 +252,51 @@ Note: All flags must be placed before the server name.
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		if len(commandArgs) > 0 {
-			command := execCmd.ShellJoin(commandArgs)
-			err := execCmd.RunCommandWithRetry(alpaconClient, serverName, command, username, groupname, env, workSessionID, os.Stdout)
-			utils.HandleWorkSessionError(err, "command", serverName, authMethod, workSessionID)
-			execCmd.HandleCommandResult(err)
-		} else {
-			session, err := websh.CreateWebshSession(alpaconClient, serverName, username, groupname, share, readOnly, workSessionID)
+		session, err := websh.CreateWebshSession(alpaconClient, serverName, username, groupname, share, readOnly, workSessionID)
+
+		if err != nil {
+			err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
+				OnMFARequired: func(srv string) error {
+					return mfa.HandleMFAError(alpaconClient, srv)
+				},
+				OnUsernameRequired: func() error {
+					_, err := iam.HandleUsernameRequired()
+					return err
+				},
+				CheckMFACompleted: func() (bool, error) {
+					return mfa.CheckMFACompletion(alpaconClient)
+				},
+				RefreshToken: alpaconClient.RefreshToken,
+				RetryOperation: func() error {
+					session, err = websh.CreateWebshSession(alpaconClient, serverName, username, groupname, share, readOnly, workSessionID)
+					return err
+				},
+			})
 
 			if err != nil {
-				err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
-					OnMFARequired: func(srv string) error {
-						return mfa.HandleMFAError(alpaconClient, srv)
-					},
-					OnUsernameRequired: func() error {
-						_, err := iam.HandleUsernameRequired()
-						return err
-					},
-					CheckMFACompleted: func() (bool, error) {
-						return mfa.CheckMFACompletion(alpaconClient)
-					},
-					RefreshToken: alpaconClient.RefreshToken,
-					RetryOperation: func() error {
-						session, err = websh.CreateWebshSession(alpaconClient, serverName, username, groupname, share, readOnly, workSessionID)
-						return err
-					},
-				})
-
-				if err != nil {
-					utils.HandleWorkSessionError(err, "websh", serverName, authMethod, workSessionID)
-					utils.CliErrorWithExit("Failed to create websh session for '%s' server: %s.", serverName, err)
-				}
+				utils.HandleWorkSessionError(err, "websh", serverName, authMethod, workSessionID)
+				utils.CliErrorWithExit("Failed to create websh session for '%s' server: %s.", serverName, err)
 			}
-			// Set up sudo MFA listener in background so it doesn't delay
-			// terminal open. If the user types sudo before the listener is
-			// ready, the approval request will expire and they can retry.
-			listenerDone := make(chan *event.SudoListener, 1)
-			go func() {
-				listenerDone <- setupSudoListener(alpaconClient, session.ID, serverName)
-			}()
-			defer func() {
-				select {
-				case sl := <-listenerDone:
-					if sl != nil {
-						sl.Stop()
-					}
-				case <-time.After(3 * time.Second):
-					// Don't block exit if listener setup is stuck
-				}
-			}()
-
-			_ = websh.OpenNewTerminal(alpaconClient, session)
 		}
+		// Set up sudo MFA listener in background so it doesn't delay
+		// terminal open. If the user types sudo before the listener is
+		// ready, the approval request will expire and they can retry.
+		listenerDone := make(chan *event.SudoListener, 1)
+		go func() {
+			listenerDone <- setupSudoListener(alpaconClient, session.ID, serverName)
+		}()
+		defer func() {
+			select {
+			case sl := <-listenerDone:
+				if sl != nil {
+					sl.Stop()
+				}
+			case <-time.After(3 * time.Second):
+				// Don't block exit if listener setup is stuck
+			}
+		}()
+
+		_ = websh.OpenNewTerminal(alpaconClient, session)
 	},
 }
 

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -143,8 +143,8 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   alpacon websh my-server "ls -la /var/log"
   alpacon websh root@my-server "systemctl status nginx"
 
-  # Pass a secret via the shell env; the value stays off every command line and
-  # out of the session recording. psql reads PGPASSWORD directly from the env.
+  # Pass a secret via the shell env; the value stays off the alpacon command line
+  # and out of the session recording. psql reads PGPASSWORD directly from the env.
   export PGPASSWORD=hunter2
   alpacon websh --env="PGPASSWORD" my-server 'psql -h localhost -U app -c "SELECT 1"'
 
@@ -168,8 +168,8 @@ Flags:
   -g, --groupname [GROUP_NAME]       Specify the group name for command execution.
   --env="KEY"                        Pass an environment variable, reading its value
                                      from the current shell. This keeps the value off
-                                     the command line and out of the audit log—use it
-                                     for secrets such as passwords or tokens.
+                                     the alpacon command line and out of the audit
+                                     log—use it for secrets such as passwords or tokens.
   --env="KEY=VALUE"                  Set 'KEY' to a literal value. Discouraged: the
                                      value is written on the command line and recorded
                                      verbatim in the audit log. Never pass credentials

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -51,7 +51,7 @@ func ParseWebshArgs(args []string) (WebshArgs, error) {
 			res.Username, i = extractValue(args, i)
 		case strings.HasPrefix(args[i], "-g") || strings.HasPrefix(args[i], "--groupname"):
 			res.Groupname, i = extractValue(args, i)
-		case strings.HasPrefix(args[i], "--env"):
+		case args[i] == "--env" || strings.HasPrefix(args[i], "--env="):
 			if errMsg := execCmd.ParseEnvArg(args[i], res.Env); errMsg != "" {
 				return res, errors.New(errMsg)
 			}

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -238,6 +238,12 @@ Note: All flags must be placed before the server name.
 			return
 		}
 
+		// Interactive websh has no channel for env: CreateWebshSession takes none.
+		// Warn rather than silently drop, since the help frames --env as the secrets channel.
+		if len(env) > 0 {
+			utils.CliWarning("--env has no effect on an interactive websh session; it applies only when running a command")
+		}
+
 		if parsed.OutputFormat != "" {
 			if parsed.OutputFormat != utils.OutputFormatTable && parsed.OutputFormat != utils.OutputFormatJSON {
 				utils.CliErrorWithExit("invalid --output value %q: must be 'table' or 'json'", parsed.OutputFormat)

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -53,7 +53,9 @@ func ParseWebshArgs(args []string) (WebshArgs, error) {
 		case strings.HasPrefix(args[i], "-g") || strings.HasPrefix(args[i], "--groupname"):
 			res.Groupname, i = extractValue(args, i)
 		case strings.HasPrefix(args[i], "--env"):
-			i = extractEnvValue(args, i, res.Env)
+			if errMsg := execCmd.ParseEnvArg(args[i], res.Env); errMsg != "" {
+				utils.CliErrorWithExit("%s", errMsg)
+			}
 		case strings.HasPrefix(args[i], "--read-only"):
 			if strings.Contains(args[i], "=") {
 				parts := strings.SplitN(args[i], "=", 2)
@@ -333,27 +335,6 @@ func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *
 	}
 
 	return listener
-}
-
-func extractEnvValue(args []string, i int, env map[string]string) int {
-	envString := strings.TrimPrefix(args[i], "--env=")
-	envString = strings.Trim(envString, "\"")
-
-	parts := strings.SplitN(envString, "=", 2)
-	if len(parts) == 2 {
-		env[parts[0]] = parts[1]
-	} else if len(parts) == 1 {
-		value, exists := os.LookupEnv(parts[0])
-		if !exists {
-			utils.CliWarning("No environment variable found for key '%s'\n", parts[0])
-		} else {
-			env[parts[0]] = value
-		}
-	} else {
-		utils.CliErrorWithExit("Invalid format for --env flag. Expected '--env=KEY=VALUE', but got '%s'. Please use the format: --env=MY_VAR=my_value", args[i])
-	}
-
-	return i
 }
 
 // isNotFoundError checks if an error message indicates a 404/not-found response.

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -349,6 +349,12 @@ func TestParseWebshArgs_WorkSessionEqualForm(t *testing.T) {
 	assert.Equal(t, "my-server", got.ServerName)
 }
 
+func TestParseWebshArgs_EnvErrorHidesSecret(t *testing.T) {
+	_, err := ParseWebshArgs([]string{"--env=\"=hunter2\"", "my-server", "ls"})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "hunter2", "malformed --env error must not echo the value")
+}
+
 func TestParseWebshArgs_CommandAfterServerNotConsumed(t *testing.T) {
 	got, err := ParseWebshArgs([]string{"my-server", "ls", "--work-session", "fake"})
 	require.NoError(t, err)

--- a/cmd/websh/websh_test.go
+++ b/cmd/websh/websh_test.go
@@ -355,6 +355,14 @@ func TestParseWebshArgs_EnvErrorHidesSecret(t *testing.T) {
 	assert.NotContains(t, err.Error(), "hunter2", "malformed --env error must not echo the value")
 }
 
+func TestParseWebshArgs_EnvPrefixIsExact(t *testing.T) {
+	// --env-file must not be swallowed by --env matching; websh has no
+	// unknown-flag rejection, so it falls through to the server-name slot.
+	got, err := ParseWebshArgs([]string{"--env-file=secrets", "ls"})
+	require.NoError(t, err)
+	assert.Equal(t, "--env-file=secrets", got.ServerName)
+}
+
 func TestParseWebshArgs_CommandAfterServerNotConsumed(t *testing.T) {
 	got, err := ParseWebshArgs([]string{"my-server", "ls", "--work-session", "fake"})
 	require.NoError(t, err)


### PR DESCRIPTION
## Background

AI agents such as Claude Code connect to remote databases through `alpacon exec` and often pass credentials directly on the command line (e.g. `mysql -p<password>`). Those commands are recorded verbatim in the audit log, which can expose customer secrets. Passing the value through `--env` instead keeps it off the alpacon command line. The safest form is to set the secret as a shell environment variable and pass only its key name (`--env="DB_PASS"`), so neither the alpacon command line nor the audit log ever contains the actual value, only a reference.

Previously `--env` was supported by websh only; exec failed at parse time with `unknown flag`. Since AI agents primarily use the exec path, they had no way to move credentials off the command line.

## Changes

Add a shared `ParseEnvArg` helper to the exec package that returns an error string instead of calling `os.Exit`, add an `--env` case to `ParseRemoteExecArgs`, and carry the values through `RemoteExecArgs.Env`. `cmd/exec/exec.go` passes `parsed.Env` into `SubmitCommand`/`RunExecWithApprovalWait` instead of an empty map.

The supported forms match websh. `--env="KEY"` reads the value from the current shell (only the key name is on the command line); `--env="KEY=VALUE"` sets a literal value.

`--env` detection matches only the `--env` and `--env=` forms, so an unrelated flag like `--env-file=...` is rejected as an unknown flag by exec (and, in websh, falls through to the server-name slot, which has no unknown-flag rejection) rather than being swallowed and reported as a malformed `--env`.

### Shared parsing and execution across exec and websh

The `--env` parser is unified: websh's `--env` case delegates to the same `ParseEnvArg`, so both commands accept identical forms and produce identical malformed-input errors. `ParseEnvArg` is a pure parser—it returns the error string, and both `ParseRemoteExecArgs` (exec) and `ParseWebshArgs` (websh) surface it the same way, through their normal return path rather than exiting inside the parser.

The execution path is also shared. The post-parse body of exec's command is extracted into `RunRemoteExec`, and websh command mode (`websh SERVER COMMAND`) now maps its parsed args onto `RemoteExecArgs` and calls `RunRemoteExec`. As a result, running a command through websh behaves like `alpacon exec`: same output, exit-code propagation, sudo-approval handling (including the pending-approval exit code 4 and the presence step-up), and `--output json` buffering. websh does not parse exec-only flags such as `--detach`/`--wait`, so its `Wait` is always false and the blocking approval wait never runs; the interactive `websh SERVER` path (no command) is unchanged and keeps its own sudo MFA listener.

The exec and websh help text recommends the shell-env form (`--env="KEY"`), warns that the `--env="KEY=VALUE"` form writes the value on the command line and into the audit log, and scopes the secrecy claim to the alpacon command line (the local `export` that sets the value is still on the shell command line).

## Safety

The whole point of the feature is to keep the secret off the alpacon command line and out of the audit log, so I verified it is never re-exposed. The secret value flows only through the `Env` map; it never enters the `ShellJoin`/`Command` string, stdout, or error/warning messages. The unset-variable warning and the malformed-input error print only the key name, never the value.

`reRunHint` reconstructs the invocation for the pending-approval message and now includes the `--env` keys so a re-run stays faithful—but it emits `--env=KEY` only, never `--env=KEY=VALUE`. The re-run re-reads each value from the shell, so no value lands in the hint on stderr or in the logs.

The help examples use patterns that do not re-expose the value. `PGPASSWORD` with `psql` reads the value from the environment rather than argv, so it lands neither in the remote process's argv (visible via `ps`) nor in terminal output / the session recording.

One behavior change: in websh, malformed `--env` input (an empty key, e.g. `--env=`) now fails the command instead of the previous warn-and-skip. Failing loudly on a malformed credential flag is safer than silently dropping it, and it is consistent with exec.

## Testing

Table-driven coverage for `--env` parsing in both `ParseRemoteExecArgs` and `ParseWebshArgs`: both forms (`KEY=VALUE`, shell-sourced `KEY`), quote unwrapping, unset-variable skip, multiple flags accumulating, empty value, malformed input, and `--env` after the server name being treated as a command arg. It also asserts the shell-sourced value lands in the env map and never appears in the parsed command string. Dedicated regression tests cover the secret-not-echoed-on-malformed-input path (`TestParseRemoteExecArgs_EnvErrorHidesSecret`, `TestParseWebshArgs_EnvErrorHidesSecret`), the exact `--env` matching (`TestParseRemoteExecArgs_EnvPrefixIsExact`, `TestParseWebshArgs_EnvPrefixIsExact`), and the keys-only rerun hint (`TestReRunHint`).

Manual end-to-end run against a live workspace (server `web-editor`):

- Parse-time (no server call): `--env-file=...` rejected as unknown flag in exec; malformed `--env='=hunter2'` returns the format error with the value never echoed, in both exec and websh.
- `--env="PGPASSWORD"` injects the shell value into the remote process (`echo "$PGPASSWORD"` prints it) with only the key on the local command line; `--env=A=1 --env=B=2` accumulates; an unset key warns and is skipped.
- websh command mode matches exec: `--env` injection works, and `exit 7` propagates as exit code 7 through both `exec` and `websh`; `--output json` produces identical output.

`go build ./...`, `go test -race ./cmd/exec/... ./cmd/websh/...`, and `golangci-lint run ./...` all pass.

## Checklist

- [x] `go build ./...` passes
- [x] `go test -race ./cmd/exec/... ./cmd/websh/...` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] exec/websh help text updated
- [x] Manual e2e verified against a live workspace

Closes #263
