### PR TITLE
build(deps): bump go directive to 1.25.12 for crypto/tls fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ _ = json.NewEncoder(w).Encode(resp)
 
 ## Important notes
 
-- **Go version**: 1.25.11 (specified in go.mod)
+- **Go version**: 1.25.12 (specified in go.mod)
 - **Linter**: golangci-lint v2 with errcheck, govet, ineffassign, staticcheck, unused (see `.golangci.yml`)
 - **Config file**: `~/.alpacon/config.json` (dir `0700`, file `0600`)
 - **Alias**: `alpacon` can also be invoked as `ac`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alpacax/alpacon-cli
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Background

`govulncheck ./...` reports GO-2026-5856, an Encrypted Client Hello privacy leak in the standard library `crypto/tls`. It is reachable from our own TLS call sites — the Websh WebSocket dialer (`api/websh/websh.go`), the tunnel copy path (`pkg/tunnel/pool.go`), and the download HTTP client (`client/client.go`) — so it counts as an affected symbol, not just an imported-but-uncalled one. The vulnerability is fixed in `go1.25.12`.

## Changes

Bump the `go` directive in `go.mod` from `1.25.11` to `1.25.12`, and sync the Go version note in `CLAUDE.md` to match. No product source changes are needed since the fix lives in the standard library. CI already pins `1.25.x` across `build-and-test.yaml`, `lint.yaml`, and `release.yaml`, so it picks up the patch release automatically.

## Verification

Built and re-scanned locally with the `go1.25.12` toolchain (auto-downloaded via `GOTOOLCHAIN=auto`):

- `go build -o alpacon .` succeeds.
- `govulncheck ./...` now reports `No vulnerabilities found` — GO-2026-5856 is gone.

## Out of scope

One vulnerability remains that our code does not call: GO-2026-5024 (integer overflow in `golang.org/x/sys` `NewNTUnicodeString`, Windows-only, fixed in `v0.44.0`). It affects 0 symbols we invoke, so it is left for a separate dependency bump.
