### PR TITLE
feat(auth0): prefer the server-provided org identity for OAuth scopes

### DIFF
--- a/api/auth0/auth0.go
+++ b/api/auth0/auth0.go
@@ -59,10 +59,22 @@ func FetchAuthEnv(workspaceURL string, httpClient *http.Client) (*AuthEnvRespons
 	return &env, nil
 }
 
+// resolveOrgName returns the Auth0 organization hint used in OAuth scopes.
+// It prefers the server-provided schema name—the frozen workspace identity
+// that equals the Auth0 organization name—so logins keep working after a
+// workspace URL label changes. Older servers omit the field; fall back to
+// the caller-derived label.
+func resolveOrgName(envInfo *AuthEnvResponse, fallback string) string {
+	if envInfo != nil && envInfo.Auth0.SchemaName != "" {
+		return envInfo.Auth0.SchemaName
+	}
+	return fallback
+}
+
 func RequestDeviceCode(workspaceName string, httpClient *http.Client, envInfo *AuthEnvResponse) (*DeviceCodeResponse, error) {
 	data := map[string]string{
 		"client_id": envInfo.Auth0.ClientID,
-		"scope":     fmt.Sprintf("openid profile email offline_access cli org:%s", workspaceName),
+		"scope":     fmt.Sprintf("openid profile email offline_access cli org:%s", resolveOrgName(envInfo, workspaceName)),
 		"audience":  envInfo.Auth0.Audience,
 	}
 
@@ -141,16 +153,19 @@ func RefreshAccessToken(workspaceURL string, httpClient *http.Client, refreshTok
 		return nil, err
 	}
 
-	subDomain, err := extractSubdomain(workspaceURL)
-	if err != nil {
-		return nil, err
+	orgName := resolveOrgName(envInfo, "")
+	if orgName == "" {
+		orgName, err = extractSubdomain(workspaceURL)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	data := map[string]string{
 		"grant_type":    "refresh_token",
 		"client_id":     envInfo.Auth0.ClientID,
 		"refresh_token": refreshToken,
-		"scope":         fmt.Sprintf("cli org:%s", subDomain),
+		"scope":         fmt.Sprintf("cli org:%s", orgName),
 	}
 
 	jsonData, err := json.Marshal(data)

--- a/api/auth0/auth0_test.go
+++ b/api/auth0/auth0_test.go
@@ -1,0 +1,142 @@
+package auth0
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveOrgName(t *testing.T) {
+	tests := []struct {
+		name     string
+		envInfo  *AuthEnvResponse
+		fallback string
+		expected string
+	}{
+		{
+			name: "Server-provided schema name wins over the fallback label",
+			envInfo: &AuthEnvResponse{
+				Auth0: Auth0Config{Method: "auth0", SchemaName: "frozen-name"},
+			},
+			fallback: "renamed-label",
+			expected: "frozen-name",
+		},
+		{
+			name: "Older server without schema name falls back to the label",
+			envInfo: &AuthEnvResponse{
+				Auth0: Auth0Config{Method: "auth0"},
+			},
+			fallback: "myworkspace",
+			expected: "myworkspace",
+		},
+		{
+			name:     "Nil env info falls back to the label",
+			envInfo:  nil,
+			fallback: "myworkspace",
+			expected: "myworkspace",
+		},
+		{
+			name: "Empty fallback stays empty when the server omits the field",
+			envInfo: &AuthEnvResponse{
+				Auth0: Auth0Config{Method: "auth0"},
+			},
+			fallback: "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, resolveOrgName(tt.envInfo, tt.fallback))
+		})
+	}
+}
+
+func TestFetchAuthEnv(t *testing.T) {
+	tests := []struct {
+		name             string
+		responseBody     string
+		expectSchemaName string
+	}{
+		{
+			name: "Server provides the frozen schema name",
+			responseBody: `{
+				"auth0": {
+					"method": "auth0",
+					"client_id": "client123",
+					"domain": "auth.example.com",
+					"audience": "https://api.example.com/",
+					"schema_name": "frozen-name",
+					"workspace_id": "8b0f2c8e-0000-0000-0000-000000000000"
+				},
+				"language": "en"
+			}`,
+			expectSchemaName: "frozen-name",
+		},
+		{
+			name: "Older server omits the schema name",
+			responseBody: `{
+				"auth0": {
+					"method": "auth0",
+					"client_id": "client123",
+					"domain": "auth.example.com",
+					"audience": "https://api.example.com/"
+				},
+				"language": "en"
+			}`,
+			expectSchemaName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/auth/env/", r.URL.Path)
+				assert.Equal(t, "cli", r.URL.Query().Get("client"))
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer ts.Close()
+
+			envInfo, err := FetchAuthEnv(ts.URL, ts.Client())
+			assert.NoError(t, err)
+			assert.Equal(t, "auth0", envInfo.Auth0.Method)
+			assert.Equal(t, "client123", envInfo.Auth0.ClientID)
+			assert.Equal(t, tt.expectSchemaName, envInfo.Auth0.SchemaName)
+		})
+	}
+}
+
+func TestExtractSubdomain(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "Cloud workspace URL",
+			url:      "https://myws.us1.alpacon.io",
+			expected: "myws",
+		},
+		{
+			name:      "Host without a subdomain",
+			url:       "https://example.io",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subdomain, err := extractSubdomain(tt.url)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, subdomain)
+		})
+	}
+}

--- a/api/auth0/types.go
+++ b/api/auth0/types.go
@@ -25,6 +25,11 @@ type Auth0Config struct {
 	ClientID string `json:"client_id,omitempty"`
 	Domain   string `json:"domain,omitempty"`
 	Audience string `json:"audience,omitempty"`
+	// SchemaName is the frozen workspace identity, which equals the Auth0
+	// organization name. Prefer it over the workspace URL label when building
+	// the org scope—the URL label can change while this never does. Empty on
+	// older servers that do not return the field.
+	SchemaName string `json:"schema_name,omitempty"`
 }
 
 type AuthEnvResponse struct {


### PR DESCRIPTION
## Why

The device-code login and refresh flows derive the `org:` value in their OAuth scopes from the workspace URL's first label (`ExtractWorkspaceName` / `extractSubdomain`). That label is a mutable part of the URL: a workspace's address can be renamed over its lifetime, while the Auth0 organization name stays fixed. After such a rename, a login against the new host would send an org hint that no longer matches the organization, and authentication would fail.

## What

The auth env endpoint (`/api/auth/env`) already returns `schema_name`—the frozen workspace identity, which equals the Auth0 organization name. This change reads the org from there:

- `Auth0Config` gains a `SchemaName` field (`schema_name` in the response).
- `RequestDeviceCode` and `RefreshAccessToken` build their `org:` scope from `resolveOrgName(envInfo, fallback)`, which prefers the server-provided value.
- The URL-derived label remains the fallback for older servers that omit the field, so behavior is unchanged against existing deployments.

## Compatibility

- Servers have returned `schema_name` in this endpoint since v2.2.4, so the preferred path is already live on current deployments.
- Self-hosted servers using local auth are unaffected (no Auth0 flow).
- Server counterpart: alpacax/alpacon-server#2514 documents this contract and adds `workspace_id` alongside it.

## Tests

- New `api/auth0/auth0_test.go`: table-driven tests for `resolveOrgName` (server value preferred, fallback on absence/nil), `FetchAuthEnv` parsing with and without `schema_name`, and `extractSubdomain`.
- `go build ./...`, `go test -race ./...` all pass; `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3bLh8D5D6f9WdKonA7LcZ