### PR TITLE
docs: unify example resource IDs in command help

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ Use: "tunnel [SERVER] -l LOCAL -r REMOTE [flags]"
 - Cobra `Short` descriptions should be concise (under 50 chars) and start with a verb
 - Cobra `Long` descriptions should document SSH-like `user@host` syntax where supported
 - Cobra `Example` blocks should use realistic server names (e.g., `my-server`, not `[SERVER_NAME]`)
+- Cobra `Example` IDs: for any server-side UUID (session, certificate, note, token, job, and a user referenced by UUID such as `work-session ls --user`), use the single placeholder `550e8400-e29b-41d4-a716-446655440000`—never invent prefixed forms like `ses-`/`apr-`, those IDs are plain UUIDs. Name-like values stay realistic: a server name (`my-server`), or a username in `user@host` syntax (`root@my-server`)
 - List commands should project API responses into `*Attributes` structs for `utils.PrintTable()`
 - Comments must be written in English
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Use: "exec [USER@]SERVER COMMAND... [flags]"
 - `Short`: Concise, starts with a verb, under 50 chars
 - `Long`: Document SSH-like `user@host` syntax where supported
 - `Example`: Use realistic values (e.g., `my-server`, not `[SERVER_NAME]`)
-- `Example` IDs: for any server-side UUID (session, certificate, note, token, job, etc.), always use the single placeholder `550e8400-e29b-41d4-a716-446655440000`. It keeps the real UUID shape while being obviously a stand-in, and never invent prefixed forms like `ses-`/`apr-`—those IDs are plain UUIDs on the server. Name-like values (server, user) stay realistic per the rule above
+- `Example` IDs: for any server-side UUID (session, certificate, note, token, job, and a user referenced by UUID such as `work-session ls --user`), always use the single placeholder `550e8400-e29b-41d4-a716-446655440000`. It keeps the real UUID shape while being obviously a stand-in, and never invent prefixed forms like `ses-`/`apr-`—those IDs are plain UUIDs on the server. Name-like values stay realistic per the rule above: a server name (`my-server`), or a username in `user@host` syntax (`root@my-server`)
 
 ### Go declaration order
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Use: "exec [USER@]SERVER COMMAND... [flags]"
 - `Short`: Concise, starts with a verb, under 50 chars
 - `Long`: Document SSH-like `user@host` syntax where supported
 - `Example`: Use realistic values (e.g., `my-server`, not `[SERVER_NAME]`)
+- `Example` IDs: for any server-side UUID (session, certificate, note, token, job, etc.), always use the single placeholder `550e8400-e29b-41d4-a716-446655440000`. It keeps the real UUID shape while being obviously a stand-in, and never invent prefixed forms like `ses-`/`apr-`—those IDs are plain UUIDs on the server. Name-like values (server, user) stay realistic per the rule above
 
 ### Go declaration order
 

--- a/cmd/approval/approval_cancel.go
+++ b/cmd/approval/approval_cancel.go
@@ -17,7 +17,7 @@ pending request.
 Cancelling a work_session request also cancels the linked work
 session.`,
 	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon approval cancel apr-abc123`,
+	Example: `  alpacon approval cancel 550e8400-e29b-41d4-a716-446655440000`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/approval/approval_describe.go
+++ b/cmd/approval/approval_describe.go
@@ -21,8 +21,8 @@ var approvalDescribeCmd = &cobra.Command{
 Use --output json to see the full raw response including nested
 work session details that are omitted from the table view.`,
 	Args: cobra.ExactArgs(1),
-	Example: `  alpacon approval describe apr-abc123
-  alpacon approval desc apr-abc123`,
+	Example: `  alpacon approval describe 550e8400-e29b-41d4-a716-446655440000
+  alpacon approval desc 550e8400-e29b-41d4-a716-446655440000`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/csr/csr_retry.go
+++ b/cmd/csr/csr_retry.go
@@ -14,7 +14,7 @@ var csrRetryCmd = &cobra.Command{
 	Retries a previously failed Certificate Signing Request,
 	resubmitting it for processing in the signing pipeline.
 	`,
-	Example: `alpacon csr retry CSR_ID`,
+	Example: `alpacon csr retry 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		csrId := args[0]

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -82,7 +82,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 
   # Submit a command asynchronously and retrieve the result later
   alpacon exec --detach web-server -- apt-get update
-  alpacon exec logs <JOB_ID>`,
+  alpacon exec logs 550e8400-e29b-41d4-a716-446655440000`,
 	// DisableFlagParsing is required because remote command arguments (e.g., -U, -d)
 	// would otherwise be consumed by Cobra's flag parser.
 	// All flags are parsed manually in the Run function.

--- a/cmd/exec/logs.go
+++ b/cmd/exec/logs.go
@@ -18,13 +18,13 @@ var logsCmd = &cobra.Command{
 
 If the command is still running, prints the current status and exits.
 Run the command again later to check for completion.`,
-	Example: `  alpacon exec logs a1b2c3d4-5678-abcd-ef01-234567890abc`,
+	Example: `  alpacon exec logs 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jobID := args[0]
 
 		if !utils.IsUUID(jobID) {
-			utils.CliErrorWithExit("invalid JOB_ID %q: must be a UUID (e.g. a1b2c3d4-5678-abcd-ef01-234567890abc)", jobID)
+			utils.CliErrorWithExit("invalid JOB_ID %q: must be a UUID (e.g. 550e8400-e29b-41d4-a716-446655440000)", jobID)
 			return
 		}
 

--- a/cmd/ftp/cp.go
+++ b/cmd/ftp/cp.go
@@ -52,7 +52,7 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
   alpacon cp --no-overwrite /local/file.txt my-server:/remote/path/
 
   # Attach the transfer to a work-session
-  alpacon cp /local/file.txt my-server:/remote/path/ --work-session 11111111-2222-3333-4444-555555555555`,
+  alpacon cp /local/file.txt my-server:/remote/path/ --work-session 550e8400-e29b-41d4-a716-446655440000`,
 	Run: func(cmd *cobra.Command, args []string) {
 		username, _ := cmd.Flags().GetString("username")
 		groupname, _ := cmd.Flags().GetString("groupname")

--- a/cmd/revoke/revoke_approve.go
+++ b/cmd/revoke/revoke_approve.go
@@ -14,7 +14,7 @@ var revokeApproveCmd = &cobra.Command{
 	Approves a pending certificate revoke request, moving it forward in the
 	revocation process to eventually revoke the certificate.
 	`,
-	Example: `alpacon revoke approve REQUEST_ID`,
+	Example: `alpacon revoke approve 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		requestId := args[0]

--- a/cmd/revoke/revoke_cancel.go
+++ b/cmd/revoke/revoke_cancel.go
@@ -15,8 +15,8 @@ var revokeCancelCmd = &cobra.Command{
 	This action is irreversible.
 	`,
 	Example: `
-	alpacon revoke cancel REQUEST_ID
-	alpacon revoke cancel REQUEST_ID -y
+	alpacon revoke cancel 550e8400-e29b-41d4-a716-446655440000
+	alpacon revoke cancel 550e8400-e29b-41d4-a716-446655440000 -y
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/revoke/revoke_create.go
+++ b/cmd/revoke/revoke_create.go
@@ -23,7 +23,7 @@ var revokeCreateCmd = &cobra.Command{
 	`,
 	Example: `
 	alpacon revoke create
-	alpacon revoke create --certificate=CERT_ID --reason=1 --requested-reason="Key was compromised"
+	alpacon revoke create --certificate=550e8400-e29b-41d4-a716-446655440000 --reason=1 --requested-reason="Key was compromised"
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		certificate, _ := cmd.Flags().GetString("certificate")

--- a/cmd/revoke/revoke_deny.go
+++ b/cmd/revoke/revoke_deny.go
@@ -13,7 +13,7 @@ var revokeDenyCmd = &cobra.Command{
 	Long: `
 	Denies a pending certificate revoke request, preventing the certificate from being revoked.
 	`,
-	Example: `alpacon revoke deny REQUEST_ID`,
+	Example: `alpacon revoke deny 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		requestId := args[0]

--- a/cmd/revoke/revoke_retry.go
+++ b/cmd/revoke/revoke_retry.go
@@ -14,7 +14,7 @@ var revokeRetryCmd = &cobra.Command{
 	Retries a previously failed certificate revoke request,
 	resubmitting it for processing in the revocation pipeline.
 	`,
-	Example: `alpacon revoke retry REQUEST_ID`,
+	Example: `alpacon revoke retry 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		requestId := args[0]

--- a/cmd/tunnel/tunnel.go
+++ b/cmd/tunnel/tunnel.go
@@ -67,7 +67,7 @@ var TunnelCmd = &cobra.Command{
 	alpacon tunnel my-server -l 9000 -r 8082 -u admin -g developers
 
 	# Attach the tunnel to a work-session
-	alpacon tunnel my-server -l 9000 -r 8082 --work-session 11111111-2222-3333-4444-555555555555
+	alpacon tunnel my-server -l 9000 -r 8082 --work-session 550e8400-e29b-41d4-a716-446655440000
 
 	# Run psql with attached tunnel session
 	alpacon tunnel prod-db -l 5432 -r 5432 -- psql -h 127.0.0.1 -p 5432 -U app appdb

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -157,11 +157,11 @@ Requires an active WorkSession when using Browser login (Auth0); Token auth (API
 
   # Session management
   alpacon websh ls                          # List active sessions
-  alpacon websh describe SESSION_ID         # Show session details
-  alpacon websh watch SESSION_ID            # Watch a session (read-only, staff/superuser only)
-  alpacon websh invite SESSION_ID --email user@example.com
-  alpacon websh close SESSION_ID            # Close a session
-  alpacon websh force-close SESSION_ID      # Force close (admin only)
+  alpacon websh describe 550e8400-e29b-41d4-a716-446655440000         # Show session details
+  alpacon websh watch 550e8400-e29b-41d4-a716-446655440000            # Watch a session (read-only, staff/superuser only)
+  alpacon websh invite 550e8400-e29b-41d4-a716-446655440000 --email user@example.com
+  alpacon websh close 550e8400-e29b-41d4-a716-446655440000            # Close a session
+  alpacon websh force-close 550e8400-e29b-41d4-a716-446655440000      # Force close (admin only)
 
 Flags:
   -u, --username [USER_NAME]         Specify the username for command execution.

--- a/cmd/websh/websh_close.go
+++ b/cmd/websh/websh_close.go
@@ -10,7 +10,7 @@ import (
 var webshCloseCmd = &cobra.Command{
 	Use:     "close SESSION_ID",
 	Short:   "Close a websh session",
-	Example: `  alpacon websh close abc123`,
+	Example: `  alpacon websh close 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		sessionID := args[0]

--- a/cmd/websh/websh_describe.go
+++ b/cmd/websh/websh_describe.go
@@ -11,8 +11,8 @@ var webshDescribeCmd = &cobra.Command{
 	Use:     "describe SESSION_ID",
 	Aliases: []string{"desc"},
 	Short:   "Display detailed information about a websh session",
-	Example: `  alpacon websh describe abc123
-  alpacon websh desc abc123`,
+	Example: `  alpacon websh describe 550e8400-e29b-41d4-a716-446655440000
+  alpacon websh desc 550e8400-e29b-41d4-a716-446655440000`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		sessionID := args[0]

--- a/cmd/websh/websh_force_close.go
+++ b/cmd/websh/websh_force_close.go
@@ -10,7 +10,7 @@ import (
 var webshForceCloseCmd = &cobra.Command{
 	Use:     "force-close SESSION_ID",
 	Short:   "Force close a websh session (admin only)",
-	Example: `  alpacon websh force-close abc123`,
+	Example: `  alpacon websh force-close 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		sessionID := args[0]

--- a/cmd/websh/websh_invite.go
+++ b/cmd/websh/websh_invite.go
@@ -12,9 +12,9 @@ var webshInviteCmd = &cobra.Command{
 	Short: "Invite users to a websh session by email",
 	Long: `Invite one or more users to join an existing websh session.
 An invitation email will be sent to each specified address.`,
-	Example: `  alpacon websh invite abc123 --email user@example.com
-  alpacon websh invite abc123 --email user1@example.com --email user2@example.com
-  alpacon websh invite abc123 --email user@example.com --read-only`,
+	Example: `  alpacon websh invite 550e8400-e29b-41d4-a716-446655440000 --email user@example.com
+  alpacon websh invite 550e8400-e29b-41d4-a716-446655440000 --email user1@example.com --email user2@example.com
+  alpacon websh invite 550e8400-e29b-41d4-a716-446655440000 --email user@example.com --read-only`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		sessionID := args[0]

--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -17,9 +17,9 @@ var webshRecordsCmd = &cobra.Command{
 filtering by command text. Available on paid plans only.
 
 Use --query to search records by command text (fuzzy match).`,
-	Example: `  alpacon websh records abc123
-  alpacon websh records abc123 --query docker
-  alpacon websh rec abc123 -q "sudo reboot" -n 50`,
+	Example: `  alpacon websh records 550e8400-e29b-41d4-a716-446655440000
+  alpacon websh records 550e8400-e29b-41d4-a716-446655440000 --query docker
+  alpacon websh rec 550e8400-e29b-41d4-a716-446655440000 -q "sudo reboot" -n 50`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		sessionID := args[0]

--- a/cmd/websh/websh_watch.go
+++ b/cmd/websh/websh_watch.go
@@ -14,7 +14,7 @@ import (
 var webshWatchCmd = &cobra.Command{
 	Use:     "watch SESSION_ID",
 	Short:   "Watch an active websh session (staff/superuser only)",
-	Example: `  alpacon websh watch abc123`,
+	Example: `  alpacon websh watch 550e8400-e29b-41d4-a716-446655440000`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		sessionID := args[0]

--- a/cmd/worksession/worksession_activate.go
+++ b/cmd/worksession/worksession_activate.go
@@ -11,7 +11,7 @@ var workSessionActivateCmd = &cobra.Command{
 	Use:     "activate SESSION_ID",
 	Short:   "Activate an approved work session",
 	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon work-session activate ses-abc123`,
+	Example: `  alpacon work-session activate 550e8400-e29b-41d4-a716-446655440000`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/worksession/worksession_cancel.go
+++ b/cmd/worksession/worksession_cancel.go
@@ -12,7 +12,7 @@ var workSessionCancelCmd = &cobra.Command{
 	Short:   "Withdraw your own pending work session request",
 	Long:    "Withdraw a pending work session you requested before it is reviewed. Restricted to the session's requester (or a superuser); only pending sessions can be cancelled.",
 	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon work-session cancel ses-abc123`,
+	Example: `  alpacon work-session cancel 550e8400-e29b-41d4-a716-446655440000`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/worksession/worksession_complete.go
+++ b/cmd/worksession/worksession_complete.go
@@ -11,7 +11,7 @@ var workSessionCompleteCmd = &cobra.Command{
 	Use:     "complete SESSION_ID",
 	Short:   "Mark an active work session as completed",
 	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon work-session complete ses-abc123`,
+	Example: `  alpacon work-session complete 550e8400-e29b-41d4-a716-446655440000`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/worksession/worksession_describe.go
+++ b/cmd/worksession/worksession_describe.go
@@ -20,8 +20,8 @@ var workSessionDescribeCmd = &cobra.Command{
 	Aliases: []string{"desc"},
 	Short:   "Show details of a work session",
 	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon work-session describe ses-abc123
-  alpacon work-session desc ses-abc123`,
+	Example: `  alpacon work-session describe 550e8400-e29b-41d4-a716-446655440000
+  alpacon work-session desc 550e8400-e29b-41d4-a716-446655440000`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/worksession/worksession_extend.go
+++ b/cmd/worksession/worksession_extend.go
@@ -16,8 +16,8 @@ var workSessionExtendCmd = &cobra.Command{
 	Use:   "extend SESSION_ID",
 	Short: "Extend the expiry of an approved or active work session",
 	Args:  cobra.ExactArgs(1),
-	Example: `  alpacon work-session extend ses-abc123 --expires-in 2h
-  alpacon work-session extend ses-abc123 --expires-at 2026-05-09T10:00:00Z`,
+	Example: `  alpacon work-session extend 550e8400-e29b-41d4-a716-446655440000 --expires-in 2h
+  alpacon work-session extend 550e8400-e29b-41d4-a716-446655440000 --expires-at 2026-05-09T10:00:00Z`,
 	Run: func(cmd *cobra.Command, args []string) {
 		expiresAtVal, err := parseExpiryFlag(extendExpiresIn, extendExpiresAt)
 		if err != nil {

--- a/cmd/worksession/worksession_list.go
+++ b/cmd/worksession/worksession_list.go
@@ -59,7 +59,7 @@ var workSessionListCmd = &cobra.Command{
   alpacon work-session ls --user all               # everyone's active sessions
   alpacon work-session ls --user all --status all  # all sessions
   alpacon work-session ls --requester-type agent
-  alpacon work-session ls --user <USER_ID> --status active`,
+  alpacon work-session ls --user 550e8400-e29b-41d4-a716-446655440000 --status active`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if requesterFilter != "" && requesterFilter != "user" && requesterFilter != "agent" {
 			utils.CliUsageErrorEnvelopeWithExit(opList, "Invalid --requester-type %q: must be \"user\" or \"agent\".", requesterFilter)

--- a/cmd/worksession/worksession_recording.go
+++ b/cmd/worksession/worksession_recording.go
@@ -16,9 +16,9 @@ var workSessionRecordingCmd = &cobra.Command{
 	Aliases: []string{"rec"},
 	Short:   "Show a Websh session recording",
 	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon work-session recording ses-abc123
-  alpacon work-session recording ses-abc123 --index 2
-  alpacon work-session rec ses-abc123`,
+	Example: `  alpacon work-session recording 550e8400-e29b-41d4-a716-446655440000
+  alpacon work-session recording 550e8400-e29b-41d4-a716-446655440000 --index 2
+  alpacon work-session rec 550e8400-e29b-41d4-a716-446655440000`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/worksession/worksession_revoke.go
+++ b/cmd/worksession/worksession_revoke.go
@@ -12,7 +12,7 @@ var workSessionRevokeCmd = &cobra.Command{
 	Short:   "Force-terminate an active or approved work session",
 	Long:    "Force-terminate an active or approved work session. Superuser only.",
 	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon work-session revoke ses-abc123`,
+	Example: `  alpacon work-session revoke 550e8400-e29b-41d4-a716-446655440000`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/worksession/worksession_timeline.go
+++ b/cmd/worksession/worksession_timeline.go
@@ -30,9 +30,9 @@ var workSessionTimelineCmd = &cobra.Command{
 	Aliases: []string{"tl"},
 	Short:   "Show the activity timeline for a work session",
 	Args:    cobra.ExactArgs(1),
-	Example: `  alpacon work-session timeline ses-abc123
-  alpacon work-session timeline ses-abc123 --no-records
-  alpacon work-session tl ses-abc123 --output json`,
+	Example: `  alpacon work-session timeline 550e8400-e29b-41d4-a716-446655440000
+  alpacon work-session timeline 550e8400-e29b-41d4-a716-446655440000 --no-records
+  alpacon work-session tl 550e8400-e29b-41d4-a716-446655440000 --output json`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ac, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/worksession/worksession_update.go
+++ b/cmd/worksession/worksession_update.go
@@ -46,11 +46,11 @@ If SESSION_ID is omitted, the effective work session is resolved from the
 ALPACON_WORK_SESSION environment variable, then the workspace's active session
 (set via 'alpacon work-session use').`,
 	Args: cobra.MaximumNArgs(1),
-	Example: `  alpacon work-session update ses-abc123 --title "deploy v2" --description "rollout"
-  alpacon work-session update ses-abc123 --server web-01,db-01
-  alpacon work-session update ses-abc123 --scope command,websh
-  alpacon work-session update ses-abc123 --starts-at 2027-01-15T10:00:00Z --expires-at 2027-01-15T12:00:00Z
-  alpacon work-session update ses-abc123 --sudo "systemctl restart nginx"
+	Example: `  alpacon work-session update 550e8400-e29b-41d4-a716-446655440000 --title "deploy v2" --description "rollout"
+  alpacon work-session update 550e8400-e29b-41d4-a716-446655440000 --server web-01,db-01
+  alpacon work-session update 550e8400-e29b-41d4-a716-446655440000 --scope command,websh
+  alpacon work-session update 550e8400-e29b-41d4-a716-446655440000 --starts-at 2027-01-15T10:00:00Z --expires-at 2027-01-15T12:00:00Z
+  alpacon work-session update 550e8400-e29b-41d4-a716-446655440000 --sudo "systemctl restart nginx"
   alpacon work-session update --sudo "tail -f /var/log/nginx/*.log"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var sessionID string

--- a/cmd/worksession/worksession_use.go
+++ b/cmd/worksession/worksession_use.go
@@ -28,7 +28,7 @@ var workSessionUseCmd = &cobra.Command{
 	Long: `Set the active work-session for the current workspace by passing its SESSION_ID.
 Subsequent exec/websh/cp/tunnel commands attach to this session unless overridden with --work-session.
 Pass --unset (with no SESSION_ID) to clear the active work-session.`,
-	Example: `  alpacon work-session use ses-abc123
+	Example: `  alpacon work-session use 550e8400-e29b-41d4-a716-446655440000
   alpacon work-session use --unset`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if unsetActiveWorkSession {


### PR DESCRIPTION
## Background

The Cobra `Example:` strings across `cmd/**` showed the same concept—a server-side resource UUID—with different placeholders depending on the command: `abc123`, `ses-abc123`, `apr-abc123`, `550e8400-...`, `11111111-2222-...`, and `a1b2c3d4-...` all coexisted. Neither CLAUDE.md nor the Copilot instructions had a rule for ID formatting, so each command family had drifted on its own. This is a docs/help-text cleanup with no runtime change. Closes #262.

## What changed

Every `Example:` field that shows a server-side resource UUID (session, certificate, csr, revoke request, note, token, job) now uses the single placeholder `550e8400-e29b-41d4-a716-446655440000`. This includes `cmd/csr/csr_retry.go`, `cmd/revoke/*`, `cmd/exec/exec.go`, `cmd/websh/websh.go`, and `cmd/worksession/worksession_list.go`, which still carried symbolic ALL-CAPS stand-ins (`REQUEST_ID`, `CSR_ID`, `CERT_ID`, `JOB_ID`, `SESSION_ID`, `USER_ID`) in their Example fields even though sibling commands already used a concrete UUID. The client-side UUID validation error message in exec logs uses the same placeholder.

The ID-formatting rule was added to the `Example` convention section in both CLAUDE.md and `.github/copilot-instructions.md` so this stops drifting and automated review enforces it. The rule splits guidance by value type: UUID-referenced identifiers (including a user referenced by UUID such as `work-session ls --user`) use the placeholder UUID, while name-like values—a server name, or a username in `user@host` syntax—stay realistic.

The `Use:` field argument-name placeholders (e.g. `cancel REQUEST_ID`) and the old IDs in `_test.go` fixtures are not example values, so they are out of scope and left unchanged.

## Safety

I confirmed via the server API that work-session IDs and approval request IDs are both plain UUIDs. The `ses-`/`apr-` prefixes describe a format that does not exist, so dropping them from the examples matches actual behavior.

The share-link URL path token `abcd1234` in `cmd/websh/websh_join.go` and `cmd/websh/websh.go` is intentionally left unchanged. `JoinWebshSession` in `api/websh/websh.go` parses only the `?channel=` query parameter and ignores the path segment, and the token's real format is determined by the server frontend, which cannot be verified in this repo. It is left as-is to avoid asserting an unverified format.

## Testing

`go build ./...` and `go vet ./cmd/...` pass. There is no runtime logic change, so existing tests are unaffected.

## Checklist

- [x] build/vet pass
- [x] confirmed work-session/approval IDs are plain UUIDs on the server
- [x] added the ID-formatting rule to CLAUDE.md and .github/copilot-instructions.md

Closes #262