### PR TITLE
fix: decode ES cursor pagination in webftp-log, audit, and log commands

### DIFF
--- a/api/audit/audit.go
+++ b/api/audit/audit.go
@@ -1,9 +1,6 @@
 package audit
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/api/iam"
 	"github.com/alpacax/alpacon-cli/client"
@@ -14,11 +11,8 @@ const (
 	auditURL = "/api/audit/activity/"
 )
 
-func GetAuditLogList(ac *client.AlpaconClient, pageSize int, userName string, app string, model string) ([]AuditLogAttributes, error) {
+func GetAuditLogList(ac *client.AlpaconClient, tail int, userName string, app string, model string) ([]AuditLogAttributes, error) {
 	params := map[string]string{}
-	if pageSize > 0 {
-		params["page_size"] = fmt.Sprintf("%d", pageSize)
-	}
 	if userName != "" {
 		userID, err := iam.GetUserIDByName(ac, userName)
 		if err != nil {
@@ -33,18 +27,13 @@ func GetAuditLogList(ac *client.AlpaconClient, pageSize int, userName string, ap
 		params["model"] = model
 	}
 
-	responseBody, err := ac.SendGetRequest(utils.BuildURL(auditURL, "", params))
+	entries, err := api.FetchCursorPages[AuditLogEntry](ac, auditURL, params, tail)
 	if err != nil {
 		return nil, err
 	}
 
-	var response api.ListResponse[AuditLogEntry]
-	if err = json.Unmarshal(responseBody, &response); err != nil {
-		return nil, err
-	}
-
 	var auditList []AuditLogAttributes
-	for _, entry := range response.Results {
+	for _, entry := range entries {
 		auditList = append(auditList, AuditLogAttributes{
 			Username:    entry.Username,
 			App:         entry.App,

--- a/api/audit/audit_test.go
+++ b/api/audit/audit_test.go
@@ -1,0 +1,37 @@
+package audit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/api"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for #274: a cursor-token next crashed the old int-typed unmarshal.
+func TestGetAuditLogList_FollowsCursor(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_ = json.NewEncoder(w).Encode(api.CursorListResponse[AuditLogEntry]{
+				Next:    "eyJzIjpbMV0sImQiOiJhZnRlciJ9",
+				Results: []AuditLogEntry{{Username: "alice", App: "cert"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(api.CursorListResponse[AuditLogEntry]{
+			Results: []AuditLogEntry{{Username: "bob", App: "iam"}},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	logs, err := GetAuditLogList(ac, 5, "", "", "")
+	require.NoError(t, err)
+	require.Len(t, logs, 2)
+	assert.Equal(t, "bob", logs[1].Username)
+}

--- a/api/audit/audit_test.go
+++ b/api/audit/audit_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api"
@@ -34,4 +36,30 @@ func TestGetAuditLogList_FollowsCursor(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, logs, 2)
 	assert.Equal(t, "bob", logs[1].Username)
+}
+
+func TestGetAuditLogList_Filters(t *testing.T) {
+	var gotQuery url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/api/iam/users") {
+			assert.Equal(t, "alice", r.URL.Query().Get("username"))
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"user-1"}]}`))
+			return
+		}
+		gotQuery = r.URL.Query()
+		_ = json.NewEncoder(w).Encode(api.CursorListResponse[AuditLogEntry]{
+			Results: []AuditLogEntry{{Username: "alice"}},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	logs, err := GetAuditLogList(ac, 5, "alice", "cert", "certificate")
+	require.NoError(t, err)
+	assert.Len(t, logs, 1)
+	// The username filter is resolved to a user ID before hitting the audit endpoint.
+	assert.Equal(t, "user-1", gotQuery.Get("user"))
+	assert.Equal(t, "cert", gotQuery.Get("app"))
+	assert.Equal(t, "certificate", gotQuery.Get("model"))
 }

--- a/api/log/log.go
+++ b/api/log/log.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/alpacax/alpacon-cli/api"
@@ -14,7 +13,7 @@ const (
 	getSystemLogURL = "/api/history/logs/"
 )
 
-func GetSystemLogList(ac *client.AlpaconClient, serverName string, pageSize int) ([]LogAttributes, error) {
+func GetSystemLogList(ac *client.AlpaconClient, serverName string, tail int) ([]LogAttributes, error) {
 	serverID, err := server.GetServerIDByName(ac, serverName)
 	if err != nil {
 		return nil, err
@@ -23,21 +22,14 @@ func GetSystemLogList(ac *client.AlpaconClient, serverName string, pageSize int)
 	params := map[string]string{
 		"server": serverID,
 	}
-	if pageSize > 0 {
-		params["page_size"] = fmt.Sprintf("%d", pageSize)
-	}
-	responseBody, err := ac.SendGetRequest(utils.BuildURL(getSystemLogURL, "", params))
+
+	entries, err := api.FetchCursorPages[LogEntry](ac, getSystemLogURL, params, tail)
 	if err != nil {
 		return nil, err
 	}
 
-	var response api.ListResponse[LogEntry]
-	if err = json.Unmarshal(responseBody, &response); err != nil {
-		return nil, err
-	}
-
 	var logList []LogAttributes
-	for _, log := range response.Results {
+	for _, log := range entries {
 		logList = append(logList, LogAttributes{
 			Program: log.Program,
 			Level:   getLogLevel(log.Level),

--- a/api/log/log_test.go
+++ b/api/log/log_test.go
@@ -42,9 +42,12 @@ func TestGetSystemLogList_NoExtraPagination(t *testing.T) {
 			if pageSize != "25" {
 				t.Errorf("expected page_size=25, got %s", pageSize)
 			}
+			if server := r.URL.Query().Get("server"); server != "srv-1" {
+				t.Errorf("expected server=srv-1, got %s", server)
+			}
 
 			var results []LogEntry
-			for i := 0; i < 25; i++ {
+			for i := range 25 {
 				results = append(results, LogEntry{
 					Program: "sshd",
 					Level:   20,

--- a/api/log/log_test.go
+++ b/api/log/log_test.go
@@ -53,8 +53,9 @@ func TestGetSystemLogList_NoExtraPagination(t *testing.T) {
 				})
 			}
 
-			resp := api.ListResponse[LogEntry]{
-				Count:   200, // more items exist on server
+			// Cursor token present, but limit is reached: no follow-up request.
+			resp := api.CursorListResponse[LogEntry]{
+				Next:    "eyJzIjpbMV0sImQiOiJhZnRlciJ9",
 				Results: results,
 			}
 			_ = json.NewEncoder(w).Encode(resp)

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -57,6 +57,9 @@ func FetchCursorPages[T any](ac *client.AlpaconClient, endpoint string, params m
 		params["page_size"] = strconv.Itoa(min(maxPageSize, limit-len(result)))
 		if cursor != "" {
 			params["cursor"] = cursor
+		} else {
+			// Drop any caller-supplied cursor so the first request starts from the first page.
+			delete(params, "cursor")
 		}
 
 		responseBody, err := ac.SendGetRequest(utils.BuildURL(endpoint, "", params))

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -41,3 +41,43 @@ func FetchAllPages[T any](ac *client.AlpaconClient, endpoint string, params map[
 
 	return result, nil
 }
+
+// FetchCursorPages follows the Elasticsearch cursor contract, accumulating up to limit items.
+func FetchCursorPages[T any](ac *client.AlpaconClient, endpoint string, params map[string]string, limit int) ([]T, error) {
+	if params == nil {
+		params = make(map[string]string)
+	}
+
+	// The server caps page_size at 100 (ESCursorPagination.max_page_size).
+	const maxPageSize = 100
+
+	var result []T
+	cursor := ""
+	for len(result) < limit {
+		params["page_size"] = strconv.Itoa(min(maxPageSize, limit-len(result)))
+		if cursor != "" {
+			params["cursor"] = cursor
+		}
+
+		responseBody, err := ac.SendGetRequest(utils.BuildURL(endpoint, "", params))
+		if err != nil {
+			return nil, err
+		}
+
+		var page CursorListResponse[T]
+		if err = json.Unmarshal(responseBody, &page); err != nil {
+			return nil, err
+		}
+
+		result = append(result, page.Results...)
+		if page.Next == "" || len(page.Results) == 0 {
+			break
+		}
+		cursor = page.Next
+	}
+
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -44,6 +44,9 @@ func FetchAllPages[T any](ac *client.AlpaconClient, endpoint string, params map[
 
 // FetchCursorPages follows the Elasticsearch cursor contract, accumulating up to limit items.
 func FetchCursorPages[T any](ac *client.AlpaconClient, endpoint string, params map[string]string, limit int) ([]T, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
 	if params == nil {
 		params = make(map[string]string)
 	}

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -3,20 +3,26 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strconv"
 
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
 )
 
+// copyParams returns a shallow copy so the pagination loop never mutates the caller's map.
+func copyParams(params map[string]string) map[string]string {
+	out := make(map[string]string, len(params)+2)
+	maps.Copy(out, params)
+	return out
+}
+
 func FetchAllPages[T any](ac *client.AlpaconClient, endpoint string, params map[string]string) ([]T, error) {
 	var result []T
 	page := 1
 	const pageSize = 100
 
-	if params == nil {
-		params = make(map[string]string)
-	}
+	params = copyParams(params)
 	params["page"] = strconv.Itoa(page)
 	params["page_size"] = strconv.Itoa(pageSize)
 
@@ -48,12 +54,13 @@ func FetchCursorPages[T any](ac *client.AlpaconClient, endpoint string, params m
 	if limit <= 0 {
 		return nil, nil
 	}
-	if params == nil {
-		params = make(map[string]string)
-	}
 
 	// The server caps page_size at 100 (ESCursorPagination.max_page_size).
 	const maxPageSize = 100
+
+	params = copyParams(params)
+	// Drop any caller-supplied cursor so the first request starts from the first page.
+	delete(params, "cursor")
 
 	result := make([]T, 0, min(limit, maxPageSize))
 	cursor := ""
@@ -61,9 +68,6 @@ func FetchCursorPages[T any](ac *client.AlpaconClient, endpoint string, params m
 		params["page_size"] = strconv.Itoa(min(maxPageSize, limit-len(result)))
 		if cursor != "" {
 			params["cursor"] = cursor
-		} else {
-			// Drop any caller-supplied cursor so the first request starts from the first page.
-			delete(params, "cursor")
 		}
 
 		responseBody, err := ac.SendGetRequest(utils.BuildURL(endpoint, "", params))

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/alpacax/alpacon-cli/client"
@@ -67,12 +68,12 @@ func FetchCursorPages[T any](ac *client.AlpaconClient, endpoint string, params m
 
 		responseBody, err := ac.SendGetRequest(utils.BuildURL(endpoint, "", params))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("fetching cursor page from %s: %w", endpoint, err)
 		}
 
 		var page CursorListResponse[T]
 		if err = json.Unmarshal(responseBody, &page); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("decoding cursor page from %s: %w", endpoint, err)
 		}
 
 		result = append(result, page.Results...)

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -54,7 +54,7 @@ func FetchCursorPages[T any](ac *client.AlpaconClient, endpoint string, params m
 	// The server caps page_size at 100 (ESCursorPagination.max_page_size).
 	const maxPageSize = 100
 
-	var result []T
+	result := make([]T, 0, min(limit, maxPageSize))
 	cursor := ""
 	for len(result) < limit {
 		params["page_size"] = strconv.Itoa(min(maxPageSize, limit-len(result)))

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -88,15 +88,53 @@ func TestFetchCursorPages_PageSize(t *testing.T) {
 }
 
 func TestFetchCursorPages_NonPositiveLimit(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		t.Run(strconv.Itoa(limit), func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("no request expected for non-positive limit")
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			items, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", nil, limit)
+			require.NoError(t, err)
+			assert.Empty(t, items)
+		})
+	}
+}
+
+func TestFetchCursorPages_SecondPageErrorDiscardsPartial(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("no request expected for non-positive limit")
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_ = json.NewEncoder(w).Encode(CursorListResponse[cursorItem]{
+				Next:    "TOKEN2",
+				Results: []cursorItem{{Name: "a"}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"detail":"internal server error"}`))
 	}))
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	items, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", nil, 0)
-	require.NoError(t, err)
-	assert.Empty(t, items)
+	items, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", nil, 10)
+	require.Error(t, err)
+	assert.Nil(t, items)
+}
+
+func TestFetchCursorPages_MalformedJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results": [`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	items, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", nil, 10)
+	require.Error(t, err)
+	assert.Nil(t, items)
 }
 
 func TestFetchCursorPages_StopsOnEmptyResults(t *testing.T) {

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -170,3 +170,25 @@ func TestFetchCursorPages_IgnoresStaleCursorParam(t *testing.T) {
 	assert.Len(t, items, 1)
 	assert.Equal(t, []string{""}, gotCursors)
 }
+
+func TestFetchCursorPages_DoesNotMutateCallerParams(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_ = json.NewEncoder(w).Encode(CursorListResponse[cursorItem]{
+				Next:    "TOKEN2",
+				Results: []cursorItem{{Name: "a"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(CursorListResponse[cursorItem]{Results: []cursorItem{{Name: "b"}}})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	params := map[string]string{"app": "cert"}
+	_, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", params, 10)
+	require.NoError(t, err)
+	// The helper must leave no page_size/cursor residue in the caller's map.
+	assert.Equal(t, map[string]string{"app": "cert"}, params)
+}

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -115,3 +115,20 @@ func TestFetchCursorPages_StopsOnEmptyResults(t *testing.T) {
 	assert.Empty(t, items)
 	assert.Equal(t, 1, requests)
 }
+
+func TestFetchCursorPages_IgnoresStaleCursorParam(t *testing.T) {
+	var gotCursors []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCursors = append(gotCursors, r.URL.Query().Get("cursor"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CursorListResponse[cursorItem]{Results: []cursorItem{{Name: "a"}}})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	// A caller-supplied cursor must not leak into the first request.
+	items, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", map[string]string{"cursor": "STALE"}, 10)
+	require.NoError(t, err)
+	assert.Len(t, items, 1)
+	assert.Equal(t, []string{""}, gotCursors)
+}

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type cursorItem struct {
+	Name string `json:"name"`
+}
+
+func TestFetchCursorPages_SinglePageNullNext(t *testing.T) {
+	var requests int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		// Raw wire form of ESCursorPagination: null next, extra fields ignored.
+		_, _ = w.Write([]byte(`{"count":2,"next":null,"previous":null,"results":[{"name":"a"},{"name":"b"}]}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	items, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", nil, 100)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+	assert.Equal(t, 1, requests)
+}
+
+func TestFetchCursorPages_FollowsCursorAndCaps(t *testing.T) {
+	var gotCursors []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCursors = append(gotCursors, r.URL.Query().Get("cursor"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_ = json.NewEncoder(w).Encode(CursorListResponse[cursorItem]{
+				Next:    "TOKEN2",
+				Results: []cursorItem{{Name: "a"}, {Name: "b"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(CursorListResponse[cursorItem]{
+			Results: []cursorItem{{Name: "c"}, {Name: "d"}},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	items, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", nil, 3)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"", "TOKEN2"}, gotCursors)
+	require.Len(t, items, 3)
+	assert.Equal(t, "c", items[2].Name)
+}
+
+func TestFetchCursorPages_PageSize(t *testing.T) {
+	tests := []struct {
+		limit        int
+		wantPageSize string
+	}{
+		{250, "100"},
+		{3, "3"},
+	}
+	for _, tt := range tests {
+		t.Run(strconv.Itoa(tt.limit), func(t *testing.T) {
+			var gotPageSize string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if gotPageSize == "" {
+					gotPageSize = r.URL.Query().Get("page_size")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(CursorListResponse[cursorItem]{Results: []cursorItem{{Name: "a"}}})
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			_, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", nil, tt.limit)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPageSize, gotPageSize)
+		})
+	}
+}
+
+func TestFetchCursorPages_NonPositiveLimit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("no request expected for non-positive limit")
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	items, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", nil, 0)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestFetchCursorPages_StopsOnEmptyResults(t *testing.T) {
+	var requests int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		// Pathological page: next token but no results must not loop forever.
+		_ = json.NewEncoder(w).Encode(CursorListResponse[cursorItem]{Next: "MORE"})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	items, err := FetchCursorPages[cursorItem](ac, "/api/history/logs/", nil, 10)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+	assert.Equal(t, 1, requests)
+}

--- a/api/types.go
+++ b/api/types.go
@@ -8,3 +8,9 @@ type ListResponse[T any] struct {
 	Last     int `json:"last"`
 	Results  []T `json:"results"`
 }
+
+// CursorListResponse decodes the Elasticsearch cursor-pagination contract (base64 next token, not ListResponse's int page).
+type CursorListResponse[T any] struct {
+	Next    string `json:"next"`
+	Results []T    `json:"results"`
+}

--- a/api/webftp/webftp.go
+++ b/api/webftp/webftp.go
@@ -1,9 +1,6 @@
 package webftp
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/alpacax/alpacon-cli/api"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
@@ -13,11 +10,8 @@ const (
 	webftpLogURL = "/api/history/webftp-logs/"
 )
 
-func GetWebFTPLogList(ac *client.AlpaconClient, pageSize int, serverName string, userName string, action string) ([]WebFTPLogAttributes, error) {
+func GetWebFTPLogList(ac *client.AlpaconClient, tail int, serverName string, userName string, action string) ([]WebFTPLogAttributes, error) {
 	params := map[string]string{}
-	if pageSize > 0 {
-		params["page_size"] = fmt.Sprintf("%d", pageSize)
-	}
 	if serverName != "" {
 		params["server_name"] = serverName
 	}
@@ -28,18 +22,13 @@ func GetWebFTPLogList(ac *client.AlpaconClient, pageSize int, serverName string,
 		params["action"] = action
 	}
 
-	responseBody, err := ac.SendGetRequest(utils.BuildURL(webftpLogURL, "", params))
+	entries, err := api.FetchCursorPages[WebFTPLogEntry](ac, webftpLogURL, params, tail)
 	if err != nil {
 		return nil, err
 	}
 
-	var response api.ListResponse[WebFTPLogEntry]
-	if err = json.Unmarshal(responseBody, &response); err != nil {
-		return nil, err
-	}
-
 	var logList []WebFTPLogAttributes
-	for _, entry := range response.Results {
+	for _, entry := range entries {
 		entryServerName := ""
 		if entry.Server != nil {
 			entryServerName = entry.Server.Name

--- a/api/webftp/webftp_test.go
+++ b/api/webftp/webftp_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/api"
@@ -34,4 +35,24 @@ func TestGetWebFTPLogList_FollowsCursor(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, logs, 2)
 	assert.Equal(t, "b.txt", logs[1].FileName)
+}
+
+func TestGetWebFTPLogList_Filters(t *testing.T) {
+	var gotQuery url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.CursorListResponse[WebFTPLogEntry]{
+			Results: []WebFTPLogEntry{{FileName: "a.txt"}},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	logs, err := GetWebFTPLogList(ac, 5, "web-01", "alice", "upload")
+	require.NoError(t, err)
+	assert.Len(t, logs, 1)
+	assert.Equal(t, "web-01", gotQuery.Get("server_name"))
+	assert.Equal(t, "alice", gotQuery.Get("user_name"))
+	assert.Equal(t, "upload", gotQuery.Get("action"))
 }

--- a/api/webftp/webftp_test.go
+++ b/api/webftp/webftp_test.go
@@ -1,0 +1,37 @@
+package webftp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/api"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for #274: a cursor-token next crashed the old int-typed unmarshal.
+func TestGetWebFTPLogList_FollowsCursor(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_ = json.NewEncoder(w).Encode(api.CursorListResponse[WebFTPLogEntry]{
+				Next:    "eyJzIjpbMV0sImQiOiJhZnRlciJ9",
+				Results: []WebFTPLogEntry{{FileName: "a.txt", Action: "upload"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(api.CursorListResponse[WebFTPLogEntry]{
+			Results: []WebFTPLogEntry{{FileName: "b.txt", Action: "download"}},
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	logs, err := GetWebFTPLogList(ac, 5, "", "", "")
+	require.NoError(t, err)
+	require.Len(t, logs, 2)
+	assert.Equal(t, "b.txt", logs[1].FileName)
+}

--- a/api/websh/types.go
+++ b/api/websh/types.go
@@ -94,9 +94,3 @@ type SessionRecord struct {
 	AddedAt string `json:"added_at" table:"Added At"`
 	Record  string `json:"record"   table:"Record"`
 }
-
-// recordCursorPage decodes the cursor-pagination response; ListResponse[T] can't be reused (its Next is an int, not a cursor token).
-type recordCursorPage struct {
-	Next    string          `json:"next"`
-	Results []SessionRecord `json:"results"`
-}

--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"path"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -63,44 +62,14 @@ func GetSessionDetail(ac *client.AlpaconClient, sessionID string) ([]byte, error
 
 func GetSessionRecords(ac *client.AlpaconClient, sessionID, query string, limit int) ([]SessionRecord, error) {
 	action := "records"
+	params := map[string]string{}
 	if query != "" {
 		action = "search"
+		params["q"] = query
 	}
 
-	var records []SessionRecord
-	cursor := ""
-	for len(records) < limit {
-		params := map[string]string{
-			"page_size": strconv.Itoa(min(100, limit-len(records))),
-		}
-		if query != "" {
-			params["q"] = query
-		}
-		if cursor != "" {
-			params["cursor"] = cursor
-		}
-
-		body, err := ac.SendGetRequest(utils.BuildURL(sessionsBaseURL, path.Join(sessionID, action), params))
-		if err != nil {
-			return nil, err
-		}
-
-		var page recordCursorPage
-		if err = json.Unmarshal(body, &page); err != nil {
-			return nil, err
-		}
-
-		records = append(records, page.Results...)
-		if page.Next == "" || len(page.Results) == 0 {
-			break
-		}
-		cursor = page.Next
-	}
-
-	if len(records) > limit {
-		records = records[:limit]
-	}
-	return records, nil
+	endpoint := path.Join(sessionsBaseURL, sessionID, action)
+	return api.FetchCursorPages[SessionRecord](ac, endpoint, params, limit)
 }
 
 func CloseSession(ac *client.AlpaconClient, sessionID string) error {

--- a/api/websh/websh_test.go
+++ b/api/websh/websh_test.go
@@ -222,81 +222,34 @@ func TestBuildSessionRequest_IncludesWorkSession(t *testing.T) {
 }
 
 func TestGetSessionRecords_FollowsCursor(t *testing.T) {
-	var gotCursors []string
+	var gotCursors, gotPageSizes []string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, "/records/"))
 		gotCursors = append(gotCursors, r.URL.Query().Get("cursor"))
+		gotPageSizes = append(gotPageSizes, r.URL.Query().Get("page_size"))
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Query().Get("cursor") == "" {
-			_ = json.NewEncoder(w).Encode(recordCursorPage{
+			_ = json.NewEncoder(w).Encode(api.CursorListResponse[SessionRecord]{
 				Next:    "TOKEN2",
 				Results: []SessionRecord{{AddedAt: "t1", Record: "docker ps"}},
 			})
 			return
 		}
-		_ = json.NewEncoder(w).Encode(recordCursorPage{
-			Next:    "",
+		_ = json.NewEncoder(w).Encode(api.CursorListResponse[SessionRecord]{
 			Results: []SessionRecord{{AddedAt: "t2", Record: "ls -la"}},
 		})
 	}))
 	defer ts.Close()
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	records, err := GetSessionRecords(ac, "sess-1", "", 100)
+	records, err := GetSessionRecords(ac, "sess-1", "", 5)
 	require.NoError(t, err)
 
-	assert.Len(t, records, 2)
+	require.Len(t, records, 2)
 	assert.Equal(t, []string{"", "TOKEN2"}, gotCursors)
+	// page_size derives from limit and the remaining count, proving limit is wired through.
+	assert.Equal(t, []string{"5", "4"}, gotPageSizes)
 	assert.Equal(t, "ls -la", records[1].Record)
-}
-
-func TestGetSessionRecords_LimitCaps(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(recordCursorPage{
-			Next:    "MORE",
-			Results: []SessionRecord{{Record: "a"}, {Record: "b"}, {Record: "c"}},
-		})
-	}))
-	defer ts.Close()
-
-	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	records, err := GetSessionRecords(ac, "sess-1", "", 2)
-	require.NoError(t, err)
-	assert.Len(t, records, 2)
-}
-
-func TestGetSessionRecords_PageSize(t *testing.T) {
-	tests := []struct {
-		name         string
-		limit        int
-		wantPageSize string
-	}{
-		{"limit above page cap", 250, "100"},
-		{"limit below page cap", 3, "3"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var gotPageSize string
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if gotPageSize == "" {
-					gotPageSize = r.URL.Query().Get("page_size")
-				}
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(recordCursorPage{
-					Next:    "",
-					Results: []SessionRecord{{Record: "a"}, {Record: "b"}, {Record: "c"}},
-				})
-			}))
-			defer ts.Close()
-
-			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-			_, err := GetSessionRecords(ac, "sess-1", "", tt.limit)
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantPageSize, gotPageSize)
-		})
-	}
 }
 
 func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
@@ -305,8 +258,7 @@ func TestGetSessionRecords_QueryHitsSearchEndpoint(t *testing.T) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, "/search/"))
 		gotQuery = r.URL.Query().Get("q")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(recordCursorPage{
-			Next:    "",
+		_ = json.NewEncoder(w).Encode(api.CursorListResponse[SessionRecord]{
 			Results: []SessionRecord{{Record: "docker ps -a"}},
 		})
 	}))

--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -25,19 +25,19 @@ var AuditCmd = &cobra.Command{
 }
 
 func init() {
-	var pageSize int
+	var tail int
 	var userName string
 	var app string
 	var model string
 
-	AuditCmd.Flags().IntVarP(&pageSize, "tail", "t", 25, "Number of audit log entries to show from the end")
+	AuditCmd.Flags().IntVarP(&tail, "tail", "t", 25, "Number of audit log entries to show from the end")
 	AuditCmd.Flags().StringVarP(&userName, "user", "u", "", "Filter by username")
 	AuditCmd.Flags().StringVarP(&app, "app", "a", "", "Filter by application")
 	AuditCmd.Flags().StringVarP(&model, "model", "m", "", "Filter by model")
 }
 
 func runAudit(cmd *cobra.Command, args []string) {
-	pageSize, _ := cmd.Flags().GetInt("tail")
+	tail, _ := cmd.Flags().GetInt("tail")
 	userName, _ := cmd.Flags().GetString("user")
 	app, _ := cmd.Flags().GetString("app")
 	model, _ := cmd.Flags().GetString("model")
@@ -47,7 +47,7 @@ func runAudit(cmd *cobra.Command, args []string) {
 		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 	}
 
-	auditList, err := audit.GetAuditLogList(alpaconClient, pageSize, userName, app, model)
+	auditList, err := audit.GetAuditLogList(alpaconClient, tail, userName, app, model)
 	if err != nil {
 		utils.CliErrorWithExit("Failed to get audit logs: %s.", err)
 	}

--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -38,6 +38,7 @@ func init() {
 
 func runAudit(cmd *cobra.Command, args []string) {
 	tail, _ := cmd.Flags().GetInt("tail")
+	utils.RequirePositiveInt("tail", tail)
 	userName, _ := cmd.Flags().GetString("user")
 	app, _ := cmd.Flags().GetString("app")
 	model, _ := cmd.Flags().GetString("model")

--- a/cmd/csr/csr_create.go
+++ b/cmd/csr/csr_create.go
@@ -71,9 +71,7 @@ var csrCreateCmd = &cobra.Command{
 			if len(signRequest.DomainList) == 0 && len(signRequest.IpList) == 0 {
 				utils.CliErrorWithExit("You must provide at least one valid domain or IP address.")
 			}
-			if csrFlags.validDays <= 0 {
-				utils.CliErrorWithExit("--valid-days must be a positive integer.")
-			}
+			utils.RequirePositiveInt("valid-days", csrFlags.validDays)
 			signRequest.ValidDays = csrFlags.validDays
 			commonName := firstOf(signRequest.DomainList, signRequest.IpList)
 			certPath.PrivateKeyPath = csrFlags.keyPath

--- a/cmd/log/log.go
+++ b/cmd/log/log.go
@@ -24,14 +24,14 @@ var LogCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		serverName := args[0]
-		pageSize, _ := cmd.Flags().GetInt("tail")
+		tail, _ := cmd.Flags().GetInt("tail")
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		logList, err := log.GetSystemLogList(alpaconClient, serverName, pageSize)
+		logList, err := log.GetSystemLogList(alpaconClient, serverName, tail)
 		if err != nil {
 			utils.CliErrorWithExit("Failed to get logs: %s.", err)
 		}
@@ -41,7 +41,7 @@ var LogCmd = &cobra.Command{
 }
 
 func init() {
-	var pageSize int
+	var tail int
 
-	LogCmd.Flags().IntVarP(&pageSize, "tail", "t", 25, "Number of log entries to show from the end")
+	LogCmd.Flags().IntVarP(&tail, "tail", "t", 25, "Number of log entries to show from the end")
 }

--- a/cmd/log/log.go
+++ b/cmd/log/log.go
@@ -25,6 +25,7 @@ var LogCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		serverName := args[0]
 		tail, _ := cmd.Flags().GetInt("tail")
+		utils.RequirePositiveInt("tail", tail)
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/cmd/webftp/webftp.go
+++ b/cmd/webftp/webftp.go
@@ -38,6 +38,7 @@ func init() {
 
 func runWebFTP(cmd *cobra.Command, args []string) {
 	tail, _ := cmd.Flags().GetInt("tail")
+	utils.RequirePositiveInt("tail", tail)
 	serverName, _ := cmd.Flags().GetString("server")
 	userName, _ := cmd.Flags().GetString("user")
 	action, _ := cmd.Flags().GetString("action")

--- a/cmd/webftp/webftp.go
+++ b/cmd/webftp/webftp.go
@@ -25,19 +25,19 @@ var WebFTPCmd = &cobra.Command{
 }
 
 func init() {
-	var pageSize int
+	var tail int
 	var serverName string
 	var userName string
 	var action string
 
-	WebFTPCmd.Flags().IntVarP(&pageSize, "tail", "t", 25, "Number of log entries to show from the end")
+	WebFTPCmd.Flags().IntVarP(&tail, "tail", "t", 25, "Number of log entries to show from the end")
 	WebFTPCmd.Flags().StringVarP(&serverName, "server", "s", "", "Filter by server name")
 	WebFTPCmd.Flags().StringVarP(&userName, "user", "u", "", "Filter by username")
 	WebFTPCmd.Flags().StringVarP(&action, "action", "a", "", "Filter by action (e.g., upload, download)")
 }
 
 func runWebFTP(cmd *cobra.Command, args []string) {
-	pageSize, _ := cmd.Flags().GetInt("tail")
+	tail, _ := cmd.Flags().GetInt("tail")
 	serverName, _ := cmd.Flags().GetString("server")
 	userName, _ := cmd.Flags().GetString("user")
 	action, _ := cmd.Flags().GetString("action")
@@ -47,7 +47,7 @@ func runWebFTP(cmd *cobra.Command, args []string) {
 		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 	}
 
-	logList, err := webftp.GetWebFTPLogList(alpaconClient, pageSize, serverName, userName, action)
+	logList, err := webftp.GetWebFTPLogList(alpaconClient, tail, serverName, userName, action)
 	if err != nil {
 		utils.CliErrorWithExit("Failed to get WebFTP logs: %s.", err)
 	}

--- a/cmd/websh/websh_records.go
+++ b/cmd/websh/websh_records.go
@@ -25,9 +25,7 @@ Use --query to search records by command text (fuzzy match).`,
 		sessionID := args[0]
 		query, _ := cmd.Flags().GetString("query")
 		limit, _ := cmd.Flags().GetInt("limit")
-		if limit <= 0 {
-			utils.CliErrorWithExit("--limit must be a positive integer.")
-		}
+		utils.RequirePositiveInt("limit", limit)
 
 		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -600,6 +600,13 @@ func SplitAndTrim(s, sep string) []string {
 	return result
 }
 
+// RequirePositiveInt exits with a usage error when an integer flag is not positive.
+func RequirePositiveInt(flagName string, value int) {
+	if value <= 0 {
+		CliErrorWithExit("--%s must be a positive integer.", flagName)
+	}
+}
+
 // ParsePositiveDuration parses a duration flag value, rejecting non-positive ones.
 // It trims surrounding whitespace so every duration flag normalizes input the same way.
 func ParsePositiveDuration(flagName, raw string) (time.Duration, error) {


### PR DESCRIPTION
## Background

`alpacon webftp-log`, `alpacon audit`, and `alpacon log` read Elasticsearch-backed endpoints that the server paginates with `ESCursorPagination`: `next`/`previous` carry base64 cursor strings (or null) and `current`/`last` are absent. The shared `api.ListResponse[T]` in `api/types.go` models only the page-number contract (`Next int`), so whenever a result set exceeded the first page the commands failed with `json: cannot unmarshal string into Go struct field ... next of type int`. A single request also capped output at the server's `max_page_size` (100), so `--tail` values above 100 were never honored. The cursor design is intentional on the server (keyset `search_after` pagination), so the fix teaches the CLI the cursor contract.

## Changes

- Add `api.CursorListResponse[T]` (`api/types.go`) for the cursor contract and `api.FetchCursorPages[T]` (`api/pagination.go`), which requests `page_size = min(100, remaining)`, follows the `next` cursor until `tail` entries are accumulated or pages run out, and truncates any overshoot. The loop generalizes the previously working inline implementation in `websh.GetSessionRecords`.
- Guard the helper against a non-positive `tail` (returns an empty result without sending any request) and copy the caller's params map on entry so the pagination loop never leaves `page_size`/`cursor` residue behind. `FetchAllPages` gets the same map-copy fix.
- Switch `GetWebFTPLogList` (`api/webftp/webftp.go`), `GetAuditLogList` (`api/audit/audit.go`), and `GetSystemLogList` (`api/log/log.go`) to the helper. Signatures keep their positional shape, so the `cmd/` layer is unchanged.
- Refactor `websh.GetSessionRecords` onto the same helper and delete the now-redundant `recordCursorPage` type.
- Reject a non-positive `--tail` at the `cmd/` layer with a usage error (`utils.RequirePositiveInt`), matching `websh records`' `--limit` handling. The existing `--limit` and `--valid-days` guards are routed through the same helper.

Behavior change: `--tail 0` (or a negative value) now exits with a usage error instead of printing one server-default page (15 entries). All three commands default `--tail` to 25, so this only affects an explicit non-positive `--tail`.

## Tests

- New `api/pagination_test.go` covers the helper: single page (null `next`), cursor following with limit truncation, `page_size` derivation, non-positive limit (0 and -1, the latter reproducing the slice-bounds panic), a pathological page (`next` token with no results) that must not loop, a stale caller-supplied `cursor` param that must not leak into the first request, that the caller's params map is not mutated, and the error paths (a mid-pagination HTTP error and a malformed JSON body both propagate the error and discard partial results).
- Regression tests in `api/webftp/webftp_test.go` and `api/audit/audit_test.go` reproduce the original crash shape (base64 `next`) and verify multi-page accumulation.
- Call-site filter params are pinned to the wire format: audit resolves the username to a user ID and sends `user`/`app`/`model`, webftp sends `server_name`/`user_name`/`action`, and log sends the resolved server ID alongside `page_size`.
- `api/log/log_test.go` now encodes the cursor contract and asserts no follow-up request once `tail` is satisfied.
- Existing `TestGetSessionRecords_*` tests are retained as the refactor safety net; the limit-wiring assertion was folded into `TestGetSessionRecords_FollowsCursor`.
- `go test -race ./...` passes and `golangci-lint run ./...` reports 0 issues. Not verified against a live workspace with over 100 accumulated logs; coverage relies on the httptest-based reproduction of the server contract.

Closes #274