### PR TITLE
feat(server): add reboot, shutdown, upgrade, and refresh system-action commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ What each refusal code means and what to do next:
 | `2`  | Usage error (invalid flags or arguments) |
 | `3`  | WorkSession gate denied—the active session does not authorize this action |
 | `4`  | Pending human approval—the action is awaiting an out-of-band approve/reject in the Alpacon console (web/Slack), not refused. For `exec`, re-run the command after approval (or pass `--wait` on the original command to block; `--wait-approval <duration>` raises the wait timeout, default 5m); `websh` command mode has no `--wait`, so re-run via `alpacon exec --wait` to block; for `work-session create` the session already exists—after approval attach it with `alpacon work-session use <id>` (or pass `--wait` on the original create to block; `--wait-approval <duration>` raises the wait timeout, default 5m). Under `--output json`, a `{"status":"pending_approval", ...}` object is emitted. Returned by `exec` (and `websh` when running a command) on a `SUDO_APPROVAL_REQUIRED` sudo denial and by `work-session create` when the session lands pending |
+| `5`  | Server busy with active user work—a disruptive `server` action (`reboot`, `shutdown`, `upgrade`) was refused because the server has an open Websh/WebFTP session or in-flight command. Transient and retryable: retry when idle, or re-run with `--force` to override |
 
 ## Contributing
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -87,8 +87,7 @@ func RequestServerAction(ac *client.AlpaconClient, serverName, action string, fo
 	}
 
 	req := serverActionRequest{Action: action, Force: force}
-	relativePath := path.Join(serverID, "actions")
-	_, err = ac.SendPostRequest(utils.BuildURL(serverURL, relativePath, nil), req)
+	_, err = ac.SendPostRequest(utils.BuildURL(serverURL, path.Join(serverID, "actions"), nil), req)
 	return err
 }
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -21,6 +21,14 @@ const (
 	iamGroupURL = "/api/iam/groups/"
 )
 
+// Server action identifiers accepted by the actions endpoint.
+const (
+	ActionRebootSystem      = "reboot_system"
+	ActionShutdownSystem    = "shutdown_system"
+	ActionUpgradeSystem     = "upgrade_system"
+	ActionUpdateInformation = "update_information"
+)
+
 // ErrRegistrationTokenNotFound is returned when no registration token matches the given name.
 var ErrRegistrationTokenNotFound = errors.New("no registration token found with the given name")
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/alpacax/alpacon-cli/api"
@@ -77,6 +78,18 @@ func DeleteServer(ac *client.AlpaconClient, serverName string) error {
 	}
 
 	return nil
+}
+
+func RequestServerAction(ac *client.AlpaconClient, serverName, action string, force bool) error {
+	serverID, err := GetServerIDByName(ac, serverName)
+	if err != nil {
+		return err
+	}
+
+	req := serverActionRequest{Action: action, Force: force}
+	relativePath := path.Join(serverID, "actions")
+	_, err = ac.SendPostRequest(utils.BuildURL(serverURL, relativePath, nil), req)
+	return err
 }
 
 func GetServerIDByName(ac *client.AlpaconClient, serverName string) (string, error) {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/alpacax/alpacon-cli/api"
@@ -87,7 +86,7 @@ func RequestServerAction(ac *client.AlpaconClient, serverName, action string, fo
 	}
 
 	req := serverActionRequest{Action: action, Force: force}
-	_, err = ac.SendPostRequest(utils.BuildURL(serverURL, path.Join(serverID, "actions"), nil), req)
+	_, err = ac.SendPostRequest(utils.BuildURL(serverURL, serverID+"/actions", nil), req)
 	return err
 }
 

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -518,8 +518,8 @@ func TestRequestServerAction(t *testing.T) {
 		action string
 		force  bool
 	}{
-		{"reboot with force", "reboot_system", true},
-		{"refresh without force", "update_information", false},
+		{"reboot with force", ActionRebootSystem, true},
+		{"refresh without force", ActionUpdateInformation, false},
 	}
 
 	for _, tt := range tests {

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -509,3 +509,61 @@ func TestDeleteServer(t *testing.T) {
 		t.Error("DELETE request was not sent")
 	}
 }
+
+func TestRequestServerAction(t *testing.T) {
+	const serverID = "action-server-id"
+
+	tests := []struct {
+		name   string
+		action string
+		force  bool
+	}{
+		{"reboot with force", "reboot_system", true},
+		{"refresh without force", "update_information", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var postCalled bool
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && strings.Contains(r.URL.RawQuery, "name=") {
+					resp := api.ListResponse[ServerDetails]{
+						Count:   1,
+						Results: []ServerDetails{{ID: serverID, Name: "target-server"}},
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(resp)
+					return
+				}
+				if r.Method == http.MethodPost {
+					postCalled = true
+					if !strings.Contains(r.URL.Path, serverID) || !strings.HasSuffix(strings.TrimRight(r.URL.Path, "/"), "actions") {
+						t.Errorf("unexpected POST path: %s", r.URL.Path)
+					}
+					var req serverActionRequest
+					if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+						t.Fatalf("failed to decode request body: %v", err)
+					}
+					if req.Action != tt.action {
+						t.Errorf("expected action %q, got %q", tt.action, req.Action)
+					}
+					if req.Force != tt.force {
+						t.Errorf("expected force %v, got %v", tt.force, req.Force)
+					}
+					w.WriteHeader(http.StatusCreated)
+					return
+				}
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			if err := RequestServerAction(ac, "target-server", tt.action, tt.force); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !postCalled {
+				t.Error("POST request was not sent")
+			}
+		})
+	}
+}

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -35,7 +35,7 @@ func TestGetServerList_PaginationBug(t *testing.T) {
 		var results []ServerDetails
 		switch page {
 		case "1", "": // page=1 or unspecified
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				results = append(results, ServerDetails{
 					ID:       fmt.Sprintf("id-%d", i),
 					Name:     fmt.Sprintf("server-%d", i),
@@ -44,7 +44,7 @@ func TestGetServerList_PaginationBug(t *testing.T) {
 				})
 			}
 		case "2":
-			for i := 0; i < 50; i++ {
+			for i := range 50 {
 				results = append(results, ServerDetails{
 					ID:       fmt.Sprintf("id-p2-%d", i),
 					Name:     fmt.Sprintf("server-p2-%d", i),

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -537,7 +537,7 @@ func TestRequestServerAction(t *testing.T) {
 				}
 				if r.Method == http.MethodPost {
 					postCalled = true
-					if !strings.Contains(r.URL.Path, serverID) || !strings.HasSuffix(strings.TrimRight(r.URL.Path, "/"), "actions") {
+					if r.URL.Path != serverURL+serverID+"/actions/" {
 						t.Errorf("unexpected POST path: %s", r.URL.Path)
 					}
 					var req serverActionRequest

--- a/api/server/types.go
+++ b/api/server/types.go
@@ -108,8 +108,7 @@ type ServerStatusMeta struct {
 	DelayNow float64 `json:"delay_now"`
 }
 
-// serverActionRequest is the body for the server actions endpoint.
-// Force overrides the server-side busy guard on disruptive actions.
+// serverActionRequest is the actions-endpoint body; Force overrides the busy guard.
 type serverActionRequest struct {
 	Action string `json:"action"`
 	Force  bool   `json:"force"`

--- a/api/server/types.go
+++ b/api/server/types.go
@@ -108,6 +108,13 @@ type ServerStatusMeta struct {
 	DelayNow float64 `json:"delay_now"`
 }
 
+// serverActionRequest is the body for the server actions endpoint.
+// Force overrides the server-side busy guard on disruptive actions.
+type serverActionRequest struct {
+	Action string `json:"action"`
+	Force  bool   `json:"force"`
+}
+
 type ServerDetails struct {
 	ID               string            `json:"id"`
 	Name             string            `json:"name"`

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -27,4 +27,5 @@ func init() {
 	ServerCmd.AddCommand(serverUpdateCmd)
 	ServerCmd.AddCommand(tokenCmd)
 	ServerCmd.AddCommand(rebootServerCmd)
+	ServerCmd.AddCommand(shutdownServerCmd)
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -26,4 +26,5 @@ func init() {
 	ServerCmd.AddCommand(serverDeleteCmd)
 	ServerCmd.AddCommand(serverUpdateCmd)
 	ServerCmd.AddCommand(tokenCmd)
+	ServerCmd.AddCommand(rebootServerCmd)
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -26,8 +26,8 @@ func init() {
 	ServerCmd.AddCommand(serverDeleteCmd)
 	ServerCmd.AddCommand(serverUpdateCmd)
 	ServerCmd.AddCommand(tokenCmd)
-	ServerCmd.AddCommand(rebootServerCmd)
-	ServerCmd.AddCommand(shutdownServerCmd)
-	ServerCmd.AddCommand(upgradeServerCmd)
-	ServerCmd.AddCommand(refreshServerCmd)
+	ServerCmd.AddCommand(serverRebootCmd)
+	ServerCmd.AddCommand(serverShutdownCmd)
+	ServerCmd.AddCommand(serverUpgradeCmd)
+	ServerCmd.AddCommand(serverRefreshCmd)
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -28,4 +28,5 @@ func init() {
 	ServerCmd.AddCommand(tokenCmd)
 	ServerCmd.AddCommand(rebootServerCmd)
 	ServerCmd.AddCommand(shutdownServerCmd)
+	ServerCmd.AddCommand(upgradeServerCmd)
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -29,4 +29,5 @@ func init() {
 	ServerCmd.AddCommand(rebootServerCmd)
 	ServerCmd.AddCommand(shutdownServerCmd)
 	ServerCmd.AddCommand(upgradeServerCmd)
+	ServerCmd.AddCommand(refreshServerCmd)
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -15,7 +15,7 @@ var ServerCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return errors.New("a subcommand is required. Use 'alpacon server list', 'alpacon server create', 'alpacon server describe', 'alpacon server update', 'alpacon server delete', or 'alpacon server token'. Run 'alpacon server --help' for more information")
+		return errors.New("a subcommand is required. Use 'alpacon server list', 'alpacon server create', 'alpacon server describe', 'alpacon server update', 'alpacon server delete', 'alpacon server reboot', 'alpacon server shutdown', 'alpacon server upgrade', 'alpacon server refresh', or 'alpacon server token'. Run 'alpacon server --help' for more information")
 	},
 }
 

--- a/cmd/server/server_action.go
+++ b/cmd/server/server_action.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"fmt"
+
 	"github.com/alpacax/alpacon-cli/api/mfa"
 	"github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/client"
@@ -42,17 +44,22 @@ func runDisruptiveServerAction(serverName, action, confirmMsg, successMsg, failM
 	}
 	if err != nil {
 		if code, _ := utils.ParseErrorResponse(err); code == utils.ServerBusyWithUserWork {
-			if force {
-				utils.CliErrorWithExit("Server '%s' is still busy with active user work "+
-					"(open Websh/WebFTP session or in-flight command) despite --force. "+
-					"Retry when idle", serverName)
-			}
-			utils.CliErrorWithExit("Server '%s' is busy with active user work "+
-				"(open Websh/WebFTP session or in-flight command). "+
-				"Retry when idle, or pass --force to override", serverName)
+			utils.CliErrorWithExit("%s", busyGuardMessage(serverName, force))
 		}
 		utils.CliErrorWithExit("%s: %s.", failMsg, err)
 	}
 
 	utils.CliSuccess("%s", successMsg)
+}
+
+// busyGuardMessage returns the busy-guard refusal text, tailored to whether --force was already used.
+func busyGuardMessage(serverName string, force bool) string {
+	if force {
+		return fmt.Sprintf("Server '%s' is still busy with active user work "+
+			"(open Websh/WebFTP session or in-flight command) despite --force. "+
+			"Retry when idle", serverName)
+	}
+	return fmt.Sprintf("Server '%s' is busy with active user work "+
+		"(open Websh/WebFTP session or in-flight command). "+
+		"Retry when idle, or pass --force to override", serverName)
 }

--- a/cmd/server/server_action.go
+++ b/cmd/server/server_action.go
@@ -44,7 +44,7 @@ func runDisruptiveServerAction(serverName, action, confirmMsg, successMsg, failM
 	}
 	if err != nil {
 		if code, _ := utils.ParseErrorResponse(err); code == utils.ServerBusyWithUserWork {
-			utils.CliErrorWithExit("%s", busyGuardMessage(serverName, force))
+			utils.CliErrorWithExitCode(utils.ExitCodeServerBusy, "%s", busyGuardMessage(serverName, force))
 		}
 		utils.CliErrorWithExit("%s: %s.", failMsg, err)
 	}

--- a/cmd/server/server_action.go
+++ b/cmd/server/server_action.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"github.com/alpacax/alpacon-cli/api/mfa"
+	"github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+// runDisruptiveServerAction runs a disruptive system action (reboot/shutdown/
+// upgrade) with local confirmation, MFA retry, and busy-guard handling.
+// confirmMsg takes the server name; failMsg is prefixed to ": <err>.".
+func runDisruptiveServerAction(serverName, action, confirmMsg, successMsg, failMsg string, yes, force bool) {
+	if !yes {
+		utils.ConfirmAction(confirmMsg, serverName)
+	}
+
+	ac, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	err = server.RequestServerAction(ac, serverName, action, force)
+	if err != nil {
+		err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
+			OnMFARequired: func(srv string) error {
+				return mfa.HandleMFAError(ac, srv)
+			},
+			CheckMFACompleted: func() (bool, error) {
+				return mfa.CheckMFACompletion(ac)
+			},
+			RefreshToken: ac.RefreshToken,
+			RetryOperation: func() error {
+				return server.RequestServerAction(ac, serverName, action, force)
+			},
+		})
+	}
+	if err != nil {
+		if code, _ := utils.ParseErrorResponse(err); code == utils.ServerBusyWithUserWork {
+			utils.CliErrorWithExit("Server '%s' is busy with active user work "+
+				"(open websh/webftp session or in-flight command). "+
+				"Retry when idle, or pass --force to override", serverName)
+		}
+		utils.CliErrorWithExit(failMsg+": %s.", err)
+	}
+
+	utils.CliSuccess("%s", successMsg)
+}

--- a/cmd/server/server_action.go
+++ b/cmd/server/server_action.go
@@ -42,6 +42,11 @@ func runDisruptiveServerAction(serverName, action, confirmMsg, successMsg, failM
 	}
 	if err != nil {
 		if code, _ := utils.ParseErrorResponse(err); code == utils.ServerBusyWithUserWork {
+			if force {
+				utils.CliErrorWithExit("Server '%s' is still busy with active user work "+
+					"(open Websh/WebFTP session or in-flight command) despite --force. "+
+					"Retry when idle", serverName)
+			}
 			utils.CliErrorWithExit("Server '%s' is busy with active user work "+
 				"(open Websh/WebFTP session or in-flight command). "+
 				"Retry when idle, or pass --force to override", serverName)

--- a/cmd/server/server_action.go
+++ b/cmd/server/server_action.go
@@ -5,43 +5,48 @@ import (
 	"github.com/alpacax/alpacon-cli/api/server"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
 )
 
-// runDisruptiveServerAction runs a disruptive system action (reboot/shutdown/
-// upgrade) with local confirmation, MFA retry, and busy-guard handling.
-// confirmMsg takes the server name; failMsg is prefixed to ": <err>.".
+// addDisruptiveActionFlags registers the shared -y/--force flags.
+func addDisruptiveActionFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	cmd.Flags().Bool("force", false, "Override the busy guard even when the server has active user work")
+}
+
+// runDisruptiveServerAction runs the action with confirmation, MFA retry, and busy-guard handling.
 func runDisruptiveServerAction(serverName, action, confirmMsg, successMsg, failMsg string, yes, force bool) {
 	if !yes {
 		utils.ConfirmAction(confirmMsg, serverName)
 	}
 
-	ac, err := client.NewAlpaconAPIClient()
+	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
 		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 	}
 
-	err = server.RequestServerAction(ac, serverName, action, force)
+	err = server.RequestServerAction(alpaconClient, serverName, action, force)
 	if err != nil {
 		err = utils.HandleCommonErrors(err, serverName, utils.ErrorHandlerCallbacks{
 			OnMFARequired: func(srv string) error {
-				return mfa.HandleMFAError(ac, srv)
+				return mfa.HandleMFAError(alpaconClient, srv)
 			},
 			CheckMFACompleted: func() (bool, error) {
-				return mfa.CheckMFACompletion(ac)
+				return mfa.CheckMFACompletion(alpaconClient)
 			},
-			RefreshToken: ac.RefreshToken,
+			RefreshToken: alpaconClient.RefreshToken,
 			RetryOperation: func() error {
-				return server.RequestServerAction(ac, serverName, action, force)
+				return server.RequestServerAction(alpaconClient, serverName, action, force)
 			},
 		})
 	}
 	if err != nil {
 		if code, _ := utils.ParseErrorResponse(err); code == utils.ServerBusyWithUserWork {
 			utils.CliErrorWithExit("Server '%s' is busy with active user work "+
-				"(open websh/webftp session or in-flight command). "+
+				"(open Websh/WebFTP session or in-flight command). "+
 				"Retry when idle, or pass --force to override", serverName)
 		}
-		utils.CliErrorWithExit(failMsg+": %s.", err)
+		utils.CliErrorWithExit("%s: %s.", failMsg, err)
 	}
 
 	utils.CliSuccess("%s", successMsg)

--- a/cmd/server/server_action_test.go
+++ b/cmd/server/server_action_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBusyGuardMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		force       bool
+		wantContain string
+		wantAbsent  string
+	}{
+		{
+			name:        "without force suggests --force",
+			force:       false,
+			wantContain: "pass --force to override",
+			wantAbsent:  "despite --force",
+		},
+		{
+			name:        "with force does not re-suggest --force",
+			force:       true,
+			wantContain: "despite --force",
+			wantAbsent:  "pass --force to override",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := busyGuardMessage("my-server", tt.force)
+			assert.Contains(t, msg, "my-server")
+			assert.Contains(t, msg, tt.wantContain)
+			assert.False(t, strings.Contains(msg, tt.wantAbsent), "message should not contain %q", tt.wantAbsent)
+		})
+	}
+}

--- a/cmd/server/server_reboot.go
+++ b/cmd/server/server_reboot.go
@@ -5,10 +5,19 @@ import (
 )
 
 var serverRebootCmd = &cobra.Command{
-	Use:     "reboot SERVER",
-	Short:   "Reboot a server's operating system",
-	Example: `alpacon server reboot my-server`,
-	Args:    cobra.ExactArgs(1),
+	Use:   "reboot SERVER",
+	Short: "Reboot a server's operating system",
+	Long: `
+	This command reboots the operating system of a specified server through its agent.
+	By default it asks for confirmation; pass -y to skip the prompt.
+	If the server has active user work (an open Websh/WebFTP session or an in-flight command), the reboot is refused unless you pass --force.
+	`,
+	Example: `
+	alpacon server reboot my-server
+	alpacon server reboot my-server -y
+	alpacon server reboot my-server --force
+	`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		yes, _ := cmd.Flags().GetBool("yes")
 		force, _ := cmd.Flags().GetBool("force")

--- a/cmd/server/server_reboot.go
+++ b/cmd/server/server_reboot.go
@@ -4,10 +4,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rebootServerCmd = &cobra.Command{
+var serverRebootCmd = &cobra.Command{
 	Use:     "reboot SERVER",
 	Short:   "Reboot a server's operating system",
-	Example: `alpacon server reboot myserver`,
+	Example: `alpacon server reboot my-server`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		yes, _ := cmd.Flags().GetBool("yes")
@@ -24,6 +24,5 @@ var rebootServerCmd = &cobra.Command{
 }
 
 func init() {
-	rebootServerCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
-	rebootServerCmd.Flags().Bool("force", false, "Override the busy guard even when the server has active user work")
+	addDisruptiveActionFlags(serverRebootCmd)
 }

--- a/cmd/server/server_reboot.go
+++ b/cmd/server/server_reboot.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var rebootServerCmd = &cobra.Command{
+	Use:     "reboot SERVER",
+	Short:   "Reboot a server's operating system",
+	Example: `alpacon server reboot myserver`,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		yes, _ := cmd.Flags().GetBool("yes")
+		force, _ := cmd.Flags().GetBool("force")
+		runDisruptiveServerAction(
+			args[0],
+			"reboot_system",
+			"Reboot server '%s'?",
+			"System reboot requested. Run 'alpacon events' to monitor progress.",
+			"Failed to reboot the server",
+			yes, force,
+		)
+	},
+}
+
+func init() {
+	rebootServerCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	rebootServerCmd.Flags().Bool("force", false, "Override the busy guard even when the server has active user work")
+}

--- a/cmd/server/server_reboot.go
+++ b/cmd/server/server_reboot.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/alpacax/alpacon-cli/api/server"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +24,7 @@ var serverRebootCmd = &cobra.Command{
 		force, _ := cmd.Flags().GetBool("force")
 		runDisruptiveServerAction(
 			args[0],
-			"reboot_system",
+			server.ActionRebootSystem,
 			"Reboot server '%s'?",
 			"System reboot requested. Run 'alpacon events' to monitor progress.",
 			"Failed to reboot the server",

--- a/cmd/server/server_refresh.go
+++ b/cmd/server/server_refresh.go
@@ -28,7 +28,3 @@ var refreshServerCmd = &cobra.Command{
 		utils.CliSuccess("System information refresh requested. Run 'alpacon events' to monitor progress.")
 	},
 }
-
-func init() {
-	ServerCmd.AddCommand(refreshServerCmd)
-}

--- a/cmd/server/server_refresh.go
+++ b/cmd/server/server_refresh.go
@@ -8,8 +8,12 @@ import (
 )
 
 var serverRefreshCmd = &cobra.Command{
-	Use:     "refresh SERVER",
-	Short:   "Refresh a server's system information",
+	Use:   "refresh SERVER",
+	Short: "Refresh a server's system information",
+	Long: `
+	This command requests a refresh of a specified server's system information through its agent.
+	It is a non-disruptive action and does not require confirmation.
+	`,
 	Example: `alpacon server refresh my-server`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/server/server_refresh.go
+++ b/cmd/server/server_refresh.go
@@ -7,20 +7,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var refreshServerCmd = &cobra.Command{
+var serverRefreshCmd = &cobra.Command{
 	Use:     "refresh SERVER",
 	Short:   "Refresh a server's system information",
-	Example: `alpacon server refresh myserver`,
+	Example: `alpacon server refresh my-server`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		serverName := args[0]
 
-		ac, err := client.NewAlpaconAPIClient()
+		alpaconClient, err := client.NewAlpaconAPIClient()
 		if err != nil {
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		err = server.RequestServerAction(ac, serverName, "update_information", false)
+		err = server.RequestServerAction(alpaconClient, serverName, "update_information", false)
 		if err != nil {
 			utils.CliErrorWithExit("Failed to refresh the server information: %s.", err)
 		}

--- a/cmd/server/server_refresh.go
+++ b/cmd/server/server_refresh.go
@@ -24,7 +24,7 @@ var serverRefreshCmd = &cobra.Command{
 			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
 		}
 
-		err = server.RequestServerAction(alpaconClient, serverName, "update_information", false)
+		err = server.RequestServerAction(alpaconClient, serverName, server.ActionUpdateInformation, false)
 		if err != nil {
 			utils.CliErrorWithExit("Failed to refresh the server information: %s.", err)
 		}

--- a/cmd/server/server_refresh.go
+++ b/cmd/server/server_refresh.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"github.com/alpacax/alpacon-cli/api/server"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var refreshServerCmd = &cobra.Command{
+	Use:     "refresh SERVER",
+	Short:   "Refresh a server's system information",
+	Example: `alpacon server refresh myserver`,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		serverName := args[0]
+
+		ac, err := client.NewAlpaconAPIClient()
+		if err != nil {
+			utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		}
+
+		err = server.RequestServerAction(ac, serverName, "update_information", false)
+		if err != nil {
+			utils.CliErrorWithExit("Failed to refresh the server information: %s.", err)
+		}
+
+		utils.CliSuccess("System information refresh requested. Run 'alpacon events' to monitor progress.")
+	},
+}
+
+func init() {
+	ServerCmd.AddCommand(refreshServerCmd)
+}

--- a/cmd/server/server_shutdown.go
+++ b/cmd/server/server_shutdown.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var shutdownServerCmd = &cobra.Command{
+	Use:     "shutdown SERVER",
+	Short:   "Shut down a server's operating system",
+	Example: `alpacon server shutdown myserver`,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		yes, _ := cmd.Flags().GetBool("yes")
+		force, _ := cmd.Flags().GetBool("force")
+		runDisruptiveServerAction(
+			args[0],
+			"shutdown_system",
+			"Shutdown server '%s'?",
+			"System shutdown requested. Run 'alpacon events' to monitor progress.",
+			"Failed to shut down the server",
+			yes, force,
+		)
+	},
+}
+
+func init() {
+	shutdownServerCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	shutdownServerCmd.Flags().Bool("force", false, "Override the busy guard even when the server has active user work")
+}

--- a/cmd/server/server_shutdown.go
+++ b/cmd/server/server_shutdown.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/alpacax/alpacon-cli/api/server"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +24,7 @@ var serverShutdownCmd = &cobra.Command{
 		force, _ := cmd.Flags().GetBool("force")
 		runDisruptiveServerAction(
 			args[0],
-			"shutdown_system",
+			server.ActionShutdownSystem,
 			"Shut down server '%s'?",
 			"System shutdown requested. Run 'alpacon events' to monitor progress.",
 			"Failed to shut down the server",

--- a/cmd/server/server_shutdown.go
+++ b/cmd/server/server_shutdown.go
@@ -4,10 +4,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var shutdownServerCmd = &cobra.Command{
+var serverShutdownCmd = &cobra.Command{
 	Use:     "shutdown SERVER",
 	Short:   "Shut down a server's operating system",
-	Example: `alpacon server shutdown myserver`,
+	Example: `alpacon server shutdown my-server`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		yes, _ := cmd.Flags().GetBool("yes")
@@ -15,7 +15,7 @@ var shutdownServerCmd = &cobra.Command{
 		runDisruptiveServerAction(
 			args[0],
 			"shutdown_system",
-			"Shutdown server '%s'?",
+			"Shut down server '%s'?",
 			"System shutdown requested. Run 'alpacon events' to monitor progress.",
 			"Failed to shut down the server",
 			yes, force,
@@ -24,6 +24,5 @@ var shutdownServerCmd = &cobra.Command{
 }
 
 func init() {
-	shutdownServerCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
-	shutdownServerCmd.Flags().Bool("force", false, "Override the busy guard even when the server has active user work")
+	addDisruptiveActionFlags(serverShutdownCmd)
 }

--- a/cmd/server/server_shutdown.go
+++ b/cmd/server/server_shutdown.go
@@ -5,10 +5,19 @@ import (
 )
 
 var serverShutdownCmd = &cobra.Command{
-	Use:     "shutdown SERVER",
-	Short:   "Shut down a server's operating system",
-	Example: `alpacon server shutdown my-server`,
-	Args:    cobra.ExactArgs(1),
+	Use:   "shutdown SERVER",
+	Short: "Shut down a server's operating system",
+	Long: `
+	This command shuts down the operating system of a specified server through its agent.
+	By default it asks for confirmation; pass -y to skip the prompt.
+	If the server has active user work (an open Websh/WebFTP session or an in-flight command), the shutdown is refused unless you pass --force.
+	`,
+	Example: `
+	alpacon server shutdown my-server
+	alpacon server shutdown my-server -y
+	alpacon server shutdown my-server --force
+	`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		yes, _ := cmd.Flags().GetBool("yes")
 		force, _ := cmd.Flags().GetBool("force")

--- a/cmd/server/server_upgrade.go
+++ b/cmd/server/server_upgrade.go
@@ -5,17 +5,26 @@ import (
 )
 
 var serverUpgradeCmd = &cobra.Command{
-	Use:     "upgrade SERVER",
-	Short:   "Upgrade a server's operating system packages",
-	Example: `alpacon server upgrade my-server`,
-	Args:    cobra.ExactArgs(1),
+	Use:   "upgrade SERVER",
+	Short: "Upgrade a server's operating system packages",
+	Long: `
+	This command upgrades the operating system packages of a specified server through its agent.
+	By default it asks for confirmation; pass -y to skip the prompt.
+	If the server has active user work (an open Websh/WebFTP session or an in-flight command), the upgrade is refused unless you pass --force.
+	`,
+	Example: `
+	alpacon server upgrade my-server
+	alpacon server upgrade my-server -y
+	alpacon server upgrade my-server --force
+	`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		yes, _ := cmd.Flags().GetBool("yes")
 		force, _ := cmd.Flags().GetBool("force")
 		runDisruptiveServerAction(
 			args[0],
 			"upgrade_system",
-			"Upgrade system on server '%s'?",
+			"Upgrade server '%s'?",
 			"System upgrade requested. Run 'alpacon events' to monitor progress.",
 			"Failed to upgrade the server",
 			yes, force,

--- a/cmd/server/server_upgrade.go
+++ b/cmd/server/server_upgrade.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/alpacax/alpacon-cli/api/server"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +24,7 @@ var serverUpgradeCmd = &cobra.Command{
 		force, _ := cmd.Flags().GetBool("force")
 		runDisruptiveServerAction(
 			args[0],
-			"upgrade_system",
+			server.ActionUpgradeSystem,
 			"Upgrade server '%s'?",
 			"System upgrade requested. Run 'alpacon events' to monitor progress.",
 			"Failed to upgrade the server",

--- a/cmd/server/server_upgrade.go
+++ b/cmd/server/server_upgrade.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var upgradeServerCmd = &cobra.Command{
+	Use:     "upgrade SERVER",
+	Short:   "Upgrade a server's operating system packages",
+	Example: `alpacon server upgrade myserver`,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		yes, _ := cmd.Flags().GetBool("yes")
+		force, _ := cmd.Flags().GetBool("force")
+		runDisruptiveServerAction(
+			args[0],
+			"upgrade_system",
+			"Upgrade system on server '%s'?",
+			"System upgrade requested. Run 'alpacon events' to monitor progress.",
+			"Failed to upgrade the server",
+			yes, force,
+		)
+	},
+}
+
+func init() {
+	upgradeServerCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	upgradeServerCmd.Flags().Bool("force", false, "Override the busy guard even when the server has active user work")
+}

--- a/cmd/server/server_upgrade.go
+++ b/cmd/server/server_upgrade.go
@@ -4,10 +4,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var upgradeServerCmd = &cobra.Command{
+var serverUpgradeCmd = &cobra.Command{
 	Use:     "upgrade SERVER",
 	Short:   "Upgrade a server's operating system packages",
-	Example: `alpacon server upgrade myserver`,
+	Example: `alpacon server upgrade my-server`,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		yes, _ := cmd.Flags().GetBool("yes")
@@ -24,6 +24,5 @@ var upgradeServerCmd = &cobra.Command{
 }
 
 func init() {
-	upgradeServerCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
-	upgradeServerCmd.Flags().Bool("force", false, "Override the busy guard even when the server has active user work")
+	addDisruptiveActionFlags(serverUpgradeCmd)
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -37,6 +37,13 @@ const (
 	// PendingApprovalStatus is the stable machine-readable status string emitted
 	// under --output json when an action is pending human approval.
 	PendingApprovalStatus = "pending_approval"
+
+	// ExitCodeServerBusy is the process exit code for a disruptive server action
+	// refused because the server has active user work (server_busy_with_user_work).
+	// It is a transient, retryable "busy now → retry later" condition, distinct from
+	// a hard failure (1): scripts and AI agents branch on it to retry when idle
+	// (or re-run with --force) rather than give up.
+	ExitCodeServerBusy = 5
 )
 
 type ErrorResponse struct {

--- a/utils/error.go
+++ b/utils/error.go
@@ -10,8 +10,7 @@ const (
 	AuthMFARequired  = "auth_mfa_required"
 	UsernameRequired = "user_username_required"
 
-	// ServerBusyWithUserWork is returned when a disruptive server action is
-	// refused because the server has active user work; --force overrides it.
+	// ServerBusyWithUserWork: disruptive action refused; --force overrides it.
 	ServerBusyWithUserWork = "server_busy_with_user_work"
 
 	// WorkSession gate codes (returned by alpacon-server work_sessions/services.py)

--- a/utils/error.go
+++ b/utils/error.go
@@ -10,6 +10,10 @@ const (
 	AuthMFARequired  = "auth_mfa_required"
 	UsernameRequired = "user_username_required"
 
+	// ServerBusyWithUserWork is returned when a disruptive server action is
+	// refused because the server has active user work; --force overrides it.
+	ServerBusyWithUserWork = "server_busy_with_user_work"
+
 	// WorkSession gate codes (returned by alpacon-server work_sessions/services.py)
 	WorkSessionRequired         = "work_session_required"
 	WorkSessionNotUsable        = "work_session_not_usable"

--- a/utils/error.go
+++ b/utils/error.go
@@ -86,12 +86,12 @@ func ParseErrorResponse(err error) (string, string) {
 
 		// Try "code: X; source: Y" format (produced by parseAPIError in the HTTP client)
 		var iterCode, iterSource string
-		for _, part := range strings.Split(errStr, "; ") {
+		for part := range strings.SplitSeq(errStr, "; ") {
 			part = strings.TrimSpace(part)
-			if strings.HasPrefix(part, "code: ") {
-				iterCode = strings.TrimPrefix(part, "code: ")
-			} else if strings.HasPrefix(part, "source: ") {
-				iterSource = strings.TrimPrefix(part, "source: ")
+			if after, ok := strings.CutPrefix(part, "code: "); ok {
+				iterCode = after
+			} else if after, ok := strings.CutPrefix(part, "source: "); ok {
+				iterSource = after
 			}
 		}
 		if iterCode != "" {

--- a/utils/error_test.go
+++ b/utils/error_test.go
@@ -124,3 +124,9 @@ func TestWorkSessionConstants(t *testing.T) {
 	assert.Equal(t, "work_session_assignee_mismatch", WorkSessionAssigneeMismatch)
 	assert.Equal(t, 3, ExitCodeWorkSessionDenied)
 }
+
+func TestServerBusyExitCode(t *testing.T) {
+	// Stable, script-facing contract—see README "Exit codes".
+	assert.Equal(t, "server_busy_with_user_work", ServerBusyWithUserWork)
+	assert.Equal(t, 5, ExitCodeServerBusy)
+}

--- a/utils/log.go
+++ b/utils/log.go
@@ -28,6 +28,15 @@ func CliErrorWithExit(msg string, args ...any) {
 	os.Exit(1)
 }
 
+// CliErrorWithExitCode prints an error message to stderr and exits with the given code.
+// Unlike CliErrorWithExit it omits the "report an issue" footer—use it for expected,
+// machine-distinguishable refusals (e.g. a busy server) that scripts branch on by exit code.
+func CliErrorWithExitCode(code int, msg string, args ...any) {
+	errorMessage := fmt.Sprintf(msg, args...)
+	fmt.Fprintf(os.Stderr, "%s: %s\n", Red("Error"), errorMessage)
+	os.Exit(code)
+}
+
 // CliInfo handles all informational messages in the CLI.
 func CliInfo(msg string, args ...any) {
 	infoMessage := fmt.Sprintf(msg, args...)


### PR DESCRIPTION
## Background

The CLI had no way to trigger server system-level actions (reboot, shutdown, OS package upgrade, system information refresh). The server already exposes these through the actions endpoint (`POST /api/servers/servers/{id}/actions/`, body `{action, force}`), but there was no CLI entry point, so engineers and AI agents had to fall back to the web console. This PR adds four subcommands that wrap that endpoint.

## Changes

Adds four commands under `alpacon server`.

- `reboot`, `shutdown`, `upgrade` are disruptive actions. Each prompts for confirmation before running (skippable with `-y`) and runs the MFA retry flow when the server requires it. If the target has active user work (an open Websh/WebFTP session or an in-flight command), the server-side busy guard refuses the action, and `--force` overrides it.
- `refresh` is a non-disruptive action (`update_information`). It has no confirmation, `--force`, or MFA path and simply issues the API call.

The API layer is a single `RequestServerAction(ac, serverName, action, force)` in `api/server/server.go`, which resolves the server ID by name and POSTs to the actions endpoint. The shared logic of the three disruptive commands (confirmation, MFA retry, busy-guard handling) is centralized in `runDisruptiveServerAction` in `cmd/server/server_action.go`, and the shared `-y`/`--force` flag registration lives in `addDisruptiveActionFlags`.

Command help (`Long`) and `Example` follow the existing `cmd/server` subcommand conventions, and the confirmation prompts are unified on the `<verb> server '%s'?` pattern. This branch also modernizes the error parsing in `utils/error.go` to Go 1.25 string-iterator idioms (`SplitSeq`/`CutPrefix`).

## Permissions

The busy guard and MFA gating are both decided server-side. The CLI only forwards `--force` (the intent to override the busy guard); it never relaxes or bypasses authorization on the client. Disruptive actions may require MFA per the server-side `mfa_rules`, while `refresh` is non-disruptive and is not subject to MFA.

## Testing

`TestRequestServerAction` in `api/server/server_test.go` verifies the transmitted `action` and `force` values and the POST path (`/api/servers/servers/{id}/actions/`) across the `reboot_system` (force=true) and `update_information` (force=false) paths. `go test -race ./...`, `go vet`, and `golangci-lint run` all pass.

## Checklist

- [x] `go build ./...` / `go vet ./...` pass
- [x] `go test -race ./...` passes
- [x] `golangci-lint run` passes (0 issues)
- [x] Busy-guard/MFA decisions delegated to the server; no client-side bypass

Closes #257