### PR TITLE
perf(event): bound gap-fill and recoverSkipped fetches with seq__lte

### DIFF
--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -10,7 +10,7 @@ import (
 	"github.com/alpacax/alpacon-cli/client"
 )
 
-// noSeqBound is the toSeq sentinel that leaves GetCommandChunks unbounded (seq
+// noSeqBound is the toSeq sentinel that leaves getCommandChunks unbounded (seq
 // is 0-indexed, so 0 is a valid upper bound and cannot mean "no bound").
 const noSeqBound = -1
 
@@ -20,11 +20,11 @@ type Chunk struct {
 	Content string `json:"content"`
 }
 
-// GetCommandChunks fetches chunks for cmdID with seq in [fromSeq, toSeq],
+// getCommandChunks fetches chunks for cmdID with seq in [fromSeq, toSeq],
 // sorted by seq ascending. A negative toSeq (noSeqBound) omits the upper
 // bound. The streaming consumers rely on the order, so we sort defensively
 // in case the server does not honor the ordering param.
-func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq, toSeq int) ([]Chunk, error) {
+func getCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq, toSeq int) ([]Chunk, error) {
 	endpoint := "/api/events/commands/" + url.PathEscape(cmdID) + "/chunks/"
 	params := map[string]string{
 		"seq__gte": strconv.Itoa(fromSeq),
@@ -47,7 +47,7 @@ func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq, toSeq int
 // order. Empty when no chunks were produced. Used by non-streaming paths (exec
 // logs, polling fallback) where Result is empty under the chunk contract.
 func GetCommandOutput(ac *client.AlpaconClient, cmdID string) (string, error) {
-	chunks, err := GetCommandChunks(ac, cmdID, 0, noSeqBound)
+	chunks, err := getCommandChunks(ac, cmdID, 0, noSeqBound)
 	if err != nil {
 		return "", err
 	}

--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -30,9 +30,9 @@ func getCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq, toSeq int
 		"seq__gte": strconv.Itoa(fromSeq),
 		"ordering": "seq",
 	}
+	// Send seq__lte only when bounded; omit rather than send empty, since the
+	// server's strict integer filter rejects an empty seq__lte.
 	if toSeq >= 0 {
-		// Omit rather than send empty when unbounded: the server's strict
-		// integer filter rejects an empty seq__lte.
 		params["seq__lte"] = strconv.Itoa(toSeq)
 	}
 	chunks, err := api.FetchAllPages[Chunk](ac, endpoint, params)

--- a/api/event/chunks.go
+++ b/api/event/chunks.go
@@ -10,20 +10,30 @@ import (
 	"github.com/alpacax/alpacon-cli/client"
 )
 
+// noSeqBound is the toSeq sentinel that leaves GetCommandChunks unbounded (seq
+// is 0-indexed, so 0 is a valid upper bound and cannot mean "no bound").
+const noSeqBound = -1
+
 // Chunk represents a single stdout/stderr chunk produced during command execution.
 type Chunk struct {
 	Seq     int    `json:"seq"`
 	Content string `json:"content"`
 }
 
-// GetCommandChunks fetches chunks for cmdID with seq >= fromSeq, sorted by seq
-// ascending. The streaming consumers rely on that order, so we sort defensively
+// GetCommandChunks fetches chunks for cmdID with seq in [fromSeq, toSeq],
+// sorted by seq ascending. A negative toSeq (noSeqBound) omits the upper
+// bound. The streaming consumers rely on the order, so we sort defensively
 // in case the server does not honor the ordering param.
-func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq int) ([]Chunk, error) {
+func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq, toSeq int) ([]Chunk, error) {
 	endpoint := "/api/events/commands/" + url.PathEscape(cmdID) + "/chunks/"
 	params := map[string]string{
 		"seq__gte": strconv.Itoa(fromSeq),
 		"ordering": "seq",
+	}
+	if toSeq >= 0 {
+		// Omit rather than send empty when unbounded: the server's strict
+		// integer filter rejects an empty seq__lte.
+		params["seq__lte"] = strconv.Itoa(toSeq)
 	}
 	chunks, err := api.FetchAllPages[Chunk](ac, endpoint, params)
 	if err != nil {
@@ -37,7 +47,7 @@ func GetCommandChunks(ac *client.AlpaconClient, cmdID string, fromSeq int) ([]Ch
 // order. Empty when no chunks were produced. Used by non-streaming paths (exec
 // logs, polling fallback) where Result is empty under the chunk contract.
 func GetCommandOutput(ac *client.AlpaconClient, cmdID string) (string, error) {
-	chunks, err := GetCommandChunks(ac, cmdID, 0)
+	chunks, err := GetCommandChunks(ac, cmdID, 0, noSeqBound)
 	if err != nil {
 		return "", err
 	}

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -38,7 +38,7 @@ func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
-	got, err := GetCommandChunks(ac, cmdID, 5)
+	got, err := GetCommandChunks(ac, cmdID, 5, noSeqBound)
 	require.NoError(t, err)
 	assert.Equal(t, []Chunk{
 		{Seq: 5, Content: "hello\n"},
@@ -46,6 +46,7 @@ func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
 	}, got)
 	assert.Contains(t, capturedQuery, "seq__gte=5")
 	assert.Contains(t, capturedQuery, "ordering=seq")
+	assert.NotContains(t, capturedQuery, "seq__lte")
 }
 
 // TestGetCommandOutput_ConcatenatesChunksInSeqOrder verifies the full output is
@@ -95,7 +96,7 @@ func TestGetCommandChunks_SortsBySeq(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
-	got, err := GetCommandChunks(ac, cmdID, 0)
+	got, err := GetCommandChunks(ac, cmdID, 0, noSeqBound)
 	require.NoError(t, err)
 	assert.Equal(t, []Chunk{
 		{Seq: 0, Content: "a\n"},

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -104,3 +104,38 @@ func TestGetCommandChunks_SortsBySeq(t *testing.T) {
 		{Seq: 2, Content: "c\n"},
 	}, got)
 }
+
+// TestGetCommandChunks_SendsSeqLteWhenBounded verifies a non-negative toSeq is
+// sent as the seq__lte upper bound.
+func TestGetCommandChunks_SendsSeqLteWhenBounded(t *testing.T) {
+	cmdID := "a1b2c3d4-1234-5678-abcd-000000000000"
+	tests := []struct {
+		name    string
+		fromSeq int
+		toSeq   int
+		wantQ   []string
+	}{
+		{"bounded range", 5, 8, []string{"seq__gte=5", "seq__lte=8"}},
+		// toSeq=0 is a valid bound (seq is 0-indexed), not treated as "unbounded".
+		{"zero is a valid bound", 0, 0, []string{"seq__lte=0"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedQuery string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedQuery = r.URL.RawQuery
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{})
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+			_, err := GetCommandChunks(ac, cmdID, tt.fromSeq, tt.toSeq)
+			require.NoError(t, err)
+			for _, want := range tt.wantQ {
+				assert.Contains(t, capturedQuery, want)
+			}
+		})
+	}
+}

--- a/api/event/chunks_test.go
+++ b/api/event/chunks_test.go
@@ -38,7 +38,7 @@ func TestGetCommandChunks_PassesSeqGteAndReturnsResults(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
-	got, err := GetCommandChunks(ac, cmdID, 5, noSeqBound)
+	got, err := getCommandChunks(ac, cmdID, 5, noSeqBound)
 	require.NoError(t, err)
 	assert.Equal(t, []Chunk{
 		{Seq: 5, Content: "hello\n"},
@@ -96,7 +96,7 @@ func TestGetCommandChunks_SortsBySeq(t *testing.T) {
 
 	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
-	got, err := GetCommandChunks(ac, cmdID, 0, noSeqBound)
+	got, err := getCommandChunks(ac, cmdID, 0, noSeqBound)
 	require.NoError(t, err)
 	assert.Equal(t, []Chunk{
 		{Seq: 0, Content: "a\n"},
@@ -131,7 +131,7 @@ func TestGetCommandChunks_SendsSeqLteWhenBounded(t *testing.T) {
 
 			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 
-			_, err := GetCommandChunks(ac, cmdID, tt.fromSeq, tt.toSeq)
+			_, err := getCommandChunks(ac, cmdID, tt.fromSeq, tt.toSeq)
 			require.NoError(t, err)
 			for _, want := range tt.wantQ {
 				assert.Contains(t, capturedQuery, want)

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -103,7 +103,7 @@ func (g *gapFillState) recoverSkipped(ac *client.AlpaconClient, cmdID string, ou
 	if len(g.skipped) == 0 {
 		return
 	}
-	final, err := GetCommandChunks(ac, cmdID, g.skipped[0], g.skipped[len(g.skipped)-1])
+	final, err := getCommandChunks(ac, cmdID, g.skipped[0], g.skipped[len(g.skipped)-1])
 	if err != nil {
 		utils.CliWarning("failed to fetch skipped chunks (seq %s): %v; output may be incomplete", formatSeqs(g.skipped), err)
 		return
@@ -347,7 +347,7 @@ func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, l
 	// as a duplicate. Chunks past the gap are picked up by applyChunk or the
 	// terminal drain once the gap is filled.
 	lastSeq := -1
-	if existing, err := GetCommandChunks(ac, cmdID, 0, noSeqBound); err == nil {
+	if existing, err := getCommandChunks(ac, cmdID, 0, noSeqBound); err == nil {
 		for _, c := range existing {
 			if c.Seq != lastSeq+1 {
 				break
@@ -413,7 +413,7 @@ func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk Chunk
 			return lastSeq
 		}
 		before := lastSeq
-		missing, err := GetCommandChunks(ac, cmdID, lastSeq+1, chunk.Seq-1)
+		missing, err := getCommandChunks(ac, cmdID, lastSeq+1, chunk.Seq-1)
 		g.lastAttempt = gapFillNow()
 		if err != nil {
 			// Fetch failed: back off (noProgress++ keeps the throttle window
@@ -471,7 +471,7 @@ func chunkContent(chunks []Chunk) map[int]string {
 }
 
 func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, out io.Writer) int {
-	final, err := GetCommandChunks(ac, cmdID, lastSeq+1, noSeqBound)
+	final, err := getCommandChunks(ac, cmdID, lastSeq+1, noSeqBound)
 	if err != nil {
 		utils.CliWarning("failed to fetch trailing chunks (from seq %d): %v; output may be incomplete",
 			lastSeq+1, err)

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -98,12 +98,12 @@ func (g *gapFillState) giveUpGap(lastSeq, nextSeq int, missing []Chunk, out io.W
 
 // recoverSkipped makes a final fetch for seqs skipped mid-stream (giveUpGap),
 // printing late content out of order and reporting still-absent seqs as lost.
-// g.skipped is ascending, so the fetch starts at its first seq.
+// g.skipped is ascending, so the fetch is bounded to [first seq, last seq].
 func (g *gapFillState) recoverSkipped(ac *client.AlpaconClient, cmdID string, out io.Writer) {
 	if len(g.skipped) == 0 {
 		return
 	}
-	final, err := GetCommandChunks(ac, cmdID, g.skipped[0])
+	final, err := GetCommandChunks(ac, cmdID, g.skipped[0], g.skipped[len(g.skipped)-1])
 	if err != nil {
 		utils.CliWarning("failed to fetch skipped chunks (seq %s): %v; output may be incomplete", formatSeqs(g.skipped), err)
 		return
@@ -347,7 +347,7 @@ func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, l
 	// as a duplicate. Chunks past the gap are picked up by applyChunk or the
 	// terminal drain once the gap is filled.
 	lastSeq := -1
-	if existing, err := GetCommandChunks(ac, cmdID, 0); err == nil {
+	if existing, err := GetCommandChunks(ac, cmdID, 0, noSeqBound); err == nil {
 		for _, c := range existing {
 			if c.Seq != lastSeq+1 {
 				break
@@ -413,7 +413,7 @@ func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk Chunk
 			return lastSeq
 		}
 		before := lastSeq
-		missing, err := GetCommandChunks(ac, cmdID, lastSeq+1)
+		missing, err := GetCommandChunks(ac, cmdID, lastSeq+1, chunk.Seq-1)
 		g.lastAttempt = gapFillNow()
 		if err != nil {
 			// Fetch failed: back off (noProgress++ keeps the throttle window
@@ -426,6 +426,8 @@ func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk Chunk
 		} else {
 			// Advance only over contiguous seqs, stopping at the first hole, so a
 			// gap-fill racing ahead of persistence can't skip a not-yet-stored seq.
+			// The c.Seq > chunk.Seq clip is a safety net for old servers that
+			// ignore seq__lte and return the tail past the requested bound.
 			for _, c := range missing {
 				if c.Seq != lastSeq+1 || c.Seq > chunk.Seq {
 					break
@@ -468,7 +470,7 @@ func chunkContent(chunks []Chunk) map[int]string {
 }
 
 func drainRemainingChunks(ac *client.AlpaconClient, cmdID string, lastSeq int, out io.Writer) int {
-	final, err := GetCommandChunks(ac, cmdID, lastSeq+1)
+	final, err := GetCommandChunks(ac, cmdID, lastSeq+1, noSeqBound)
 	if err != nil {
 		utils.CliWarning("failed to fetch trailing chunks (from seq %d): %v; output may be incomplete",
 			lastSeq+1, err)

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -426,8 +426,9 @@ func applyChunk(ac *client.AlpaconClient, cmdID string, lastSeq int, chunk Chunk
 		} else {
 			// Advance only over contiguous seqs, stopping at the first hole, so a
 			// gap-fill racing ahead of persistence can't skip a not-yet-stored seq.
-			// The c.Seq > chunk.Seq clip is a safety net for old servers that
-			// ignore seq__lte and return the tail past the requested bound.
+			// The c.Seq > chunk.Seq clip caps consumption at the live chunk's seq
+			// (one past the requested seq__lte), so an old server that ignores
+			// seq__lte and returns the whole tail can't overrun the live chunk.
 			for _, c := range missing {
 				if c.Seq != lastSeq+1 || c.Seq > chunk.Seq {
 					break

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -1440,3 +1440,78 @@ func TestDrainRemainingChunks_NoWarnWhenContiguous(t *testing.T) {
 	assert.Equal(t, "c3\nc4\nc5\nc6\n", out.String())
 	assert.NotContains(t, stderr, "never arrived")
 }
+
+// TestApplyChunk_SendsSeqLteBound verifies the gap-fill re-fetch is bounded by
+// the live chunk that exposed the hole (seq__lte == chunk.Seq-1).
+func TestApplyChunk_SendsSeqLteBound(t *testing.T) {
+	var lastLte atomic.Pointer[string]
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s := r.URL.Query().Get("seq__lte")
+		lastLte.Store(&s)
+		// Return the whole gap so applyChunk can advance contiguously.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{
+			Count:   2,
+			Results: []Chunk{{Seq: 1, Content: "c1\n"}, {Seq: 2, Content: "c2\n"}},
+		})
+	}))
+	t.Cleanup(ts.Close)
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	g := &gapFillState{}
+	out := &bytes.Buffer{}
+	// lastSeq=0, live chunk seq=3 -> gap [1,2], bound seq__lte=2.
+	_ = applyChunk(ac, "cmd", 0, ChunkEvent{Seq: 3, Content: "c3\n"}, out, g)
+
+	got := lastLte.Load()
+	require.NotNil(t, got)
+	assert.Equal(t, "2", *got)
+}
+
+// TestRecoverSkippedChunks_SendsSeqLteBound verifies the final recovery fetch is
+// bounded by the last skipped seq (g.skipped is ascending).
+func TestRecoverSkippedChunks_SendsSeqLteBound(t *testing.T) {
+	var lastLte atomic.Pointer[string]
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s := r.URL.Query().Get("seq__lte")
+		lastLte.Store(&s)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{})
+	}))
+	t.Cleanup(ts.Close)
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	g := &gapFillState{skipped: []int{1, 4}}
+	out := &bytes.Buffer{}
+	g.recoverSkipped(ac, "cmd", out)
+
+	got := lastLte.Load()
+	require.NotNil(t, got)
+	assert.Equal(t, "4", *got)
+}
+
+// TestApplyChunk_OldServerIgnoringSeqLte_OutputIdentical verifies that when a
+// server ignores seq__lte and returns the full tail, applyChunk's contiguous
+// consumption still stops at the live chunk (client-side upper-bound filter).
+func TestApplyChunk_OldServerIgnoringSeqLte_OutputIdentical(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Old server: ignores seq__lte, returns everything from seq__gte on.
+		from, _ := strconv.Atoi(r.URL.Query().Get("seq__gte"))
+		var results []Chunk
+		for s := from; s <= 5; s++ {
+			results = append(results, Chunk{Seq: s, Content: fmt.Sprintf("c%d\n", s)})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{Count: len(results), Results: results})
+	}))
+	t.Cleanup(ts.Close)
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	g := &gapFillState{}
+	out := &bytes.Buffer{}
+	// Gap [1,2] exposed by live chunk seq=3; server also returns 4,5 (ignored).
+	lastSeq := applyChunk(ac, "cmd", 0, ChunkEvent{Seq: 3, Content: "c3\n"}, out, g)
+
+	assert.Equal(t, 3, lastSeq, "advances only through the live chunk, not the extra tail")
+	assert.Equal(t, "c1\nc2\nc3\n", out.String(), "extra tail beyond the bound is not emitted")
+}

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -1103,8 +1103,9 @@ func captureStderr(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-// parseSeqLte reads the optional seq__lte upper bound; an absent or
-// unparseable value means "no upper bound" (mirroring the server).
+// parseSeqLte reads the optional seq__lte upper bound. An absent value means
+// "no upper bound". An unparseable value is ignored here too, unlike the real
+// server, whose strict integer filter rejects it — the CLI never sends one.
 func parseSeqLte(r *http.Request) (to int, hasLte bool) {
 	if lte := r.URL.Query().Get("seq__lte"); lte != "" {
 		if v, err := strconv.Atoi(lte); err == nil {

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -1360,7 +1360,7 @@ func TestGiveUpGap_BoundsCumulativeSkipped(t *testing.T) {
 	out := &bytes.Buffer{}
 	last := 0
 	stderr := captureStderr(t, func() {
-		for range 4 {
+		for i := 0; i < 4; i++ {
 			next := last + 3 + 1 // gap of 3 seqs, each under maxGapWidth=4
 			last = g.giveUpGap(last, next, nil, out)
 		}
@@ -1442,53 +1442,53 @@ func TestDrainRemainingChunks_NoWarnWhenContiguous(t *testing.T) {
 	assert.NotContains(t, stderr, "never arrived")
 }
 
-// TestApplyChunk_SendsSeqLteBound verifies the gap-fill re-fetch is bounded by
-// the live chunk that exposed the hole (seq__lte == chunk.Seq-1).
-func TestApplyChunk_SendsSeqLteBound(t *testing.T) {
-	var lastLte atomic.Pointer[string]
+// lteCapturingServer serves results and records the seq__gte/seq__lte query
+// params of the last request, so a caller can assert the fetch was bounded.
+// bounds() is read after the fetch completes, so the plain vars need no lock.
+func lteCapturingServer(t *testing.T, results []Chunk) (ac *client.AlpaconClient, bounds func() (gte, lte string)) {
+	t.Helper()
+	var gte, lte string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s := r.URL.Query().Get("seq__lte")
-		lastLte.Store(&s)
-		// Return the whole gap so applyChunk can advance contiguously.
+		gte = r.URL.Query().Get("seq__gte")
+		lte = r.URL.Query().Get("seq__lte")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{
-			Count:   2,
-			Results: []Chunk{{Seq: 1, Content: "c1\n"}, {Seq: 2, Content: "c2\n"}},
-		})
+		_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{Count: len(results), Results: results})
 	}))
 	t.Cleanup(ts.Close)
-	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	ac = &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	return ac, func() (string, string) { return gte, lte }
+}
+
+// TestApplyChunk_SendsSeqLteBound verifies the gap-fill re-fetch is bounded by
+// the live chunk that exposed the hole (seq__gte == lastSeq+1, seq__lte == chunk.Seq-1).
+func TestApplyChunk_SendsSeqLteBound(t *testing.T) {
+	// Return the whole gap so applyChunk can advance contiguously.
+	ac, bounds := lteCapturingServer(t, []Chunk{{Seq: 1, Content: "c1\n"}, {Seq: 2, Content: "c2\n"}})
 
 	g := &gapFillState{}
 	out := &bytes.Buffer{}
-	// lastSeq=0, live chunk seq=3 -> gap [1,2], bound seq__lte=2.
+	// lastSeq=0, live chunk seq=3 -> gap [1,2], bounds seq__gte=1, seq__lte=2.
 	_ = applyChunk(ac, "cmd", 0, ChunkEvent{Seq: 3, Content: "c3\n"}, out, g)
 
-	got := lastLte.Load()
-	require.NotNil(t, got)
-	assert.Equal(t, "2", *got)
+	gte, lte := bounds()
+	assert.Equal(t, "1", gte)
+	assert.Equal(t, "2", lte)
 }
 
 // TestRecoverSkippedChunks_SendsSeqLteBound verifies the final recovery fetch is
-// bounded by the last skipped seq (g.skipped is ascending).
+// bounded by the first and last skipped seq (g.skipped is ascending).
 func TestRecoverSkippedChunks_SendsSeqLteBound(t *testing.T) {
-	var lastLte atomic.Pointer[string]
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s := r.URL.Query().Get("seq__lte")
-		lastLte.Store(&s)
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{})
-	}))
-	t.Cleanup(ts.Close)
-	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	ac, bounds := lteCapturingServer(t, nil)
 
 	g := &gapFillState{skipped: []int{1, 4}}
 	out := &bytes.Buffer{}
-	g.recoverSkipped(ac, "cmd", out)
+	_ = captureStderr(t, func() {
+		g.recoverSkipped(ac, "cmd", out)
+	})
 
-	got := lastLte.Load()
-	require.NotNil(t, got)
-	assert.Equal(t, "4", *got)
+	gte, lte := bounds()
+	assert.Equal(t, "1", gte)
+	assert.Equal(t, "4", lte)
 }
 
 // TestApplyChunk_OldServerIgnoringSeqLte_OutputIdentical verifies that when a
@@ -1515,4 +1515,31 @@ func TestApplyChunk_OldServerIgnoringSeqLte_OutputIdentical(t *testing.T) {
 
 	assert.Equal(t, 3, lastSeq, "advances only through the live chunk, not the extra tail")
 	assert.Equal(t, "c1\nc2\nc3\n", out.String(), "extra tail beyond the bound is not emitted")
+}
+
+// TestRecoverSkippedChunks_OldServerIgnoringSeqLte_OutputIdentical verifies that
+// when a server ignores seq__lte and returns extra chunks, recoverSkipped emits
+// only the skipped seqs it looks up via the bySeq map, never the extra tail.
+func TestRecoverSkippedChunks_OldServerIgnoringSeqLte_OutputIdentical(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Old server: ignores seq__lte, returns everything from seq__gte on.
+		from, _ := strconv.Atoi(r.URL.Query().Get("seq__gte"))
+		var results []Chunk
+		for s := from; s <= 6; s++ {
+			results = append(results, Chunk{Seq: s, Content: fmt.Sprintf("c%d\n", s)})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{Count: len(results), Results: results})
+	}))
+	t.Cleanup(ts.Close)
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+
+	g := &gapFillState{skipped: []int{1, 4}}
+	out := &bytes.Buffer{}
+	// Server returns 1..6 (ignoring seq__lte=4); only skipped 1 and 4 are emitted.
+	_ = captureStderr(t, func() {
+		g.recoverSkipped(ac, "cmd", out)
+	})
+
+	assert.Equal(t, "c1\nc4\n", out.String(), "only skipped seqs emitted, extra tail ignored")
 }

--- a/api/event/event_test.go
+++ b/api/event/event_test.go
@@ -1103,16 +1103,31 @@ func captureStderr(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-// holeServer serves /chunks/?seq__gte=N returning every seq >= N except those
-// in `hole`. fetches counts the chunk requests. Used to simulate a seq that is
-// never persisted server-side.
+// parseSeqLte reads the optional seq__lte upper bound; an absent or
+// unparseable value means "no upper bound" (mirroring the server).
+func parseSeqLte(r *http.Request) (to int, hasLte bool) {
+	if lte := r.URL.Query().Get("seq__lte"); lte != "" {
+		if v, err := strconv.Atoi(lte); err == nil {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+// holeServer serves /chunks/?seq__gte=N[&seq__lte=M] returning every seq in the
+// window except those in `hole`. fetches counts the chunk requests. Used to
+// simulate a seq that is never persisted server-side.
 func holeServer(t *testing.T, maxSeq int, hole map[int]bool, fetches *atomic.Int32) *client.AlpaconClient {
 	t.Helper()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fetches.Add(1)
 		from, _ := strconv.Atoi(r.URL.Query().Get("seq__gte"))
+		to, hasLte := parseSeqLte(r)
 		var results []Chunk
 		for s := from; s <= maxSeq; s++ {
+			if hasLte && s > to {
+				break
+			}
 			if hole[s] {
 				continue
 			}
@@ -1125,18 +1140,20 @@ func holeServer(t *testing.T, maxSeq int, hole map[int]bool, fetches *atomic.Int
 	return &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
 }
 
-// chunkServer serves an explicit chunk list (filtered by seq__gte), for tests
-// that need specific or out-of-range seqs holeServer's contiguous range can't
-// express.
+// chunkServer serves an explicit chunk list (filtered by seq__gte and optional
+// seq__lte), for tests that need specific or out-of-range seqs holeServer's
+// contiguous range can't express.
 func chunkServer(t *testing.T, chunks []Chunk) *client.AlpaconClient {
 	t.Helper()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		from, _ := strconv.Atoi(r.URL.Query().Get("seq__gte"))
+		to, hasLte := parseSeqLte(r)
 		var results []Chunk
 		for _, c := range chunks {
-			if c.Seq >= from {
-				results = append(results, c)
+			if c.Seq < from || (hasLte && c.Seq > to) {
+				continue
 			}
+			results = append(results, c)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.ListResponse[Chunk]{Count: len(results), Results: results})
@@ -1342,7 +1359,7 @@ func TestGiveUpGap_BoundsCumulativeSkipped(t *testing.T) {
 	out := &bytes.Buffer{}
 	last := 0
 	stderr := captureStderr(t, func() {
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			next := last + 3 + 1 // gap of 3 seqs, each under maxGapWidth=4
 			last = g.giveUpGap(last, next, nil, out)
 		}


### PR DESCRIPTION
## Background

While streaming command output, the re-fetches that fill seq holes only set a lower bound (`seq__gte`), so they downloaded everything from the hole to the current end of output and discarded the unneeded tail client-side. As long as a hole stayed open and the command kept producing output, each retry cost O(current tail). The server now supports a `seq__lte` upper-bound filter (alpacax/alpacon-server#2571), so the CLI can narrow these re-fetches to the window it actually needs.

## Changes

Add a `toSeq` upper-bound argument to `getCommandChunks`. The function stays single; unbounded is expressed with a negative sentinel `noSeqBound` (-1). Because seq is 0-indexed, `0` is a legitimate upper bound, so the sentinel must be negative rather than `0`. `seq__lte` is sent only when `toSeq >= 0`; when unbounded the parameter is omitted entirely (the server's strict integer filter rejects an empty `seq__lte`, so an empty value is never sent).

Call sites (5):

| Location | Range | Kind |
|---|---|---|
| `applyChunk` gap-fill | `[lastSeq+1, chunk.Seq-1]` | bounded |
| `recoverSkipped` | `[skipped[0], skipped[last]]` | bounded |
| `GetCommandOutput` | `noSeqBound` | unbounded |
| `streamSubscribed` initial fetch | `noSeqBound` | unbounded |
| `drainRemainingChunks` | `noSeqBound` | unbounded |

The two bounded upper values are already known to the code (`chunk.Seq-1`, and the last element of the ascending `g.skipped`), so no new state is introduced.

## Backward compatibility

If an older server ignores `seq__lte` and returns the full tail, behavior is unchanged. `applyChunk`'s consume loop stops at `c.Seq > chunk.Seq` (client-side clip), so it never consumes chunks past the bound, and `recoverSkipped` only looks up the exact seqs it cares about via the `bySeq` map, so any extra chunks are ignored. This fallback is pinned by a regression test for each call site (`applyChunk` and `recoverSkipped`).

This assumes a server that either supports `seq__lte` (alpacax/alpacon-server#2571 and later) or ignores unknown query parameters — the DRF default. The only unsupported case is a server that rejects unknown parameters with a 400: gap-fill re-fetches would fail repeatedly and fall through to `giveUpGap`, dropping output. No such server version is known. Note also that `recoverSkipped`'s `[skipped[0], skipped[last]]` window is not tight — it can still be wide when skips are far apart — but a single bounded request is strictly better than the previous unbounded fetch.

## Testing

- New tests: `seq__lte` is sent when bounded (including the `0` boundary) and omitted when unbounded; the `applyChunk` and `recoverSkipped` call sites derive the expected bound; output stays identical at both call sites when an old server ignores `seq__lte`.
- Test servers (`holeServer`/`chunkServer`) now honor `seq__lte` via a shared `parseSeqLte` helper.
- `go build ./...` OK, `go vet ./api/event/` OK, `golangci-lint run ./api/event/...` 0 issues, `go test -race ./api/event/` PASS.
- Verified end-to-end against a live server (`web-editor`, ubuntu 24.04) with the freshly built binary: a 300-line burst streamed back contiguous `1..300` with no gaps or duplicates, confirming the bounded and unbounded fetch paths preserve output integrity.

## Checklist

- [x] Build, vet, lint, and race tests pass
- [x] Backward-compatibility regression test added
- [x] Verified on a live server
- [ ] Reviewer approval

Closes #273
