### PR TITLE
refactor(event): collapse duplicate WebSocket listener skeletons

### DIFF
--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -27,7 +27,7 @@ type ChunkEvent struct {
 // Lifecycle: NewCommandOutputListener -> Start -> (consume Chunks) -> Stop.
 // Stop is idempotent and safe to call from any goroutine.
 type CommandOutputListener struct {
-	wsListener
+	*wsListener
 	commandID string
 	chunks    chan ChunkEvent
 }

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -2,19 +2,16 @@ package event
 
 import (
 	"encoding/json"
-	"net/http"
-	"sync"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/client"
-	"github.com/gorilla/websocket"
 )
 
 const (
-	// Mirror sudolistener backoff to keep reconnection behavior consistent.
-	commandOutputReconnectBase  = 1 * time.Second
-	commandOutputReconnectMax   = 30 * time.Second
-	commandOutputChunkBuffer    = 256
+	commandOutputChunkBuffer = 256
+
+	// commandOutputConnectTimeout bounds the dial and doubles as the callers'
+	// WaitConnected budget, so a slow dial can't outlive the wait.
 	commandOutputConnectTimeout = 5 * time.Second
 )
 
@@ -30,16 +27,9 @@ type ChunkEvent struct {
 // Lifecycle: NewCommandOutputListener -> Start -> (consume Chunks) -> Stop.
 // Stop is idempotent and safe to call from any goroutine.
 type CommandOutputListener struct {
-	wsURL       string
-	wsHeader    http.Header
-	commandID   string
-	chunks      chan ChunkEvent
-	done        chan struct{}
-	connected   chan struct{}
-	connectOnce sync.Once
-	closeOnce   sync.Once
-	mu          sync.Mutex
-	conn        *websocket.Conn
+	wsListener
+	commandID string
+	chunks    chan ChunkEvent
 }
 
 // commandOutputEnvelope is the WS message format emitted by alpacon-server.
@@ -51,6 +41,21 @@ type commandOutputEnvelope struct {
 		Content   string `json:"content"`
 	} `json:"payload"`
 }
+
+// NewCommandOutputListener constructs a listener without connecting. ac may be
+// nil (empty header, for tests); commandID may be set later via setCommandID.
+func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string) *CommandOutputListener {
+	l := &CommandOutputListener{
+		wsListener: newWSListener(ac, wsURL, commandOutputConnectTimeout),
+		commandID:  commandID,
+		chunks:     make(chan ChunkEvent, commandOutputChunkBuffer),
+	}
+	l.handleFrame = l.handleMessage
+	return l
+}
+
+// Chunks returns a receive-only channel of parsed chunk events.
+func (l *CommandOutputListener) Chunks() <-chan ChunkEvent { return l.chunks }
 
 // handleMessage parses one WS frame and pushes a matching chunk onto chunks.
 // Non-matching frames (wrong event_type, wrong command_id, parse failure) are
@@ -82,119 +87,4 @@ func (l *CommandOutputListener) setCommandID(id string) {
 	l.mu.Lock()
 	l.commandID = id
 	l.mu.Unlock()
-}
-
-// NewCommandOutputListener constructs a listener without connecting. ac may be
-// nil (empty header, for tests); commandID may be set later via setCommandID.
-func NewCommandOutputListener(ac *client.AlpaconClient, wsURL, commandID string) *CommandOutputListener {
-	var header http.Header
-	if ac != nil {
-		header = ac.SetWebsocketHeader()
-	} else {
-		header = http.Header{}
-	}
-	return &CommandOutputListener{
-		wsURL:     wsURL,
-		wsHeader:  header,
-		commandID: commandID,
-		chunks:    make(chan ChunkEvent, commandOutputChunkBuffer),
-		done:      make(chan struct{}),
-		connected: make(chan struct{}),
-	}
-}
-
-// Start begins the WebSocket receive loop in a background goroutine.
-// It automatically reconnects with exponential backoff until Stop() is called.
-func (l *CommandOutputListener) Start() {
-	go l.listenLoop()
-}
-
-// Chunks returns a receive-only channel of parsed chunk events.
-func (l *CommandOutputListener) Chunks() <-chan ChunkEvent { return l.chunks }
-
-// WaitConnected blocks until the first successful WS connection is made or
-// timeout / shutdown intervenes. Returns true on success.
-func (l *CommandOutputListener) WaitConnected(timeout time.Duration) bool {
-	select {
-	case <-l.connected:
-		return true
-	case <-l.done:
-		return false
-	case <-time.After(timeout):
-		return false
-	}
-}
-
-// Stop closes the listener; safe to call multiple times and from any goroutine.
-func (l *CommandOutputListener) Stop() {
-	l.closeOnce.Do(func() {
-		close(l.done)
-		l.mu.Lock()
-		if l.conn != nil {
-			_ = l.conn.Close()
-		}
-		l.mu.Unlock()
-	})
-}
-
-func (l *CommandOutputListener) listenLoop() {
-	delay := commandOutputReconnectBase
-	for {
-		select {
-		case <-l.done:
-			return
-		default:
-		}
-
-		if l.connectAndListen() {
-			delay = commandOutputReconnectBase
-		}
-
-		select {
-		case <-l.done:
-			return
-		case <-time.After(delay):
-			delay *= 2
-			if delay > commandOutputReconnectMax {
-				delay = commandOutputReconnectMax
-			}
-		}
-	}
-}
-
-// connectAndListen dials, reads frames until the connection drops or Stop is
-// called, and returns whether a connection was established (to reset backoff).
-func (l *CommandOutputListener) connectAndListen() (connected bool) {
-	// Match the WaitConnected budget so a slow dial can't outlive the wait and leak past fallback.
-	dialer := websocket.Dialer{HandshakeTimeout: commandOutputConnectTimeout}
-	conn, _, dialErr := dialer.Dial(l.wsURL, l.wsHeader)
-	if dialErr != nil {
-		return false
-	}
-
-	l.mu.Lock()
-	l.conn = conn
-	l.mu.Unlock()
-
-	l.connectOnce.Do(func() { close(l.connected) })
-
-	defer func() {
-		l.mu.Lock()
-		l.conn = nil
-		l.mu.Unlock()
-		_ = conn.Close()
-	}()
-
-	for {
-		select {
-		case <-l.done:
-			return true
-		default:
-		}
-		_, message, readErr := conn.ReadMessage()
-		if readErr != nil {
-			return true
-		}
-		l.handleMessage(message)
-	}
 }

--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/client"
@@ -28,6 +29,7 @@ type ChunkEvent struct {
 // Stop is idempotent and safe to call from any goroutine.
 type CommandOutputListener struct {
 	*wsListener
+	cmdMu     sync.Mutex // guards commandID
 	commandID string
 	chunks    chan ChunkEvent
 }
@@ -68,9 +70,9 @@ func (l *CommandOutputListener) handleMessage(raw []byte) {
 	if env.EventType != "command_output" {
 		return
 	}
-	l.mu.Lock()
+	l.cmdMu.Lock()
 	cid := l.commandID
-	l.mu.Unlock()
+	l.cmdMu.Unlock()
 	if env.Payload.CommandID != cid {
 		return
 	}
@@ -84,7 +86,7 @@ func (l *CommandOutputListener) handleMessage(raw []byte) {
 // setCommandID assigns the commandID after construction. Used because
 // SubmitCommand must run after the WS is already connected.
 func (l *CommandOutputListener) setCommandID(id string) {
-	l.mu.Lock()
+	l.cmdMu.Lock()
 	l.commandID = id
-	l.mu.Unlock()
+	l.cmdMu.Unlock()
 }

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -119,13 +119,6 @@ func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
 	assert.Equal(t, []ChunkEvent{{Seq: 0, Content: "a"}, {Seq: 1, Content: "b"}}, got)
 }
 
-func TestCommandOutputListener_StopIsIdempotent(t *testing.T) {
-	l := NewCommandOutputListener(nil, "", "")
-	l.Stop()
-	l.Stop()
-	l.Stop()
-}
-
 func TestCommandOutputListener_Reconnects(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	var connectionCount atomic.Int32

--- a/api/event/commandoutput_listener_test.go
+++ b/api/event/commandoutput_listener_test.go
@@ -45,11 +45,7 @@ func TestCommandOutputListener_HandleMessage_FiltersAndEmits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := &CommandOutputListener{
-				commandID: "cmd-1",
-				chunks:    make(chan ChunkEvent, 1),
-				done:      make(chan struct{}),
-			}
+			l := NewCommandOutputListener(nil, "", "cmd-1")
 			l.handleMessage([]byte(tt.payload))
 
 			select {
@@ -124,11 +120,7 @@ func TestCommandOutputListener_Start_DeliversChunks(t *testing.T) {
 }
 
 func TestCommandOutputListener_StopIsIdempotent(t *testing.T) {
-	l := &CommandOutputListener{
-		chunks:    make(chan ChunkEvent, 1),
-		done:      make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	l := NewCommandOutputListener(nil, "", "")
 	l.Stop()
 	l.Stop()
 	l.Stop()

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -48,7 +48,7 @@ type sudoMFAEvent struct {
 // http.Client is concurrency-safe. Token refresh and grant verification are
 // serialized by mfaMu so only one MFA flow runs at a time.
 type SudoListener struct {
-	wsListener
+	*wsListener
 	ac         *client.AlpaconClient
 	serverName string
 	mfaMu      sync.Mutex // serializes handleSudoMFA so only one MFA flow runs at a time

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -55,7 +55,7 @@ type SudoListener struct {
 }
 
 // NewSudoListener creates a SudoListener but does not connect yet. ac may be
-// nil only in tests that never reach the MFA flow, which dereferences it.
+// nil in tests; MFA request frames are then dropped instead of dereferencing it.
 func NewSudoListener(ac *client.AlpaconClient, wsURL, serverName string) *SudoListener {
 	sl := &SudoListener{
 		wsListener: newWSListener(ac, wsURL, sudoHandshakeTimeout),
@@ -84,6 +84,11 @@ func (sl *SudoListener) handleMessage(message []byte) {
 }
 
 func (sl *SudoListener) handleSudoMFA(event sudoMFAEvent) {
+	// Every step below dereferences ac, which is nil only in tests.
+	if sl.ac == nil {
+		return
+	}
+
 	// Check if shutdown was requested before acquiring the lock or doing side effects
 	select {
 	case <-sl.done:

--- a/api/event/sudolistener.go
+++ b/api/event/sudolistener.go
@@ -3,7 +3,6 @@ package event
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"sync"
@@ -12,7 +11,6 @@ import (
 	"github.com/alpacax/alpacon-cli/api/mfa"
 	"github.com/alpacax/alpacon-cli/client"
 	"github.com/alpacax/alpacon-cli/utils"
-	"github.com/gorilla/websocket"
 )
 
 const (
@@ -28,11 +26,7 @@ const (
 	// extra buffer over that so a slow browser MFA does not race the expiry.
 	mfaPollingTimeout = 60 * time.Second
 
-	// reconnectBaseDelay is the initial delay for WebSocket reconnection.
-	reconnectBaseDelay = 1 * time.Second
-
-	// reconnectMaxDelay is the maximum delay between reconnection attempts.
-	reconnectMaxDelay = 30 * time.Second
+	sudoHandshakeTimeout = 10 * time.Second
 )
 
 // sudoMFAEvent represents the MFA request payload from the event WebSocket.
@@ -54,145 +48,22 @@ type sudoMFAEvent struct {
 // http.Client is concurrency-safe. Token refresh and grant verification are
 // serialized by mfaMu so only one MFA flow runs at a time.
 type SudoListener struct {
-	ac          *client.AlpaconClient
-	serverName  string
-	wsURL       string
-	wsHeader    http.Header
-	done        chan struct{}
-	stopped     chan struct{} // closed when listenLoop exits
-	connected   chan struct{} // closed after first successful WebSocket connection
-	connectOnce sync.Once
-	closeOnce   sync.Once
-	mu          sync.Mutex
-	conn        *websocket.Conn
-	mfaMu       sync.Mutex // serializes handleSudoMFA so only one MFA flow runs at a time
+	wsListener
+	ac         *client.AlpaconClient
+	serverName string
+	mfaMu      sync.Mutex // serializes handleSudoMFA so only one MFA flow runs at a time
 }
 
-// NewSudoListener creates a SudoListener but does not connect yet.
+// NewSudoListener creates a SudoListener but does not connect yet. ac may be
+// nil only in tests that never reach the MFA flow, which dereferences it.
 func NewSudoListener(ac *client.AlpaconClient, wsURL, serverName string) *SudoListener {
-	return &SudoListener{
+	sl := &SudoListener{
+		wsListener: newWSListener(ac, wsURL, sudoHandshakeTimeout),
 		ac:         ac,
 		serverName: serverName,
-		wsURL:      wsURL,
-		wsHeader:   ac.SetWebsocketHeader(),
-		done:       make(chan struct{}),
-		stopped:    make(chan struct{}),
-		connected:  make(chan struct{}),
 	}
-}
-
-// Start begins listening for sudo MFA events in a background goroutine.
-// It automatically reconnects on disconnection. Call Stop() to shut down.
-func (sl *SudoListener) Start() {
-	go func() {
-		defer close(sl.stopped)
-		sl.listenLoop()
-	}()
-}
-
-// WaitConnected blocks until the WebSocket connection is established or the
-// timeout expires. Returns true if connected, false on timeout or shutdown.
-func (sl *SudoListener) WaitConnected(timeout time.Duration) bool {
-	select {
-	case <-sl.connected:
-		return true
-	case <-sl.done:
-		return false
-	case <-time.After(timeout):
-		return false
-	}
-}
-
-// Stop signals the listener to shut down and closes the WebSocket connection
-// to unblock any pending ReadMessage call.
-func (sl *SudoListener) Stop() {
-	sl.closeOnce.Do(func() {
-		close(sl.done)
-		sl.mu.Lock()
-		if sl.conn != nil {
-			_ = sl.conn.Close()
-		}
-		sl.mu.Unlock()
-	})
-}
-
-func (sl *SudoListener) listenLoop() {
-	delay := reconnectBaseDelay
-
-	for {
-		select {
-		case <-sl.done:
-			return
-		default:
-		}
-
-		connected, err := sl.connectAndListen()
-		if err == nil {
-			return
-		}
-
-		// Reset backoff if we had a successful connection that later dropped
-		if connected {
-			delay = reconnectBaseDelay
-		}
-
-		select {
-		case <-sl.done:
-			return
-		case <-time.After(delay):
-			delay *= 2
-			if delay > reconnectMaxDelay {
-				delay = reconnectMaxDelay
-			}
-		}
-	}
-}
-
-// connectAndListen dials the event WebSocket and reads messages until
-// the connection drops or Stop() is called. Returns (true, err) if the
-// connection was established, (false, err) if the dial itself failed.
-func (sl *SudoListener) connectAndListen() (connected bool, err error) {
-	dialer := websocket.Dialer{
-		HandshakeTimeout: 10 * time.Second,
-	}
-	conn, _, dialErr := dialer.Dial(sl.wsURL, sl.wsHeader)
-	if dialErr != nil {
-		return false, fmt.Errorf("event websocket connection failed: %w", dialErr)
-	}
-
-	sl.mu.Lock()
-	sl.conn = conn
-	sl.mu.Unlock()
-
-	// Signal that we have successfully connected (first time only)
-	sl.connectOnce.Do(func() { close(sl.connected) })
-
-	defer func() {
-		sl.mu.Lock()
-		sl.conn = nil
-		sl.mu.Unlock()
-		_ = conn.Close()
-	}()
-
-	for {
-		select {
-		case <-sl.done:
-			return true, nil
-		default:
-		}
-
-		_, message, readErr := conn.ReadMessage()
-		if readErr != nil {
-			select {
-			case <-sl.done:
-				return true, nil
-			default:
-			}
-			return true, fmt.Errorf("event websocket read error: %w", readErr)
-		}
-
-		sl.handleMessage(message)
-	}
+	sl.handleFrame = sl.handleMessage
+	return sl
 }
 
 func (sl *SudoListener) handleMessage(message []byte) {

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -69,6 +69,17 @@ func TestSudoListener_HandleMessage_IgnoresNonMFA(t *testing.T) {
 	}
 }
 
+func TestSudoListener_HandleSudoMFA_DropsRequestWhenClientIsNil(t *testing.T) {
+	sl := NewSudoListener(nil, "", "")
+
+	var event sudoMFAEvent
+	event.Payload.Type = "auth"
+	event.Payload.Query = "mfa_request"
+	event.Payload.SudoGrantID = "test-grant-id"
+
+	assert.NotPanics(t, func() { sl.handleSudoMFA(event) })
+}
+
 func TestSudoListener_StopIsIdempotent(t *testing.T) {
 	sl := NewSudoListener(nil, "", "")
 

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -145,9 +145,10 @@ func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
 
 	sl := NewSudoListener(nil, wsURL, "")
 
-	// Run connectAndListen and signal when the read loop processes a message
+	// Local signal, so the test does not close the skeleton's stopped channel
+	readDone := make(chan struct{})
 	go func() {
-		defer close(sl.stopped)
+		defer close(readDone)
 		_ = sl.connectAndListen()
 	}()
 
@@ -161,7 +162,7 @@ func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
 	close(clientRead) // server closes → client read loop exits
 
 	select {
-	case <-sl.stopped:
+	case <-readDone:
 		// connectAndListen returned cleanly after server disconnect
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for connectAndListen to return")

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -60,11 +60,7 @@ func TestSudoListener_HandleMessage_IgnoresNonMFA(t *testing.T) {
 		},
 	}
 
-	sl := &SudoListener{
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(nil, "", "")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -74,11 +70,7 @@ func TestSudoListener_HandleMessage_IgnoresNonMFA(t *testing.T) {
 }
 
 func TestSudoListener_StopIsIdempotent(t *testing.T) {
-	sl := &SudoListener{
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(nil, "", "")
 
 	sl.Stop()
 	sl.Stop()
@@ -102,13 +94,7 @@ func TestSudoListener_StopClosesConnection(t *testing.T) {
 	defer server.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	sl := &SudoListener{
-		wsURL:     wsURL,
-		wsHeader:  http.Header{},
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(nil, wsURL, "")
 	sl.Start()
 
 	// Wait for connection to establish by polling sl.conn
@@ -154,18 +140,12 @@ func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
 
-	sl := &SudoListener{
-		wsURL:     wsURL,
-		wsHeader:  http.Header{},
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(nil, wsURL, "")
 
 	// Run connectAndListen and signal when the read loop processes a message
 	go func() {
 		defer close(sl.stopped)
-		_, _ = sl.connectAndListen()
+		_ = sl.connectAndListen()
 	}()
 
 	// Wait for connection, then signal server to close
@@ -186,11 +166,7 @@ func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
 }
 
 func TestSudoListener_WaitConnected_Success(t *testing.T) {
-	sl := &SudoListener{
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(nil, "", "")
 
 	// Simulate connection after short delay
 	go func() {
@@ -203,11 +179,7 @@ func TestSudoListener_WaitConnected_Success(t *testing.T) {
 }
 
 func TestSudoListener_WaitConnected_Timeout(t *testing.T) {
-	sl := &SudoListener{
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(nil, "", "")
 
 	start := time.Now()
 	result := sl.WaitConnected(100 * time.Millisecond)
@@ -219,11 +191,7 @@ func TestSudoListener_WaitConnected_Timeout(t *testing.T) {
 }
 
 func TestSudoListener_WaitConnected_Shutdown(t *testing.T) {
-	sl := &SudoListener{
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(nil, "", "")
 
 	go func() {
 		time.Sleep(50 * time.Millisecond)
@@ -255,15 +223,10 @@ func TestSudoListener_VerifySudoGrant_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	sl := &SudoListener{
-		ac: &client.AlpaconClient{
-			HTTPClient: ts.Client(),
-			BaseURL:    ts.URL,
-		},
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(&client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}, "", "")
 
 	err := sl.verifySudoGrant("grant-123")
 	assert.NoError(t, err)
@@ -275,15 +238,10 @@ func TestSudoListener_VerifySudoGrant_ServerError(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	sl := &SudoListener{
-		ac: &client.AlpaconClient{
-			HTTPClient: ts.Client(),
-			BaseURL:    ts.URL,
-		},
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(&client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}, "", "")
 
 	err := sl.verifySudoGrant("grant-123")
 	assert.Error(t, err)
@@ -305,13 +263,7 @@ func TestSudoListener_ReconnectsAfterDisconnect(t *testing.T) {
 	defer server.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	sl := &SudoListener{
-		wsURL:     wsURL,
-		wsHeader:  http.Header{},
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(nil, wsURL, "")
 	sl.Start()
 
 	// Wait for at least 2 connection attempts (initial + reconnect)
@@ -329,11 +281,7 @@ func TestSudoListener_ReconnectsAfterDisconnect(t *testing.T) {
 }
 
 func TestSudoListener_PollMFACompletion_Timeout(t *testing.T) {
-	sl := &SudoListener{
-		done:      make(chan struct{}),
-		stopped:   make(chan struct{}),
-		connected: make(chan struct{}),
-	}
+	sl := NewSudoListener(nil, "", "")
 
 	start := time.Now()
 	go func() {

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -206,6 +206,13 @@ func TestSudoListener_WaitConnected_Shutdown(t *testing.T) {
 	assert.Less(t, elapsed, 1*time.Second, "should exit quickly on shutdown")
 }
 
+func newTestSudoListener(ts *httptest.Server) *SudoListener {
+	return NewSudoListener(&client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}, "", "")
+}
+
 func TestSudoListener_VerifySudoGrant_Success(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
@@ -223,10 +230,7 @@ func TestSudoListener_VerifySudoGrant_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	sl := NewSudoListener(&client.AlpaconClient{
-		HTTPClient: ts.Client(),
-		BaseURL:    ts.URL,
-	}, "", "")
+	sl := newTestSudoListener(ts)
 
 	err := sl.verifySudoGrant("grant-123")
 	assert.NoError(t, err)
@@ -238,10 +242,7 @@ func TestSudoListener_VerifySudoGrant_ServerError(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	sl := NewSudoListener(&client.AlpaconClient{
-		HTTPClient: ts.Client(),
-		BaseURL:    ts.URL,
-	}, "", "")
+	sl := newTestSudoListener(ts)
 
 	err := sl.verifySudoGrant("grant-123")
 	assert.Error(t, err)

--- a/api/event/sudolistener_test.go
+++ b/api/event/sudolistener_test.go
@@ -80,14 +80,6 @@ func TestSudoListener_HandleSudoMFA_DropsRequestWhenClientIsNil(t *testing.T) {
 	assert.NotPanics(t, func() { sl.handleSudoMFA(event) })
 }
 
-func TestSudoListener_StopIsIdempotent(t *testing.T) {
-	sl := NewSudoListener(nil, "", "")
-
-	sl.Stop()
-	sl.Stop()
-	sl.Stop()
-}
-
 func TestSudoListener_StopClosesConnection(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 
@@ -174,47 +166,6 @@ func TestSudoListener_ConnectAndListen_ExitsOnDisconnect(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for connectAndListen to return")
 	}
-}
-
-func TestSudoListener_WaitConnected_Success(t *testing.T) {
-	sl := NewSudoListener(nil, "", "")
-
-	// Simulate connection after short delay
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		close(sl.connected)
-	}()
-
-	result := sl.WaitConnected(2 * time.Second)
-	assert.True(t, result, "should return true when connected")
-}
-
-func TestSudoListener_WaitConnected_Timeout(t *testing.T) {
-	sl := NewSudoListener(nil, "", "")
-
-	start := time.Now()
-	result := sl.WaitConnected(100 * time.Millisecond)
-	elapsed := time.Since(start)
-
-	assert.False(t, result, "should return false on timeout")
-	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
-	assert.Less(t, elapsed, 1*time.Second)
-}
-
-func TestSudoListener_WaitConnected_Shutdown(t *testing.T) {
-	sl := NewSudoListener(nil, "", "")
-
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		close(sl.done)
-	}()
-
-	start := time.Now()
-	result := sl.WaitConnected(5 * time.Second)
-	elapsed := time.Since(start)
-
-	assert.False(t, result, "should return false when done is closed")
-	assert.Less(t, elapsed, 1*time.Second, "should exit quickly on shutdown")
 }
 
 func newTestSudoListener(ts *httptest.Server) *SudoListener {

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -32,12 +32,12 @@ type wsListener struct {
 }
 
 // newWSListener builds the shared skeleton. ac may be nil (empty header, for tests).
-func newWSListener(ac *client.AlpaconClient, wsURL string, handshakeTimeout time.Duration) wsListener {
+func newWSListener(ac *client.AlpaconClient, wsURL string, handshakeTimeout time.Duration) *wsListener {
 	wsHeader := http.Header{}
 	if ac != nil {
 		wsHeader = ac.SetWebsocketHeader()
 	}
-	return wsListener{
+	return &wsListener{
 		wsURL:            wsURL,
 		wsHeader:         wsHeader,
 		handshakeTimeout: handshakeTimeout,

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -27,7 +27,7 @@ type wsListener struct {
 	connected   chan struct{} // closed after first successful WebSocket connection
 	connectOnce sync.Once
 	closeOnce   sync.Once
-	mu          sync.Mutex // guards conn; embedders may reuse it for their own state
+	mu          sync.Mutex // guards conn
 	conn        *websocket.Conn
 }
 

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -50,6 +50,12 @@ func newWSListener(ac *client.AlpaconClient, wsURL string, handshakeTimeout time
 // Start reads events in a background goroutine, reconnecting automatically
 // until Stop is called.
 func (w *wsListener) Start() {
+	// Fail here rather than in the read loop, where the nil call would only
+	// surface after a successful dial, on another goroutine.
+	if w.handleFrame == nil {
+		panic("event: wsListener.handleFrame must be assigned before Start")
+	}
+
 	go func() {
 		defer close(w.stopped)
 		w.listenLoop()

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -1,0 +1,148 @@
+package event
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	wsReconnectBaseDelay = 1 * time.Second
+	wsReconnectMaxDelay  = 30 * time.Second
+)
+
+// wsListener is the shared dial/reconnect/shutdown skeleton for event WebSocket
+// consumers; embedders must assign handleFrame before calling Start.
+type wsListener struct {
+	wsURL            string
+	wsHeader         http.Header
+	handshakeTimeout time.Duration
+	handleFrame      func(message []byte)
+
+	done        chan struct{}
+	stopped     chan struct{} // closed when listenLoop exits
+	connected   chan struct{} // closed after first successful WebSocket connection
+	connectOnce sync.Once
+	closeOnce   sync.Once
+	mu          sync.Mutex // guards conn; embedders may reuse it for their own state
+	conn        *websocket.Conn
+}
+
+// newWSListener builds the shared skeleton. ac may be nil (empty header, for tests).
+func newWSListener(ac *client.AlpaconClient, wsURL string, handshakeTimeout time.Duration) wsListener {
+	wsHeader := http.Header{}
+	if ac != nil {
+		wsHeader = ac.SetWebsocketHeader()
+	}
+	return wsListener{
+		wsURL:            wsURL,
+		wsHeader:         wsHeader,
+		handshakeTimeout: handshakeTimeout,
+		done:             make(chan struct{}),
+		stopped:          make(chan struct{}),
+		connected:        make(chan struct{}),
+	}
+}
+
+// Start reads events in a background goroutine, reconnecting automatically
+// until Stop is called.
+func (w *wsListener) Start() {
+	go func() {
+		defer close(w.stopped)
+		w.listenLoop()
+	}()
+}
+
+// WaitConnected blocks until connected, timeout, or shutdown; returns whether
+// it connected.
+func (w *wsListener) WaitConnected(timeout time.Duration) bool {
+	select {
+	case <-w.connected:
+		return true
+	case <-w.done:
+		return false
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// Stop shuts down the listener and closes the connection to unblock a pending
+// ReadMessage. Safe to call from any goroutine.
+func (w *wsListener) Stop() {
+	w.closeOnce.Do(func() {
+		close(w.done)
+		w.mu.Lock()
+		if w.conn != nil {
+			_ = w.conn.Close()
+		}
+		w.mu.Unlock()
+	})
+}
+
+func (w *wsListener) listenLoop() {
+	delay := wsReconnectBaseDelay
+
+	for {
+		select {
+		case <-w.done:
+			return
+		default:
+		}
+
+		// Reset backoff if we had a successful connection that later dropped
+		if w.connectAndListen() {
+			delay = wsReconnectBaseDelay
+		}
+
+		select {
+		case <-w.done:
+			return
+		case <-time.After(delay):
+			delay *= 2
+			if delay > wsReconnectMaxDelay {
+				delay = wsReconnectMaxDelay
+			}
+		}
+	}
+}
+
+// connectAndListen dials the event WebSocket and reads until it drops or Stop
+// is called; returns whether it connected, so the caller can reset backoff.
+func (w *wsListener) connectAndListen() (connected bool) {
+	dialer := websocket.Dialer{HandshakeTimeout: w.handshakeTimeout}
+	conn, _, dialErr := dialer.Dial(w.wsURL, w.wsHeader)
+	if dialErr != nil {
+		return false
+	}
+
+	w.mu.Lock()
+	w.conn = conn
+	w.mu.Unlock()
+
+	w.connectOnce.Do(func() { close(w.connected) })
+
+	defer func() {
+		w.mu.Lock()
+		w.conn = nil
+		w.mu.Unlock()
+		_ = conn.Close()
+	}()
+
+	for {
+		select {
+		case <-w.done:
+			return true
+		default:
+		}
+
+		_, message, readErr := conn.ReadMessage()
+		if readErr != nil {
+			return true
+		}
+
+		w.handleFrame(message)
+	}
+}

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -107,12 +107,18 @@ func (w *wsListener) listenLoop() {
 		case <-w.done:
 			return
 		case <-time.After(delay):
-			delay *= 2
-			if delay > wsReconnectMaxDelay {
-				delay = wsReconnectMaxDelay
-			}
+			delay = nextReconnectDelay(delay)
 		}
 	}
+}
+
+// nextReconnectDelay doubles the backoff first, so the cap is a ceiling on the
+// delay actually waited rather than on the value that gets doubled.
+func nextReconnectDelay(delay time.Duration) time.Duration {
+	if delay *= 2; delay > wsReconnectMaxDelay {
+		return wsReconnectMaxDelay
+	}
+	return delay
 }
 
 // connectAndListen dials the event WebSocket and reads until it drops or Stop

--- a/api/event/wslistener_test.go
+++ b/api/event/wslistener_test.go
@@ -1,0 +1,15 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWSListener_StartPanicsWithoutHandleFrame(t *testing.T) {
+	w := newWSListener(nil, "", 0)
+
+	assert.PanicsWithValue(t, "event: wsListener.handleFrame must be assigned before Start", func() {
+		w.Start()
+	})
+}

--- a/api/event/wslistener_test.go
+++ b/api/event/wslistener_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -12,4 +13,53 @@ func TestWSListener_StartPanicsWithoutHandleFrame(t *testing.T) {
 	assert.PanicsWithValue(t, "event: wsListener.handleFrame must be assigned before Start", func() {
 		w.Start()
 	})
+}
+
+func TestWSListener_StopIsIdempotent(t *testing.T) {
+	w := newWSListener(nil, "", 0)
+
+	w.Stop()
+	w.Stop()
+	w.Stop()
+}
+
+func TestWSListener_WaitConnected_Success(t *testing.T) {
+	w := newWSListener(nil, "", 0)
+
+	// Simulate connection after short delay
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(w.connected)
+	}()
+
+	result := w.WaitConnected(2 * time.Second)
+	assert.True(t, result, "should return true when connected")
+}
+
+func TestWSListener_WaitConnected_Timeout(t *testing.T) {
+	w := newWSListener(nil, "", 0)
+
+	start := time.Now()
+	result := w.WaitConnected(100 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.False(t, result, "should return false on timeout")
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
+	assert.Less(t, elapsed, 1*time.Second)
+}
+
+func TestWSListener_WaitConnected_Shutdown(t *testing.T) {
+	w := newWSListener(nil, "", 0)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(w.done)
+	}()
+
+	start := time.Now()
+	result := w.WaitConnected(5 * time.Second)
+	elapsed := time.Since(start)
+
+	assert.False(t, result, "should return false when done is closed")
+	assert.Less(t, elapsed, 1*time.Second, "should exit quickly on shutdown")
 }

--- a/api/event/wslistener_test.go
+++ b/api/event/wslistener_test.go
@@ -1,6 +1,10 @@
 package event
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -46,6 +50,65 @@ func TestWSListener_WaitConnected_Timeout(t *testing.T) {
 	assert.False(t, result, "should return false on timeout")
 	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
 	assert.Less(t, elapsed, 1*time.Second)
+}
+
+func TestWSListener_NextReconnectDelay(t *testing.T) {
+	tests := []struct {
+		name  string
+		delay time.Duration
+		want  time.Duration
+	}{
+		{"base doubles", wsReconnectBaseDelay, 2 * time.Second},
+		{"below cap doubles", 8 * time.Second, 16 * time.Second},
+		{"overshoot clamps to cap", 16 * time.Second, wsReconnectMaxDelay},
+		{"cap stays at cap", wsReconnectMaxDelay, wsReconnectMaxDelay},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nextReconnectDelay(tt.delay))
+		})
+	}
+}
+
+func TestWSListener_ConnectAndListen_ReturnsFalseOnFailedHandshake(t *testing.T) {
+	// Responds 200 instead of upgrading, so Dial fails with ErrBadHandshake.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	w := newWSListener(nil, "ws"+strings.TrimPrefix(server.URL, "http"), time.Second)
+	w.handleFrame = func([]byte) {}
+
+	assert.False(t, w.connectAndListen(), "failed handshake should not count as connected")
+	assert.False(t, w.WaitConnected(0), "connected must stay open after a failed dial")
+}
+
+func TestWSListener_ListenLoop_DoesNotDialWhenAlreadyStopped(t *testing.T) {
+	var dialed atomic.Int32
+
+	// Counted at handler entry so the increment happens-before Dial returns.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dialed.Add(1)
+	}))
+	defer server.Close()
+
+	w := newWSListener(nil, "ws"+strings.TrimPrefix(server.URL, "http"), time.Second)
+	w.handleFrame = func([]byte) {}
+	w.Stop()
+
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		w.listenLoop()
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenLoop should return immediately when done is already closed")
+	}
+
+	assert.Zero(t, dialed.Load(), "listenLoop should not dial after Stop")
 }
 
 func TestWSListener_WaitConnected_Shutdown(t *testing.T) {


### PR DESCRIPTION
## Background

`SudoListener` (`api/event/sudolistener.go`) and `CommandOutputListener` (`api/event/commandoutput_listener.go`) each carried their own copy of nearly the same code. `listenLoop`, `connectAndListen`, `WaitConnected`, `Stop`, the lifecycle fields, and even the 1s/30s backoff constants existed in both files. The only thing genuinely different between them was frame handling.

Adding the generic `event watch` listener that #271 calls for would have made that loop a third copy. This collapses the skeleton first. It is PR1 of the #271 plan and does not close the issue on its own.

## What changed

A shared `wsListener` in `api/event/wslistener.go`, embedded by both listeners. The skeleton owns dialing, exponential-backoff reconnect, and shutdown; each listener keeps only its own frame handling.

| File | Lines |
|---|---|
| `api/event/sudolistener.go` | 313 to 189 |
| `api/event/commandoutput_listener.go` | 200 to 90 |
| `api/event/wslistener.go` (new) | 160 |

Two signature divergences reconciled:

`SudoListener.connectAndListen` returned `(bool, error)` while the command-output one returned `bool`. The sudo error was nil only when `done` had been closed, which `listenLoop` rechecks independently, and it never reached a user or a log. The shared version returns `bool`.

The dial handshake timeouts, 10s for sudo and 5s for command output, are preserved per-listener through the `handshakeTimeout` field. `commandOutputConnectTimeout` keeps its name because `api/event/event.go:301` and `:328` also use it as the `WaitConnected` budget.

The `stopped` channel now exists on both listeners. It is the goroutine-termination signal; without it `TestSudoListener_StopClosesConnection` degrades to polling for `conn == nil`, which cannot distinguish termination from the gap between reconnect attempts.

## Dependencies

No change to the package graph. The `api/event` to `client` edge already existed via `event.go`, `subscribe.go`, `chunks.go` and others, and `client` imports no `api/*` package, so there is no cycle. `newWSListener` takes a `*client.AlpaconClient` rather than an `http.Header` so the nil-client branch lives in one place instead of being duplicated across both constructors.

## Safety

The goal was zero behavior change, and the existing listener tests pass with their assertions untouched. Only the construction sites changed: moving fields into the embedded struct broke the struct literals, so those were mechanically replaced with `NewSudoListener` / `NewCommandOutputListener` calls. Access to `sl.mu`, `sl.conn`, and `sl.stopped` still works through field promotion.

Two failure modes that the refactor made shared, and therefore worth failing loudly on, are now guarded:

`Start` panics with `event: wsListener.handleFrame must be assigned before Start` when a constructor forgets the assignment. Previously the nil call sat in `connectAndListen`, so it only fired after a successful dial, on the read goroutine, far from the cause. `Start` has no error return and all three call sites (`cmd/websh/websh.go:350`, `api/event/event.go:300` and `:327`) call it bare, so a panic on the caller's stack is the available shape. This is a programmer error on an unexported type, not a user-facing failure.

`handleSudoMFA` returns early when `ac` is nil. `NewSudoListener` documents nil `ac` as a test-only mode, but nothing enforced it, and an `mfa_request` frame would have nil-dereferenced inside the spawned goroutine. The guard sits at the top of `handleSudoMFA` rather than at the spawn site so it is synchronously testable and covers every deref below it. The nil-`ac` test mode is load-bearing rather than incidental: `&client.AlpaconClient{}` makes `SetWebsocketHeader()` emit an empty `Origin`, which gorilla's `checkSameOrigin` rejects, while a nil client yields a header with no `Origin` at all.

`wsListener.mu` guards `conn` and nothing else. `CommandOutputListener` carries its own `cmdMu` for `commandID` rather than reusing the skeleton lock, so the invariant stays readable from one file.

`newWSListener` returns `*wsListener` and both listeners embed the pointer. Returning the struct by value copied a type holding a `sync.Mutex` and two `sync.Once`. It was safe in practice because the value is pristine at that point, but `go vet` could not confirm it — copylocks skips call expressions, since `lockPathRhs` returns nil for an `*ast.CallExpr`. Returning a pointer removes the value-copy shape from the type instead of relying on a reader to know it is fresh.

## Tests

Tests that never dial — `WaitConnected` success, timeout and shutdown, plus a `StopIsIdempotent` that existed identically in both listener files — moved to `api/event/wslistener_test.go`. They hand-close `connected` and `done`, so they asserted nothing about either concrete listener. Tests that do dial stayed where they were: they double as proof that each embedder is wired correctly.

Three skeleton blocks were unreachable from the existing tests and are now covered. Each new test was mutation-checked: inverting the logic it guards makes it fail.

| Uncovered block | Test |
|---|---|
| backoff cap | `TestWSListener_NextReconnectDelay` |
| dial-failure return | `TestWSListener_ConnectAndListen_ReturnsFalseOnFailedHandshake` |
| `listenLoop` entry check for a closed `done` | `TestWSListener_ListenLoop_DoesNotDialWhenAlreadyStopped` |

The cap needed the doubling extracted to `nextReconnectDelay`, because reaching it through `listenLoop` costs 1+2+4+8+16 seconds of real waiting. The extraction also pins the operation order, which the loop never asserted — clamping before doubling would silently stretch the wait to twice the ceiling, and the mutation run confirms the test catches exactly that.

Coverage of `api/event/wslistener.go`: `listenLoop` 81.8 to 100 percent, `connectAndListen` 90.5 to 95.2 percent, everything else at 100 percent. One block stays uncovered, the read loop's `case <-w.done` at `api/event/wslistener.go:148`. `Stop` closes `conn`, so `ReadMessage` always wakes with an error first and that arm is not deterministically reachable.

```
go build ./... && go vet ./...
go test -race ./...
golangci-lint run ./...
gofmt -l ./api/ ./cmd/
```

All packages pass, lint reports 0 issues, gofmt reports no differences.

## Checklist

- [x] Existing listener tests pass with assertions unchanged
- [x] `go test -race ./...` passes
- [x] golangci-lint reports 0 issues
- [x] No import cycle introduced
- [x] New tests mutation-checked against the logic they guard
- [ ] Reviewer confirms behavior parity by comparing pre- and post-refactor listener code

Refs #271
