### PR TITLE
refactor(event): accept any event type in the subscription helper

### DIFF
--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -67,7 +67,7 @@ func (l *CommandOutputListener) handleMessage(raw []byte) {
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return
 	}
-	if env.EventType != "command_output" {
+	if env.EventType != EventTypeCommandOutput {
 		return
 	}
 	l.cmdMu.Lock()

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -336,7 +336,7 @@ func StreamApprovedCommand(ac *client.AlpaconClient, cmdID string, out io.Writer
 // chunks, then writes live chunks to out until the command reaches a terminal
 // state. Shared by the fresh-submit and approval-resume paths.
 func streamSubscribed(ac *client.AlpaconClient, session *EventSessionResponse, listener *CommandOutputListener, cmdID string, out io.Writer, timeout time.Duration, waitApproval bool) error {
-	if err := SubscribeCommandOutput(ac, session.ChannelID, cmdID); err != nil {
+	if err := SubscribeEvent(ac, session.ChannelID, EventTypeCommandOutput, cmdID); err != nil {
 		listener.Stop()
 		return runCommandFallbackFromID(ac, cmdID, out, waitApproval, err)
 	}

--- a/api/event/subscribe.go
+++ b/api/event/subscribe.go
@@ -10,6 +10,10 @@ import (
 const (
 	eventSessionsURL      = "/api/events/sessions/"
 	eventSubscriptionsURL = "/api/events/subscriptions/"
+
+	// Event types the CLI subscribes to; the server defines the full set.
+	EventTypeSudo          = "sudo"
+	EventTypeCommandOutput = "command_output"
 )
 
 // EventSessionResponse is returned when creating an event session.
@@ -42,34 +46,18 @@ func CreateEventSession(ac *client.AlpaconClient) (*EventSessionResponse, error)
 	return &resp, nil
 }
 
-// SubscribeSudoEvent subscribes the given channel to sudo events for a websh session.
-func SubscribeSudoEvent(ac *client.AlpaconClient, channelID, sessionID string) error {
+// SubscribeEvent subscribes the given channel to eventType events, scoped to
+// targetID (a websh session for sudo, a command for command_output).
+func SubscribeEvent(ac *client.AlpaconClient, channelID, eventType, targetID string) error {
 	req := &EventSubscriptionRequest{
 		Channel:   channelID,
-		EventType: "sudo",
-		TargetID:  sessionID,
+		EventType: eventType,
+		TargetID:  targetID,
 	}
 
 	_, err := ac.SendPostRequest(eventSubscriptionsURL, req)
 	if err != nil {
-		return fmt.Errorf("failed to subscribe to sudo events: %w", err)
-	}
-
-	return nil
-}
-
-// SubscribeCommandOutput subscribes the channel to command_output events for the
-// given command (target_id scopes delivery to that command's chunks).
-func SubscribeCommandOutput(ac *client.AlpaconClient, channelID, commandID string) error {
-	req := &EventSubscriptionRequest{
-		Channel:   channelID,
-		EventType: "command_output",
-		TargetID:  commandID,
-	}
-
-	_, err := ac.SendPostRequest(eventSubscriptionsURL, req)
-	if err != nil {
-		return fmt.Errorf("failed to subscribe to command_output events: %w", err)
+		return fmt.Errorf("failed to subscribe to %s events: %w", eventType, err)
 	}
 
 	return nil

--- a/api/event/subscribe_test.go
+++ b/api/event/subscribe_test.go
@@ -40,31 +40,47 @@ func TestCreateEventSession(t *testing.T) {
 	assert.Equal(t, expected.ChannelID, resp.ChannelID)
 }
 
-func TestSubscribeSudoEvent(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Contains(t, r.URL.Path, "events/subscriptions")
-
-		var req EventSubscriptionRequest
-		err := json.NewDecoder(r.Body).Decode(&req)
-		assert.NoError(t, err)
-		assert.Equal(t, "channel-456", req.Channel)
-		assert.Equal(t, "sudo", req.EventType)
-		assert.Equal(t, "session-123", req.TargetID)
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"id":"sub-789"}`))
-	}))
-	defer ts.Close()
-
-	ac := &client.AlpaconClient{
-		HTTPClient: ts.Client(),
-		BaseURL:    ts.URL,
+func TestSubscribeEvent_SendsExpectedPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		targetID  string
+	}{
+		{name: "sudo", eventType: EventTypeSudo, targetID: "session-123"},
+		{name: "command output", eventType: EventTypeCommandOutput, targetID: "command-uuid"},
+		{name: "type the CLI does not know yet", eventType: "work_session", targetID: "ws-uuid"},
 	}
 
-	err := SubscribeSudoEvent(ac, "channel-456", "session-123")
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Contains(t, r.URL.Path, "events/subscriptions")
+
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				var req EventSubscriptionRequest
+				require.NoError(t, json.Unmarshal(body, &req))
+				assert.Equal(t, "channel-456", req.Channel)
+				assert.Equal(t, tt.eventType, req.EventType)
+				assert.Equal(t, tt.targetID, req.TargetID)
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"id":"sub-789"}`))
+			}))
+			defer ts.Close()
+
+			ac := &client.AlpaconClient{
+				HTTPClient: ts.Client(),
+				BaseURL:    ts.URL,
+			}
+
+			err := SubscribeEvent(ac, "channel-456", tt.eventType, tt.targetID)
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestCreateEventSession_ServerError(t *testing.T) {
@@ -83,7 +99,7 @@ func TestCreateEventSession_ServerError(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
-func TestSubscribeSudoEvent_ServerError(t *testing.T) {
+func TestSubscribeEvent_ServerError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -94,35 +110,8 @@ func TestSubscribeSudoEvent_ServerError(t *testing.T) {
 		BaseURL:    ts.URL,
 	}
 
-	err := SubscribeSudoEvent(ac, "channel-456", "session-123")
-	assert.Error(t, err)
-}
-
-func TestSubscribeCommandOutput_SendsExpectedPayload(t *testing.T) {
-	channelID := "channel-uuid"
-	cmdID := "command-uuid"
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Contains(t, r.URL.Path, "events/subscriptions")
-
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-
-		var req EventSubscriptionRequest
-		require.NoError(t, json.Unmarshal(body, &req))
-		assert.Equal(t, channelID, req.Channel)
-		assert.Equal(t, "command_output", req.EventType)
-		assert.Equal(t, cmdID, req.TargetID)
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{}`))
-	}))
-	defer ts.Close()
-
-	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-
-	err := SubscribeCommandOutput(ac, channelID, cmdID)
-	assert.NoError(t, err)
+	err := SubscribeEvent(ac, "channel-456", EventTypeSudo, "session-123")
+	require.Error(t, err)
+	// websh's isNotFoundError matches a literal ": not found" suffix, so the wrap must keep the server's message last.
+	assert.Contains(t, err.Error(), "failed to subscribe to sudo events: ")
 }

--- a/api/event/subscribe_test.go
+++ b/api/event/subscribe_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpacon-cli/client"
@@ -112,6 +113,25 @@ func TestSubscribeEvent_ServerError(t *testing.T) {
 
 	err := SubscribeEvent(ac, "channel-456", EventTypeSudo, "session-123")
 	require.Error(t, err)
-	// websh's isNotFoundError matches a literal ": not found" suffix, so the wrap must keep the server's message last.
 	assert.Contains(t, err.Error(), "failed to subscribe to sudo events: ")
+}
+
+func TestSubscribeEvent_NotFoundKeepsServerMessageLast(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail": "Not found."}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}
+
+	err := SubscribeEvent(ac, "channel-456", EventTypeSudo, "session-123")
+	require.Error(t, err)
+	// websh's isNotFoundError matches a literal ": not found." suffix on the
+	// lowercased message, so the wrap must keep the server's detail last.
+	assert.True(t, strings.HasSuffix(strings.ToLower(err.Error()), ": not found."), "got %q", err.Error())
 }

--- a/cmd/websh/websh.go
+++ b/cmd/websh/websh.go
@@ -354,7 +354,7 @@ func setupSudoListener(ac *client.AlpaconClient, sessionID, serverName string) *
 		return nil
 	}
 
-	if err := event.SubscribeSudoEvent(ac, eventSession.ChannelID, sessionID); err != nil {
+	if err := event.SubscribeEvent(ac, eventSession.ChannelID, event.EventTypeSudo, sessionID); err != nil {
 		listener.Stop()
 		if !isNotFoundError(err) {
 			utils.CliWarning("Sudo MFA listener unavailable: %s", err)


### PR DESCRIPTION
## Background

`api/event/subscribe.go` carried `SubscribeSudoEvent` and `SubscribeCommandOutput`, whose bodies were identical apart from the `EventType` literal and the error string. `EventSubscriptionRequest` already held an `event_type` field, so the only thing pinning the type was the helper itself.

`event watch --type work_session`, which #271 calls for, is a third event type. Under the current shape every new type means another copy of the same function. This is PR2 of the #271 plan and does not close the issue on its own.

## What changed

Both helpers are replaced by `SubscribeEvent(ac, channelID, eventType, targetID)`. The plan left the option of reducing them to wrappers, but a wrapper only moves the hardcoded type from the helper to the wrapper, and `api/` has no external consumers, so the call sites were updated instead. Precedent is #237.

There are two call sites.

| Location | Change |
|---|---|
| `cmd/websh/websh.go:357` | `event.SubscribeEvent(ac, eventSession.ChannelID, event.EventTypeSudo, sessionID)` |
| `api/event/event.go:339` | `SubscribeEvent(ac, session.ChannelID, EventTypeCommandOutput, cmdID)` |

`EventTypeSudo` and `EventTypeCommandOutput` are new constants in `subscribe.go`. Without them the call sites pass bare strings, which relocates the hardcoding rather than removing it. They are exported because `cmd/websh` references them. Only the two types the CLI consumes are declared; the server owns the full set, and `SubscribeEvent` forwards types that have no constant here.

A second commit replaces the remaining `"command_output"` literal in the frame filter at `api/event/commandoutput_listener.go:70` with the same constant. It is not part of the subscription helper, so it sits outside the literal scope of PR2, but it was the last hardcoded copy of that string. One line, no behavior change, and it was separated into its own commit so it could be dropped if a reviewer preferred. Review has since kept it.

A named `type EventType string` was suggested in review and deliberately not taken here: it would have to propagate to `EventSubscriptionRequest.EventType` and to everything that builds or reads that struct, which is more than a PR scoped to the subscription helper should carry. The JSON wire shape is not part of the cost — a named type with underlying kind `string` marshals identically to `string`, so `POST /api/events/subscriptions/` would be unaffected. Worth revisiting when `work_session` lands in PR4/PR5 and there are three call-site types instead of two.

## Error message

The wrap moves from per-type literals to `failed to subscribe to %s events: %w`, reproducing the previous output of both functions with `eventType` as a format argument.

The shape matters. `isNotFoundError` at `cmd/websh/websh.go:371` only checks whether the message ends with a literal `": not found"` or `": not found."`, and it is what silently skips the 404 from older servers that lack the subscription API. If `%w` stops being last, that path starts emitting a warning instead.

## Tests

`TestSubscribeSudoEvent` and `TestSubscribeCommandOutput_SendsExpectedPayload` were near-identical and are now one table-driven `TestSubscribeEvent_SendsExpectedPayload`. The cases are sudo, command output, and `work_session`, which has no constant in the CLI. That last case covers what this PR actually sells: an arbitrary `event_type` reaching the payload untouched.

`TestSubscribeSudoEvent_ServerError` is renamed `TestSubscribeEvent_ServerError` and keeps the 500 case.

A third commit adds `TestSubscribeEvent_NotFoundKeepsServerMessageLast`, which pins the wrap order described above. The test server returns a real 404 with `{"detail": "Not found."}` and the assertion is `strings.HasSuffix(strings.ToLower(err.Error()), ": not found.")` — the exact predicate `isNotFoundError` evaluates. It replaces a prefix assertion that only described that property in a comment without testing it. `isNotFoundError` is unexported in `cmd/websh`, so the test mirrors the suffix match rather than calling it.

The `TestCreateEventSession` tests are unchanged.

```
go build ./... && go vet ./...
go test -race ./...
golangci-lint run ./...
gofmt -l .
```

All packages pass, lint reports 0 issues, gofmt reports no differences. A repo-wide search confirms neither deleted symbol is referenced in code, comments, or docs.

## Checklist

- [x] `go test -race ./...` passes
- [x] golangci-lint reports 0 issues
- [x] No remaining references to the two deleted functions
- [x] Error wrap compatibility with `isNotFoundError` pinned by a test
- [x] Reviewer decided the `commandoutput_listener.go` one-liner stays in this PR

Refs #271
