### PR TITLE
refactor(event): relocate command history to exec ls

### DIFF
--- a/api/event/commandoutput_listener.go
+++ b/api/event/commandoutput_listener.go
@@ -36,7 +36,7 @@ type CommandOutputListener struct {
 
 // commandOutputEnvelope is the WS message format emitted by alpacon-server.
 type commandOutputEnvelope struct {
-	EventType string `json:"event_type"`
+	EventType EventType `json:"event_type"`
 	Payload   struct {
 		CommandID string `json:"command_id"`
 		Seq       int    `json:"seq"`

--- a/api/event/subscribe.go
+++ b/api/event/subscribe.go
@@ -10,10 +10,15 @@ import (
 const (
 	eventSessionsURL      = "/api/events/sessions/"
 	eventSubscriptionsURL = "/api/events/subscriptions/"
+)
 
-	// Event types the CLI subscribes to; the server defines the full set.
-	EventTypeSudo          = "sudo"
-	EventTypeCommandOutput = "command_output"
+// EventType is a server event channel type, marshalled as a plain string. The server
+// defines the full set; untyped literals convert, so types the CLI lacks a constant for stay usable.
+type EventType string
+
+const (
+	EventTypeSudo          EventType = "sudo"
+	EventTypeCommandOutput EventType = "command_output"
 )
 
 // EventSessionResponse is returned when creating an event session.
@@ -25,9 +30,9 @@ type EventSessionResponse struct {
 
 // EventSubscriptionRequest is sent to subscribe to an event type.
 type EventSubscriptionRequest struct {
-	Channel   string `json:"channel"`
-	EventType string `json:"event_type"`
-	TargetID  string `json:"target_id"`
+	Channel   string    `json:"channel"`
+	EventType EventType `json:"event_type"`
+	TargetID  string    `json:"target_id"`
 }
 
 // CreateEventSession creates a new event session and returns the WebSocket URL
@@ -48,7 +53,7 @@ func CreateEventSession(ac *client.AlpaconClient) (*EventSessionResponse, error)
 
 // SubscribeEvent subscribes the given channel to eventType events, scoped to
 // targetID (a websh session for sudo, a command for command_output).
-func SubscribeEvent(ac *client.AlpaconClient, channelID, eventType, targetID string) error {
+func SubscribeEvent(ac *client.AlpaconClient, channelID string, eventType EventType, targetID string) error {
 	req := &EventSubscriptionRequest{
 		Channel:   channelID,
 		EventType: eventType,

--- a/api/event/subscribe.go
+++ b/api/event/subscribe.go
@@ -10,16 +10,16 @@ import (
 const (
 	eventSessionsURL      = "/api/events/sessions/"
 	eventSubscriptionsURL = "/api/events/subscriptions/"
+
+	// Left untyped so every const stays in one block; they remain assignable and
+	// comparable to EventType.
+	EventTypeSudo          = "sudo"
+	EventTypeCommandOutput = "command_output"
 )
 
 // EventType is a server event channel type, marshalled as a plain string. The server
 // defines the full set; untyped literals convert, so types the CLI lacks a constant for stay usable.
 type EventType string
-
-const (
-	EventTypeSudo          EventType = "sudo"
-	EventTypeCommandOutput EventType = "command_output"
-)
 
 // EventSessionResponse is returned when creating an event session.
 type EventSessionResponse struct {

--- a/api/event/subscribe_test.go
+++ b/api/event/subscribe_test.go
@@ -44,7 +44,7 @@ func TestCreateEventSession(t *testing.T) {
 func TestSubscribeEvent_SendsExpectedPayload(t *testing.T) {
 	tests := []struct {
 		name      string
-		eventType string
+		eventType EventType
 		targetID  string
 	}{
 		{name: "sudo", eventType: EventTypeSudo, targetID: "session-123"},

--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -9,7 +9,7 @@ import (
 var EventCmd = &cobra.Command{
 	Use:     "event",
 	Aliases: []string{"events"},
-	Short:   "List recent remote command executions (deprecated: use 'exec ls')",
+	Short:   "List recent remote command executions (deprecated)",
 	Long: `List recent remote command executions, most recent last.
 
 This command has moved to 'alpacon exec ls' and will be removed in a future

--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -1,8 +1,7 @@
 package event
 
 import (
-	"github.com/alpacax/alpacon-cli/api/event"
-	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/cmd/exec"
 	"github.com/alpacax/alpacon-cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -10,47 +9,32 @@ import (
 var EventCmd = &cobra.Command{
 	Use:     "event",
 	Aliases: []string{"events"},
-	Short:   "Retrieve and display recent Alpacon events",
-	Long: `
-	Retrieve and display a list of recent events from the Alpacon, with options to filter by server, user, and the number of events. 
-	Use the '--tail' flag to limit the output to the last N event entries. 
-	Specify a server with '--server' or filter events by user with '--user' to narrow down the results.
-	`,
-	Example: `
-	alpacon event
-	alpacon events
-	alpacon event -tail 10 -s myserver -u admin
-	alpacon event --tail=10 --server=myserver --user=admin
-	`,
+	Short:   "List recent remote command executions (deprecated: use 'exec ls')",
+	Long: `List recent remote command executions, most recent last.
+
+This command has moved to 'alpacon exec ls' and will be removed in a future
+release. It still works today and takes the same flags.
+
+The 'event' name is being repurposed for the Alpacon event channel.`,
+	Example: `  alpacon event
+  alpacon event --tail 10 --server my-server --user admin`,
+	// Deprecated is deliberately unused: it makes IsAvailableCommand() false, dropping
+	// 'event' from root help and with it the event-channel subcommands landing here.
 	Run: runEvent,
 }
 
 func init() {
-	var pageSize int
-	var serverName string
-	var userName string
-
-	EventCmd.Flags().IntVarP(&pageSize, "tail", "t", 25, "Number of event entries to show from the end")
-	EventCmd.Flags().StringVarP(&serverName, "server", "s", "", "Specify server for events")
-	EventCmd.Flags().StringVarP(&userName, "user", "u", "", "Specify request user for events")
+	EventCmd.Flags().IntP("tail", "t", 25, "Number of command entries to show from the end")
+	EventCmd.Flags().StringP("server", "s", "", "Filter by server name")
+	EventCmd.Flags().StringP("user", "u", "", "Filter by requesting user")
 }
 
-func runEvent(cmd *cobra.Command, args []string) {
+func runEvent(cmd *cobra.Command, _ []string) {
+	utils.CliWarning("'alpacon event' has moved to 'alpacon exec ls' and will be removed in a future release.")
+
 	pageSize, _ := cmd.Flags().GetInt("tail")
 	serverName, _ := cmd.Flags().GetString("server")
 	userName, _ := cmd.Flags().GetString("user")
 
-	alpaconClient, err := client.NewAlpaconAPIClient()
-	if err != nil {
-		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		return
-	}
-
-	eventList, err := event.GetEventList(alpaconClient, pageSize, serverName, userName)
-	if err != nil {
-		utils.CliErrorWithExit("Failed to get events: %s.", err)
-		return
-	}
-
-	utils.PrintTable(eventList)
+	exec.RunList(pageSize, serverName, userName)
 }

--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -24,17 +24,11 @@ The 'event' name is being repurposed for the Alpacon event channel.`,
 }
 
 func init() {
-	EventCmd.Flags().IntP("tail", "t", 25, "Number of command entries to show from the end")
-	EventCmd.Flags().StringP("server", "s", "", "Filter by server name")
-	EventCmd.Flags().StringP("user", "u", "", "Filter by requesting user")
+	exec.AddListFlags(EventCmd)
 }
 
 func runEvent(cmd *cobra.Command, _ []string) {
 	utils.CliWarning("'alpacon event' has moved to 'alpacon exec ls' and will be removed in a future release.")
 
-	pageSize, _ := cmd.Flags().GetInt("tail")
-	serverName, _ := cmd.Flags().GetString("server")
-	userName, _ := cmd.Flags().GetString("user")
-
-	exec.RunList(pageSize, serverName, userName)
+	exec.RunListFromFlags(cmd)
 }

--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -32,6 +32,9 @@ intended for the remote command (e.g., -U, -d) are not interpreted as alpacon fl
 
 All flags must be placed before the server name.
 
+Subcommand names (ls, logs) win over a server of the same name. To reach a server
+literally named 'ls' or 'logs', put -- before it: alpacon exec -- ls uptime
+
 Shell metacharacters (;, |, &, $) pass through unquoted to the remote shell.
 To send a literal metacharacter, wrap the argument in quotes:
   alpacon exec server 'echo hello;world'

--- a/cmd/exec/list.go
+++ b/cmd/exec/list.go
@@ -19,25 +19,34 @@ and --user to filter by the requesting user.`,
   alpacon exec ls --tail 10
   alpacon exec ls --tail 10 --server my-server --user admin`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		pageSize, _ := cmd.Flags().GetInt("tail")
-		serverName, _ := cmd.Flags().GetString("server")
-		userName, _ := cmd.Flags().GetString("user")
-
-		RunList(pageSize, serverName, userName)
+		RunListFromFlags(cmd)
 	},
 }
 
 func init() {
-	listCmd.Flags().IntP("tail", "t", 25, "Number of command entries to show from the end")
-	listCmd.Flags().StringP("server", "s", "", "Filter by server name")
-	listCmd.Flags().StringP("user", "u", "", "Filter by requesting user")
+	AddListFlags(listCmd)
 
 	ExecCmd.AddCommand(listCmd)
 }
 
-// RunList is exported for the deprecated 'alpacon event', which delegates here so the
-// two cannot drift. Their flag sets are still declared separately and must stay in sync.
-func RunList(pageSize int, serverName, userName string) {
+// AddListFlags and RunListFromFlags are exported for the deprecated 'alpacon event', which
+// delegates here. Both live in this file so the flag names exist in exactly one place.
+func AddListFlags(cmd *cobra.Command) {
+	cmd.Flags().IntP("tail", "t", 25, "Number of command entries to show from the end")
+	cmd.Flags().StringP("server", "s", "", "Filter by server name")
+	cmd.Flags().StringP("user", "u", "", "Filter by requesting user")
+}
+
+// RunListFromFlags requires the flag set registered by AddListFlags.
+func RunListFromFlags(cmd *cobra.Command) {
+	pageSize, _ := cmd.Flags().GetInt("tail")
+	serverName, _ := cmd.Flags().GetString("server")
+	userName, _ := cmd.Flags().GetString("user")
+
+	runList(pageSize, serverName, userName)
+}
+
+func runList(pageSize int, serverName, userName string) {
 	utils.RequirePositiveInt("tail", pageSize)
 
 	alpaconClient, err := client.NewAlpaconAPIClient()

--- a/cmd/exec/list.go
+++ b/cmd/exec/list.go
@@ -1,0 +1,56 @@
+package exec
+
+import (
+	"github.com/alpacax/alpacon-cli/api/event"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:     "ls",
+	Aliases: []string{"list"},
+	Short:   "List recent remote command executions",
+	Long: `List recent remote command executions, most recent last.
+
+Use --tail to limit the number of entries, --server to scope to one server,
+and --user to filter by the requesting user.`,
+	Example: `  alpacon exec ls
+  alpacon exec ls --tail 10
+  alpacon exec ls --tail 10 --server my-server --user admin`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		pageSize, _ := cmd.Flags().GetInt("tail")
+		serverName, _ := cmd.Flags().GetString("server")
+		userName, _ := cmd.Flags().GetString("user")
+
+		RunList(pageSize, serverName, userName)
+	},
+}
+
+func init() {
+	listCmd.Flags().IntP("tail", "t", 25, "Number of command entries to show from the end")
+	listCmd.Flags().StringP("server", "s", "", "Filter by server name")
+	listCmd.Flags().StringP("user", "u", "", "Filter by requesting user")
+
+	ExecCmd.AddCommand(listCmd)
+}
+
+// RunList is exported for the deprecated 'alpacon event', which delegates here so the
+// two cannot drift. Their flag sets are still declared separately and must stay in sync.
+func RunList(pageSize int, serverName, userName string) {
+	utils.RequirePositiveInt("tail", pageSize)
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+		return
+	}
+
+	eventList, err := event.GetEventList(alpaconClient, pageSize, serverName, userName)
+	if err != nil {
+		utils.CliErrorWithExit("Failed to retrieve the commands: %s.", err)
+		return
+	}
+
+	utils.PrintTable(eventList)
+}

--- a/cmd/exec/list.go
+++ b/cmd/exec/list.go
@@ -52,13 +52,11 @@ func runList(pageSize int, serverName, userName string) {
 	alpaconClient, err := client.NewAlpaconAPIClient()
 	if err != nil {
 		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
-		return
 	}
 
 	eventList, err := event.GetEventList(alpaconClient, pageSize, serverName, userName)
 	if err != nil {
 		utils.CliErrorWithExit("Failed to retrieve the commands: %s.", err)
-		return
 	}
 
 	utils.PrintTable(eventList)

--- a/cmd/exec/list_test.go
+++ b/cmd/exec/list_test.go
@@ -1,0 +1,71 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// DisableFlagParsing only covers the parent; this pins that a child still routes and parses flags normally.
+func TestExecLsRoutesAndParsesFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectedTail   int
+		expectedServer string
+		expectedUser   string
+	}{
+		{
+			name:         "defaults",
+			args:         []string{"ls"},
+			expectedTail: 25,
+		},
+		{
+			name:           "long flags",
+			args:           []string{"ls", "--tail", "10", "--server", "my-server", "--user", "admin"},
+			expectedTail:   10,
+			expectedServer: "my-server",
+			expectedUser:   "admin",
+		},
+		{
+			name:           "short flags",
+			args:           []string{"ls", "-t", "5", "-s", "other-server", "-u", "operator"},
+			expectedTail:   5,
+			expectedServer: "other-server",
+			expectedUser:   "operator",
+		},
+		{
+			name:         "list alias",
+			args:         []string{"list", "--tail", "7"},
+			expectedTail: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, flags, err := ExecCmd.Find(tt.args)
+			require.NoError(t, err)
+			require.Equal(t, "ls", cmd.Name())
+
+			// Reset from each flag's own default so a prior case cannot leak in and the defaults case still checks what is registered.
+			for _, name := range []string{"tail", "server", "user"} {
+				require.NoError(t, cmd.Flags().Set(name, cmd.Flags().Lookup(name).DefValue))
+			}
+
+			require.NoError(t, cmd.ParseFlags(flags))
+
+			tail, err := cmd.Flags().GetInt("tail")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTail, tail)
+
+			server, err := cmd.Flags().GetString("server")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedServer, server)
+
+			user, err := cmd.Flags().GetString("user")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedUser, user)
+		})
+	}
+}


### PR DESCRIPTION
## Background

`alpacon event` lists command executions from `/api/events/commands/`. The subscription channel #271 wants is a different API — `/api/events/sessions/` plus `/api/events/subscriptions/`. Under one name the parent is command-scoped while the children cover every event type.

So `event` is promoted to mean the event channel, and the history table moves next to `alpacon exec logs JOB_ID`. PR3 of the #271 plan and the only break in it. PR1 (#287) and PR2 (#289) are merged. Does not close the issue.

## What changed

| Commit | Change |
|---|---|
| `1c1b82d` | `type EventType string` in `api/event` |
| `25fde70` | New `alpacon exec ls` |
| `75fc725` | `alpacon event` warns, then delegates to `exec.RunList` |
| `dcac960` | Event-type constants back into one `const` block (review) |
| `09477cd` | Shorten the deprecated `Short` so root help stops wrapping (review) |
| `e7942ce` | Share the list flag set between the two commands (review) |
| `983faad` | Drop unreachable returns after `CliErrorWithExit` (review) |

`exec ls` keeps alias `list` and the same `--tail`/`--server`/`--user`. The API layer is untouched — `GetEventList` stays in `api/event`, which `cmd/exec` already imports.

`event` still works, warns on stderr, and delegates instead of holding a second copy. Delegation over duplication is empirical: the two copies drifted three times during review — error wording, flag help, `Example` syntax. `cmd/token/acl_list.go:12` already uses this shape.

Nothing about the flag set is duplicated either. Both commands call `exec.AddListFlags(cmd)` to declare the three flags and `exec.RunListFromFlags(cmd)` to read them, so the flag names appear only in `cmd/exec/list.go` and `cmd/event/event.go` contains none of them. Two exported symbols rather than one because `cmd/event` needs its own `FlagSet`, so registration and read cannot collapse into a single call.

## Reasoning

Cobra's `Deprecated` field is unused: a non-empty value makes `IsAvailableCommand()` false (v1.10.2, `command.go:1607-1610`), dropping `event` from root help and with it any way to find the subcommands landing here next. Its built-in notice also prints via `c.Printf` to stdout, which would corrupt `--output json`. The `cmd/token/acl_*` precedent covers leaf commands being fully replaced.

Correction to PR2: #289 deferred the named type partly on the grounds that it would change the JSON wire shape. That was wrong — an underlying kind of `string` marshals identically. The real cost was struct propagation and scope growth, reason enough on its own. `EventType` applies to `SubscribeEvent`'s parameter, `EventSubscriptionRequest.EventType`, and the WS envelope field; the constants stay untyped so every const sits in one block. No validation, because `event watch --type` must accept server types the CLI has no constant for — the `"work_session"` case in `subscribe_test.go` pins that.

## Behavior changes

`alpacon event --tail 0` is now rejected. Previously `page_size` was omitted (`api/event/event.go:158`) and the server default of 15 applied. `--tail` already defaults to 25, so 0 was only a second path to a smaller value and `--tail 15` is identical. Matches `exec ls` and the same flag on `audit`, `log`, `webftp`.

The fetch-failure message on `event` changes from "Failed to get events" to "Failed to retrieve the commands". Exit code unchanged at 1.

## Known limitations

- A server named `ls` or `list` is unreachable through `exec ls` — it routes to the subcommand and prints the table with no error. Pre-existing for `logs`; the `--` escape is now documented in `cmd/exec/exec.go`'s `Long`.
- During the transition `event` still prints command history rather than event-channel output. Deliberate.
- The deprecation notice names no removal version. None has been decided, and the removal is effectively gated on PR4/PR5 landing rather than on a time-based window, since that is when a bare `alpacon event` printing command history becomes actively wrong.

## Tests

`cmd/exec/list_test.go` pins that a child routes and parses its own flags while the parent `ExecCmd` sets `DisableFlagParsing`. Per cobra the child is unaffected, but nothing pinned it and `exec` had no flag-bearing subcommand to show it. All four cases reset flags from their own `DefValue` to remove order dependence.

`cmd/event/event.go` has no unit test: `utils.CliWarning` writes straight to `os.Stderr`, so capturing it would mean refactoring production code, and `cmd/log`, `cmd/audit`, `cmd/webftp` have none either. Verified on the binary instead.

```
go build -o alpacon . && go vet ./... && gofmt -l .
golangci-lint run ./...
go test -race ./...
go test -race -shuffle=on -count=2 ./cmd/exec/
```

All packages pass (37 ok), lint reports 0 issues, gofmt reports no differences. Each commit was checked out into a temporary worktree and builds and vets independently.

Checked on the binary: `event` still in root help; the notice goes to stderr only, leaving `--output json` stdout intact; `--tail 0` and `--tail -1` exit 1 before any network call; `exec -- ls uptime` treats `ls` as the server name. The two flag blocks are now diffed rather than eyeballed — `diff` of the `Flags:` section of `event --help` against `exec ls --help` reports only cobra's auto `--help` line.

## Checklist

- [x] `go test -race ./...` passes
- [x] golangci-lint reports 0 issues
- [x] Each of the seven commits builds independently
- [x] `event` confirmed still present in root help
- [x] stderr/stdout separation confirmed under `--output json`
- [x] Wire format unchanged
- [x] `--tail 0` rejection confirmed acceptable — it matches `audit`, `log`, `webftp`, and `--tail 15` reproduces the old behavior exactly
- [x] Flag declarations collapsed; the two help outputs are byte-identical apart from cobra's `--help` line

Refs #271
