### PR TITLE
feat(event): add event watch to stream the event channel

### DIFF
--- a/api/event/subscribe.go
+++ b/api/event/subscribe.go
@@ -32,7 +32,8 @@ type EventSessionResponse struct {
 type EventSubscriptionRequest struct {
 	Channel   string    `json:"channel"`
 	EventType EventType `json:"event_type"`
-	TargetID  string    `json:"target_id"`
+	// Omitted rather than sent empty: the server validates target_id as a UUID.
+	TargetID string `json:"target_id,omitempty"`
 }
 
 // CreateEventSession creates a new event session and returns the WebSocket URL
@@ -51,8 +52,9 @@ func CreateEventSession(ac *client.AlpaconClient) (*EventSessionResponse, error)
 	return &resp, nil
 }
 
-// SubscribeEvent subscribes the given channel to eventType events, scoped to
-// targetID (a websh session for sudo, a command for command_output).
+// SubscribeEvent subscribes the given channel to eventType events, scoped to targetID
+// (a websh session for sudo, a command for command_output, a work session for
+// work_session). An empty targetID is omitted, which only some event types allow.
 func SubscribeEvent(ac *client.AlpaconClient, channelID string, eventType EventType, targetID string) error {
 	req := &EventSubscriptionRequest{
 		Channel:   channelID,

--- a/api/event/subscribe_test.go
+++ b/api/event/subscribe_test.go
@@ -84,6 +84,35 @@ func TestSubscribeEvent_SendsExpectedPayload(t *testing.T) {
 	}
 }
 
+func TestSubscribeEvent_OmitsEmptyTarget(t *testing.T) {
+	bodies := make(chan map[string]any, 1)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		bodies <- body
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"sub-789"}`))
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{
+		HTTPClient: ts.Client(),
+		BaseURL:    ts.URL,
+	}
+
+	require.NoError(t, SubscribeEvent(ac, "channel-456", "notification", ""))
+
+	body := <-bodies
+	_, present := body["target_id"]
+	// The server validates target_id as a UUID, so an empty string would be a 400.
+	assert.False(t, present, "empty target must be omitted from the request body")
+	assert.Equal(t, "channel-456", body["channel"])
+	assert.Equal(t, "notification", body["event_type"])
+}
+
 func TestCreateEventSession_ServerError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/api/event/watcher.go
+++ b/api/event/watcher.go
@@ -3,11 +3,13 @@ package event
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"sync"
 	"time"
 
 	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
 )
 
 const (
@@ -54,8 +56,8 @@ func NewWatcher(ac *client.AlpaconClient, eventType EventType, targetID string) 
 	return w
 }
 
-// Only after a first success: before that, a dial is worth retrying inside
-// WaitConnected's window rather than ending the command.
+// Only after a first success: before that, a retryable attempt is worth another try
+// inside WaitConnected's window rather than ending the command.
 func (w *Watcher) announceOutage(cause error) {
 	w.stateMu.Lock()
 	subscribed := w.subscribed
@@ -83,10 +85,21 @@ func (w *Watcher) Err() error {
 	return w.err
 }
 
+// The session request carries neither --type nor --target, so only a 4xx proves retrying
+// pointless. Anything else gets the retry window a dial failure already gets.
+func (w *Watcher) sessionCreateFailed(cause error) error {
+	if status := utils.HTTPStatusCode(cause); status >= http.StatusBadRequest && status < http.StatusInternalServerError {
+		return w.fail(cause)
+	}
+
+	w.announceOutage(cause)
+	return cause
+}
+
 func (w *Watcher) provisionSession() (string, error) {
 	session, err := CreateEventSession(w.ac)
 	if err != nil {
-		return "", w.fail(err)
+		return "", w.sessionCreateFailed(err)
 	}
 
 	// Rejected here because the dialer's own *url.Error quotes the whole URL, and this
@@ -137,10 +150,9 @@ func (w *Watcher) subscribe() error {
 	return nil
 }
 
-// A failure before any successful subscribe is fatal, so a bad target or an
-// unreachable server surfaces the server's own message rather than a generic connect
-// timeout. Session creation counts: before a first success nothing proves the request
-// valid. Later failures are ordinary reconnect material.
+// A failure before any successful subscribe is fatal, so a bad target or an expired
+// login surfaces the server's own message rather than a generic connect timeout.
+// Later failures are ordinary reconnect material.
 func (w *Watcher) fail(cause error) error {
 	w.stateMu.Lock()
 	fatal := !w.subscribed

--- a/api/event/watcher.go
+++ b/api/event/watcher.go
@@ -1,0 +1,182 @@
+package event
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/client"
+)
+
+const (
+	watchHandshakeTimeout = 10 * time.Second
+	watchFrameBuffer      = 256
+
+	// Bounded so a compromised server cannot grow the CLI's memory without limit.
+	watchFrameLimit = 1024 * 1024
+)
+
+// Watcher streams raw event frames for one event type. Event channel tokens are
+// single-use, so every dial attempt provisions its own session and re-subscribes once
+// connected. When WaitConnected returns false, Err holds the reason if it was fatal.
+type Watcher struct {
+	*wsListener
+	ac              *client.AlpaconClient
+	eventType       EventType
+	targetID        string
+	frames          chan []byte
+	reconnected     chan struct{}
+	reconnectFailed chan error
+
+	stateMu    sync.Mutex // guards channelID, subscribed, warned, err
+	channelID  string
+	subscribed bool
+	warned     bool
+	err        error
+}
+
+func NewWatcher(ac *client.AlpaconClient, eventType EventType, targetID string) *Watcher {
+	w := &Watcher{
+		ac:              ac,
+		eventType:       eventType,
+		targetID:        targetID,
+		frames:          make(chan []byte, watchFrameBuffer),
+		reconnected:     make(chan struct{}, 1),
+		reconnectFailed: make(chan error, 1),
+	}
+	w.wsListener = newProvisionedWSListener(ac, w.provisionSession, watchHandshakeTimeout)
+	w.readLimit = watchFrameLimit
+	w.handleFrame = w.handleMessage
+	w.onConnected = w.subscribe
+	w.onDialFailed = w.announceOutage
+	return w
+}
+
+// Only after a first success: before that, a dial is worth retrying inside
+// WaitConnected's window rather than ending the command.
+func (w *Watcher) announceOutage(cause error) {
+	w.stateMu.Lock()
+	subscribed := w.subscribed
+	w.stateMu.Unlock()
+
+	if subscribed {
+		_ = w.fail(cause)
+	}
+}
+
+func (w *Watcher) Frames() <-chan []byte { return w.frames }
+
+// Reconnected fires on each re-subscribe. Events published while disconnected are
+// lost for good: the event channel has no history to replay.
+func (w *Watcher) Reconnected() <-chan struct{} { return w.reconnected }
+
+// ReconnectFailed reports the first failure of each outage, so a stream whose
+// reconnects keep failing is distinguishable from a quiet one.
+func (w *Watcher) ReconnectFailed() <-chan error { return w.reconnectFailed }
+
+// Err returns the error that stopped the Watcher before it ever subscribed.
+func (w *Watcher) Err() error {
+	w.stateMu.Lock()
+	defer w.stateMu.Unlock()
+	return w.err
+}
+
+func (w *Watcher) provisionSession() (string, error) {
+	session, err := CreateEventSession(w.ac)
+	if err != nil {
+		return "", w.fail(err)
+	}
+
+	// Rejected here because the dialer's own *url.Error quotes the whole URL, and this
+	// URL carries a live channel token. Only the inner reason is safe to keep.
+	if _, err := url.Parse(session.WebsocketURL); err != nil {
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			err = urlErr.Err
+		}
+		return "", w.fail(fmt.Errorf("server returned a malformed event channel URL: %w", err))
+	}
+
+	w.stateMu.Lock()
+	w.channelID = session.ChannelID
+	w.stateMu.Unlock()
+
+	return session.WebsocketURL, nil
+}
+
+func (w *Watcher) subscribe() error {
+	w.stateMu.Lock()
+	channelID := w.channelID
+	first := !w.subscribed
+	w.stateMu.Unlock()
+
+	if err := SubscribeEvent(w.ac, channelID, w.eventType, w.targetID); err != nil {
+		return w.fail(err)
+	}
+
+	w.stateMu.Lock()
+	w.subscribed = true
+	w.warned = false
+	// An unread notice describes an outage that is over: leaving it queued would
+	// misreport a healthy stream and crowd out the next outage's notice.
+	select {
+	case <-w.reconnectFailed:
+	default:
+	}
+	w.stateMu.Unlock()
+
+	if !first {
+		select {
+		case w.reconnected <- struct{}{}:
+		default:
+		}
+	}
+
+	return nil
+}
+
+// A failure before any successful subscribe is fatal, so a bad target or an
+// unreachable server surfaces the server's own message rather than a generic connect
+// timeout. Session creation counts: before a first success nothing proves the request
+// valid. Later failures are ordinary reconnect material.
+func (w *Watcher) fail(cause error) error {
+	w.stateMu.Lock()
+	fatal := !w.subscribed
+	if fatal {
+		w.err = cause
+	}
+	announce := !fatal && !w.warned
+	w.stateMu.Unlock()
+
+	if fatal {
+		w.Stop()
+		return cause
+	}
+
+	if announce {
+		// Never park the dial loop on an undrained notice; warned is set only on a
+		// delivered one, so a dropped notice is re-announced next attempt.
+		select {
+		case w.reconnectFailed <- cause:
+			w.stateMu.Lock()
+			w.warned = true
+			w.stateMu.Unlock()
+		default:
+		}
+	}
+
+	return cause
+}
+
+func (w *Watcher) handleMessage(raw []byte) {
+	// Copied because raw is handed to another goroutine through frames.
+	frame := make([]byte, len(raw))
+	copy(frame, raw)
+
+	select {
+	case w.frames <- frame:
+	case <-w.done:
+	}
+}

--- a/api/event/watcher.go
+++ b/api/event/watcher.go
@@ -86,9 +86,13 @@ func (w *Watcher) Err() error {
 }
 
 // The session request carries neither --type nor --target, so only a 4xx proves retrying
-// pointless. Anything else gets the retry window a dial failure already gets.
+// pointless—except 408 and 429, which ask for exactly that. Anything else gets the retry
+// window a dial failure already gets.
 func (w *Watcher) sessionCreateFailed(cause error) error {
-	if status := utils.HTTPStatusCode(cause); status >= http.StatusBadRequest && status < http.StatusInternalServerError {
+	status := utils.HTTPStatusCode(cause)
+	retryLater := status == http.StatusRequestTimeout || status == http.StatusTooManyRequests
+
+	if !retryLater && status >= http.StatusBadRequest && status < http.StatusInternalServerError {
 		return w.fail(cause)
 	}
 

--- a/api/event/watcher_test.go
+++ b/api/event/watcher_test.go
@@ -1,0 +1,332 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newWatcherTestServer serves the session, subscription, and WebSocket endpoints on one
+// httptest server so a Watcher can run end to end. shouldUpgrade and subscribeStatus each
+// receive their own 1-based attempt count, in the order the runtime reaches them.
+func newWatcherTestServer(t *testing.T, shouldUpgrade func(attempt int32) bool, subscribeStatus func(attempt int32) int, wsHandler func(conn *websocket.Conn, n int32)) (*httptest.Server, *atomic.Int32, *atomic.Int32) {
+	t.Helper()
+
+	var sessions, conns, subscribes atomic.Int32
+	upgrader := websocket.Upgrader{}
+	mux := http.NewServeMux()
+
+	ts := httptest.NewServer(mux)
+
+	mux.HandleFunc(eventSessionsURL, func(w http.ResponseWriter, r *http.Request) {
+		n := sessions.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(EventSessionResponse{
+			ID:           "session",
+			WebsocketURL: "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/",
+			ChannelID:    fmt.Sprintf("channel-%d", n),
+		})
+	})
+
+	mux.HandleFunc(eventSubscriptionsURL, func(w http.ResponseWriter, r *http.Request) {
+		status := subscribeStatus(subscribes.Add(1))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status >= 400 {
+			_, _ = w.Write([]byte(`{"detail":"Invalid input."}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"sub"}`))
+	})
+
+	mux.HandleFunc("/ws/", func(w http.ResponseWriter, r *http.Request) {
+		n := conns.Add(1)
+		if !shouldUpgrade(n) {
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		wsHandler(conn, n)
+	})
+
+	t.Cleanup(ts.Close)
+	return ts, &sessions, &subscribes
+}
+
+func alwaysCreated(int32) int { return http.StatusCreated }
+
+func alwaysUpgrade(int32) bool { return true }
+
+func alwaysRejected(int32) int { return http.StatusBadRequest }
+
+func TestWatcher_ForwardsFramesVerbatim(t *testing.T) {
+	frame := `{"event_type":"work_session","payload":{"category":"status","sub_type":"approved","unknown":1}}`
+
+	ts, _, _ := newWatcherTestServer(t, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(frame))
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	w := NewWatcher(ac, "work_session", "ws-uuid")
+	w.Start()
+	defer w.Stop()
+
+	require.True(t, w.WaitConnected(3*time.Second))
+	require.NoError(t, w.Err())
+
+	select {
+	case got := <-w.Frames():
+		assert.JSONEq(t, frame, string(got))
+	case <-time.After(3 * time.Second):
+		t.Fatal("no frame received")
+	}
+}
+
+func TestWatcher_CreatesANewSessionOnReconnect(t *testing.T) {
+	ts, sessions, subscribes := newWatcherTestServer(t, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
+		if n == 1 {
+			// The token is single-use, so recovering means a whole new session.
+			_ = conn.Close()
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	w := NewWatcher(ac, "work_session", "ws-uuid")
+	w.reconnectBaseDelay = testReconnectBaseDelay
+	w.Start()
+	defer w.Stop()
+
+	require.True(t, w.WaitConnected(3*time.Second))
+
+	select {
+	case <-w.Reconnected():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("expected a reconnect, sessions=%d subscribes=%d", sessions.Load(), subscribes.Load())
+	}
+
+	assert.GreaterOrEqual(t, sessions.Load(), int32(2), "each attempt must create its own event session")
+}
+
+func TestWatcher_FirstSubscribeFailureStopsAndSurfaces(t *testing.T) {
+	ts, _, _ := newWatcherTestServer(t, alwaysUpgrade, alwaysRejected, func(conn *websocket.Conn, _ int32) {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	w := NewWatcher(ac, "work_session", "not-a-uuid")
+	w.Start()
+	defer w.Stop()
+
+	assert.False(t, w.WaitConnected(3*time.Second), "a rejected subscription must not report connected")
+
+	err := w.Err()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to subscribe to work_session events")
+}
+
+func TestWatcher_FailureAfterFirstSuccessIsNonFatal(t *testing.T) {
+	firstOnly := func(attempt int32) int {
+		if attempt == 1 {
+			return http.StatusCreated
+		}
+		return http.StatusBadRequest
+	}
+
+	ts, _, subscribes := newWatcherTestServer(t, alwaysUpgrade, firstOnly, func(conn *websocket.Conn, n int32) {
+		if n == 1 {
+			// Dropped only after its subscribe succeeded, so the reconnect is the
+			// attempt that gets rejected.
+			_ = conn.Close()
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	w := NewWatcher(ac, "work_session", "ws-uuid")
+	w.reconnectBaseDelay = testReconnectBaseDelay
+	w.Start()
+	defer w.Stop()
+
+	require.True(t, w.WaitConnected(3*time.Second))
+	require.NoError(t, w.Err())
+
+	require.Eventually(t, func() bool {
+		return subscribes.Load() >= 2
+	}, 5*time.Second, 10*time.Millisecond, "expected a rejected re-subscribe")
+
+	assert.NoError(t, w.Err())
+	select {
+	case <-w.done:
+		t.Fatal("watcher stopped after a post-success subscribe failure")
+	default:
+	}
+
+	select {
+	case failErr := <-w.ReconnectFailed():
+		assert.ErrorContains(t, failErr, "failed to subscribe to work_session events")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a ReconnectFailed notice after a post-success failure")
+	}
+
+	require.Eventually(t, func() bool {
+		return subscribes.Load() >= 3
+	}, 5*time.Second, 10*time.Millisecond, "expected the listener to keep retrying")
+
+	assert.NoError(t, w.Err())
+	select {
+	case <-w.done:
+		t.Fatal("watcher stopped after a post-success subscribe failure")
+	default:
+	}
+}
+
+func TestWatcher_DialFailureAfterFirstSuccessIsAnnounced(t *testing.T) {
+	// A refused handshake is a real dial error, which reaches neither provision nor
+	// subscribe.
+	firstConnOnly := func(attempt int32) bool { return attempt == 1 }
+
+	ts, _, _ := newWatcherTestServer(t, firstConnOnly, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		_ = conn.Close()
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	w := NewWatcher(ac, "work_session", "ws-uuid")
+	w.reconnectBaseDelay = testReconnectBaseDelay
+	w.Start()
+	defer w.Stop()
+
+	require.True(t, w.WaitConnected(3*time.Second))
+
+	select {
+	case failErr := <-w.ReconnectFailed():
+		assert.Error(t, failErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("a dial failure after a first success must be announced")
+	}
+
+	assert.NoError(t, w.Err(), "a dial failure after a first success must not be fatal")
+}
+
+func TestWatcher_StaleFailureNoticeIsDroppedOnRecovery(t *testing.T) {
+	secondOnly := func(attempt int32) int {
+		if attempt == 2 {
+			return http.StatusBadRequest
+		}
+		return http.StatusCreated
+	}
+
+	ts, _, subscribes := newWatcherTestServer(t, alwaysUpgrade, secondOnly, func(conn *websocket.Conn, n int32) {
+		if n == 1 {
+			_ = conn.Close()
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	w := NewWatcher(ac, "work_session", "ws-uuid")
+	w.reconnectBaseDelay = testReconnectBaseDelay
+	w.Start()
+	defer w.Stop()
+
+	require.True(t, w.WaitConnected(3*time.Second))
+
+	// ReconnectFailed is deliberately never drained: attempt 2 queues a notice that
+	// attempt 3's recovery must discard.
+	require.Eventually(t, func() bool {
+		return subscribes.Load() >= 3
+	}, 5*time.Second, 10*time.Millisecond, "expected a recovery after the rejected re-subscribe")
+
+	select {
+	case <-w.Reconnected():
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected a reconnect notice after recovery")
+	}
+
+	select {
+	case failErr := <-w.ReconnectFailed():
+		t.Fatalf("a resolved outage must not stay queued, got %v", failErr)
+	default:
+	}
+}
+
+func TestWatcher_MalformedWebsocketURLStopsAndSurfaces(t *testing.T) {
+	const token = "hunter2"
+	// A DEL byte makes url.Parse fail; left to the dialer that surfaces as a *url.Error
+	// quoting the whole URL, token included.
+	badURL := "ws://127.0.0.1/ws/session/channel/" + token + "/\x7f"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(EventSessionResponse{
+			ID:           "session",
+			WebsocketURL: badURL,
+			ChannelID:    "channel",
+		})
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	w := NewWatcher(ac, "work_session", "ws-uuid")
+	w.Start()
+	defer w.Stop()
+
+	assert.False(t, w.WaitConnected(2*time.Second))
+
+	err := w.Err()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), token, "a malformed-url error must not echo the channel token")
+	assert.Contains(t, err.Error(), "malformed event channel URL")
+}
+
+func TestWatcher_SessionCreateFailureStopsAndSurfaces(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	w := NewWatcher(ac, "work_session", "ws-uuid")
+	w.Start()
+	defer w.Stop()
+
+	assert.False(t, w.WaitConnected(2*time.Second))
+	require.Error(t, w.Err())
+	assert.Contains(t, w.Err().Error(), "failed to create event session")
+}

--- a/api/event/watcher_test.go
+++ b/api/event/watcher_test.go
@@ -338,29 +338,43 @@ func TestWatcher_SessionCreateRejectionStopsAndSurfaces(t *testing.T) {
 	assert.Contains(t, w.Err().Error(), "failed to create event session")
 }
 
-func TestWatcher_SessionCreateServerErrorIsRetried(t *testing.T) {
-	failFirst := func(attempt int32) int {
-		if attempt == 1 {
-			return http.StatusBadGateway
-		}
-		return http.StatusCreated
+func TestWatcher_SessionCreateRetryableStatusIsRetried(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"server error", http.StatusBadGateway},
+		// Both are 4xx that ask to be retried, so the fatal band has to skip them.
+		{"request timeout", http.StatusRequestTimeout},
+		{"too many requests", http.StatusTooManyRequests},
 	}
 
-	ts, sessions, _ := newWatcherTestServer(t, failFirst, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failFirst := func(attempt int32) int {
+				if attempt == 1 {
+					return tt.status
+				}
+				return http.StatusCreated
 			}
-		}
-	})
 
-	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
-	w := NewWatcher(ac, "work_session", "ws-uuid")
-	w.reconnectBaseDelay = testReconnectBaseDelay
-	w.Start()
-	defer w.Stop()
+			ts, sessions, _ := newWatcherTestServer(t, failFirst, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+				for {
+					if _, _, err := conn.ReadMessage(); err != nil {
+						return
+					}
+				}
+			})
 
-	require.True(t, w.WaitConnected(3*time.Second), "a transient session-create failure must be absorbed, not fatal")
-	assert.NoError(t, w.Err())
-	assert.GreaterOrEqual(t, sessions.Load(), int32(2), "the failed attempt must be retried with a new session")
+			ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+			w := NewWatcher(ac, "work_session", "ws-uuid")
+			w.reconnectBaseDelay = testReconnectBaseDelay
+			w.Start()
+			defer w.Stop()
+
+			require.True(t, w.WaitConnected(3*time.Second), "a transient session-create failure must be absorbed, not fatal")
+			assert.NoError(t, w.Err())
+			assert.GreaterOrEqual(t, sessions.Load(), int32(2), "the failed attempt must be retried with a new session")
+		})
+	}
 }

--- a/api/event/watcher_test.go
+++ b/api/event/watcher_test.go
@@ -33,7 +33,7 @@ func newWatcherTestServer(t *testing.T, sessionStatus func(attempt int32) int, s
 		w.Header().Set("Content-Type", "application/json")
 		if status := sessionStatus(n); status >= 400 {
 			w.WriteHeader(status)
-			_, _ = w.Write([]byte(`{"detail":"Bad gateway."}`))
+			_, _ = fmt.Fprintf(w, `{"detail":"Session create failed with %d."}`, status)
 			return
 		}
 		_ = json.NewEncoder(w).Encode(EventSessionResponse{

--- a/api/event/watcher_test.go
+++ b/api/event/watcher_test.go
@@ -17,9 +17,9 @@ import (
 )
 
 // newWatcherTestServer serves the session, subscription, and WebSocket endpoints on one
-// httptest server so a Watcher can run end to end. shouldUpgrade and subscribeStatus each
-// receive their own 1-based attempt count, in the order the runtime reaches them.
-func newWatcherTestServer(t *testing.T, shouldUpgrade func(attempt int32) bool, subscribeStatus func(attempt int32) int, wsHandler func(conn *websocket.Conn, n int32)) (*httptest.Server, *atomic.Int32, *atomic.Int32) {
+// httptest server so a Watcher can run end to end. Each hook receives its own 1-based
+// attempt count, in the order the runtime reaches them.
+func newWatcherTestServer(t *testing.T, sessionStatus func(attempt int32) int, shouldUpgrade func(attempt int32) bool, subscribeStatus func(attempt int32) int, wsHandler func(conn *websocket.Conn, n int32)) (*httptest.Server, *atomic.Int32, *atomic.Int32) {
 	t.Helper()
 
 	var sessions, conns, subscribes atomic.Int32
@@ -31,6 +31,11 @@ func newWatcherTestServer(t *testing.T, shouldUpgrade func(attempt int32) bool, 
 	mux.HandleFunc(eventSessionsURL, func(w http.ResponseWriter, r *http.Request) {
 		n := sessions.Add(1)
 		w.Header().Set("Content-Type", "application/json")
+		if status := sessionStatus(n); status >= 400 {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"detail":"Bad gateway."}`))
+			return
+		}
 		_ = json.NewEncoder(w).Encode(EventSessionResponse{
 			ID:           "session",
 			WebsocketURL: "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/",
@@ -74,7 +79,7 @@ func alwaysRejected(int32) int { return http.StatusBadRequest }
 func TestWatcher_ForwardsFramesVerbatim(t *testing.T) {
 	frame := `{"event_type":"work_session","payload":{"category":"status","sub_type":"approved","unknown":1}}`
 
-	ts, _, _ := newWatcherTestServer(t, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
 		_ = conn.WriteMessage(websocket.TextMessage, []byte(frame))
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
@@ -100,7 +105,7 @@ func TestWatcher_ForwardsFramesVerbatim(t *testing.T) {
 }
 
 func TestWatcher_CreatesANewSessionOnReconnect(t *testing.T) {
-	ts, sessions, subscribes := newWatcherTestServer(t, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
+	ts, sessions, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, n int32) {
 		if n == 1 {
 			// The token is single-use, so recovering means a whole new session.
 			_ = conn.Close()
@@ -131,7 +136,7 @@ func TestWatcher_CreatesANewSessionOnReconnect(t *testing.T) {
 }
 
 func TestWatcher_FirstSubscribeFailureStopsAndSurfaces(t *testing.T) {
-	ts, _, _ := newWatcherTestServer(t, alwaysUpgrade, alwaysRejected, func(conn *websocket.Conn, _ int32) {
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, alwaysRejected, func(conn *websocket.Conn, _ int32) {
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
 				return
@@ -159,7 +164,7 @@ func TestWatcher_FailureAfterFirstSuccessIsNonFatal(t *testing.T) {
 		return http.StatusBadRequest
 	}
 
-	ts, _, subscribes := newWatcherTestServer(t, alwaysUpgrade, firstOnly, func(conn *websocket.Conn, n int32) {
+	ts, _, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, firstOnly, func(conn *websocket.Conn, n int32) {
 		if n == 1 {
 			// Dropped only after its subscribe succeeded, so the reconnect is the
 			// attempt that gets rejected.
@@ -217,7 +222,7 @@ func TestWatcher_DialFailureAfterFirstSuccessIsAnnounced(t *testing.T) {
 	// subscribe.
 	firstConnOnly := func(attempt int32) bool { return attempt == 1 }
 
-	ts, _, _ := newWatcherTestServer(t, firstConnOnly, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+	ts, _, _ := newWatcherTestServer(t, alwaysCreated, firstConnOnly, alwaysCreated, func(conn *websocket.Conn, _ int32) {
 		_ = conn.Close()
 	})
 
@@ -247,7 +252,7 @@ func TestWatcher_StaleFailureNoticeIsDroppedOnRecovery(t *testing.T) {
 		return http.StatusCreated
 	}
 
-	ts, _, subscribes := newWatcherTestServer(t, alwaysUpgrade, secondOnly, func(conn *websocket.Conn, n int32) {
+	ts, _, subscribes := newWatcherTestServer(t, alwaysCreated, alwaysUpgrade, secondOnly, func(conn *websocket.Conn, n int32) {
 		if n == 1 {
 			_ = conn.Close()
 			return
@@ -315,9 +320,11 @@ func TestWatcher_MalformedWebsocketURLStopsAndSurfaces(t *testing.T) {
 	assert.Contains(t, err.Error(), "malformed event channel URL")
 }
 
-func TestWatcher_SessionCreateFailureStopsAndSurfaces(t *testing.T) {
+func TestWatcher_SessionCreateRejectionStopsAndSurfaces(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"Invalid token."}`))
 	}))
 	defer ts.Close()
 
@@ -329,4 +336,31 @@ func TestWatcher_SessionCreateFailureStopsAndSurfaces(t *testing.T) {
 	assert.False(t, w.WaitConnected(2*time.Second))
 	require.Error(t, w.Err())
 	assert.Contains(t, w.Err().Error(), "failed to create event session")
+}
+
+func TestWatcher_SessionCreateServerErrorIsRetried(t *testing.T) {
+	failFirst := func(attempt int32) int {
+		if attempt == 1 {
+			return http.StatusBadGateway
+		}
+		return http.StatusCreated
+	}
+
+	ts, sessions, _ := newWatcherTestServer(t, failFirst, alwaysUpgrade, alwaysCreated, func(conn *websocket.Conn, _ int32) {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	ac := &client.AlpaconClient{HTTPClient: ts.Client(), BaseURL: ts.URL}
+	w := NewWatcher(ac, "work_session", "ws-uuid")
+	w.reconnectBaseDelay = testReconnectBaseDelay
+	w.Start()
+	defer w.Stop()
+
+	require.True(t, w.WaitConnected(3*time.Second), "a transient session-create failure must be absorbed, not fatal")
+	assert.NoError(t, w.Err())
+	assert.GreaterOrEqual(t, sessions.Load(), int32(2), "the failed attempt must be retried with a new session")
 }

--- a/api/event/wslistener.go
+++ b/api/event/wslistener.go
@@ -17,33 +17,51 @@ const (
 // wsListener is the shared dial/reconnect/shutdown skeleton for event WebSocket
 // consumers; embedders must assign handleFrame before calling Start.
 type wsListener struct {
-	wsURL            string
+	// Event channel tokens are single-use, so a reconnect needs a freshly provisioned URL.
+	provision func() (string, error)
+	// The server accepts a subscription only once the channel is connected.
+	onConnected func() error
+	// A dial error reaches neither provision nor onConnected, so without this an outage
+	// at the transport level is silent.
+	onDialFailed     func(error)
+	handleFrame      func(message []byte)
 	wsHeader         http.Header
 	handshakeTimeout time.Duration
-	handleFrame      func(message []byte)
+	readLimit        int64 // 0 for gorilla's default of no limit
+	// The first backoff step, lowered by tests so a reconnect assertion does not have to
+	// sit through the production delay.
+	reconnectBaseDelay time.Duration
 
 	done        chan struct{}
 	stopped     chan struct{} // closed when listenLoop exits
-	connected   chan struct{} // closed after first successful WebSocket connection
+	connected   chan struct{} // closed after the first successful connect and subscribe
 	connectOnce sync.Once
 	closeOnce   sync.Once
 	mu          sync.Mutex // guards conn
 	conn        *websocket.Conn
 }
 
-// newWSListener builds the shared skeleton. ac may be nil (empty header, for tests).
+// newWSListener builds the skeleton for a listener that always dials the same
+// URL. ac may be nil (empty header, for tests).
 func newWSListener(ac *client.AlpaconClient, wsURL string, handshakeTimeout time.Duration) *wsListener {
+	return newProvisionedWSListener(ac, func() (string, error) { return wsURL, nil }, handshakeTimeout)
+}
+
+// newProvisionedWSListener builds the skeleton for a listener that obtains a new
+// URL for every dial attempt. ac may be nil (empty header, for tests).
+func newProvisionedWSListener(ac *client.AlpaconClient, provision func() (string, error), handshakeTimeout time.Duration) *wsListener {
 	wsHeader := http.Header{}
 	if ac != nil {
 		wsHeader = ac.SetWebsocketHeader()
 	}
 	return &wsListener{
-		wsURL:            wsURL,
-		wsHeader:         wsHeader,
-		handshakeTimeout: handshakeTimeout,
-		done:             make(chan struct{}),
-		stopped:          make(chan struct{}),
-		connected:        make(chan struct{}),
+		provision:          provision,
+		wsHeader:           wsHeader,
+		handshakeTimeout:   handshakeTimeout,
+		reconnectBaseDelay: wsReconnectBaseDelay,
+		done:               make(chan struct{}),
+		stopped:            make(chan struct{}),
+		connected:          make(chan struct{}),
 	}
 }
 
@@ -62,8 +80,8 @@ func (w *wsListener) Start() {
 	}()
 }
 
-// WaitConnected blocks until connected, timeout, or shutdown; returns whether
-// it connected.
+// WaitConnected blocks until connected and subscribed, timeout, or shutdown;
+// returns whether it connected.
 func (w *wsListener) WaitConnected(timeout time.Duration) bool {
 	select {
 	case <-w.connected:
@@ -89,7 +107,7 @@ func (w *wsListener) Stop() {
 }
 
 func (w *wsListener) listenLoop() {
-	delay := wsReconnectBaseDelay
+	delay := w.reconnectBaseDelay
 
 	for {
 		select {
@@ -100,7 +118,7 @@ func (w *wsListener) listenLoop() {
 
 		// Reset backoff if we had a successful connection that later dropped
 		if w.connectAndListen() {
-			delay = wsReconnectBaseDelay
+			delay = w.reconnectBaseDelay
 		}
 
 		select {
@@ -121,20 +139,31 @@ func nextReconnectDelay(delay time.Duration) time.Duration {
 	return delay
 }
 
-// connectAndListen dials the event WebSocket and reads until it drops or Stop
-// is called; returns whether it connected, so the caller can reset backoff.
+// connectAndListen dials the event WebSocket, runs onConnected if set, then reads
+// until the connection drops or Stop is called. Returns whether it connected and
+// subscribed, so the caller can reset backoff.
 func (w *wsListener) connectAndListen() (connected bool) {
-	dialer := websocket.Dialer{HandshakeTimeout: w.handshakeTimeout}
-	conn, _, dialErr := dialer.Dial(w.wsURL, w.wsHeader)
-	if dialErr != nil {
+	wsURL, err := w.provision()
+	if err != nil {
 		return false
+	}
+
+	dialer := websocket.Dialer{HandshakeTimeout: w.handshakeTimeout}
+	conn, _, dialErr := dialer.Dial(wsURL, w.wsHeader)
+	if dialErr != nil {
+		if w.onDialFailed != nil {
+			w.onDialFailed(dialErr)
+		}
+		return false
+	}
+
+	if w.readLimit > 0 {
+		conn.SetReadLimit(w.readLimit)
 	}
 
 	w.mu.Lock()
 	w.conn = conn
 	w.mu.Unlock()
-
-	w.connectOnce.Do(func() { close(w.connected) })
 
 	defer func() {
 		w.mu.Lock()
@@ -142,6 +171,14 @@ func (w *wsListener) connectAndListen() (connected bool) {
 		w.mu.Unlock()
 		_ = conn.Close()
 	}()
+
+	if w.onConnected != nil {
+		if err := w.onConnected(); err != nil {
+			return false
+		}
+	}
+
+	w.connectOnce.Do(func() { close(w.connected) })
 
 	for {
 		select {

--- a/api/event/wslistener_test.go
+++ b/api/event/wslistener_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -8,8 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// testReconnectBaseDelay keeps reconnect assertions off the production 1s backoff.
+const testReconnectBaseDelay = 10 * time.Millisecond
 
 func TestWSListener_StartPanicsWithoutHandleFrame(t *testing.T) {
 	w := newWSListener(nil, "", 0)
@@ -125,4 +131,129 @@ func TestWSListener_WaitConnected_Shutdown(t *testing.T) {
 
 	assert.False(t, result, "should return false when done is closed")
 	assert.Less(t, elapsed, 1*time.Second, "should exit quickly on shutdown")
+}
+
+func TestWSListener_ProvisionCalledPerDialAttempt(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var conns atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		if conns.Add(1) == 1 {
+			// Drop the first connection so the listener has to dial again.
+			_ = conn.Close()
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	var provisions atomic.Int32
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	w := newProvisionedWSListener(nil, func() (string, error) {
+		provisions.Add(1)
+		return wsURL, nil
+	}, time.Second)
+	w.handleFrame = func([]byte) {}
+	w.reconnectBaseDelay = testReconnectBaseDelay
+	w.Start()
+	defer w.Stop()
+
+	require.True(t, w.WaitConnected(2*time.Second))
+
+	// The listener reconnects on its own; wait for the second dial.
+	deadline := time.After(5 * time.Second)
+	for conns.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("expected a reconnect, conns=%d provisions=%d", conns.Load(), provisions.Load())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	assert.GreaterOrEqual(t, provisions.Load(), int32(2), "provision must run once per dial attempt")
+}
+
+func TestWSListener_ProvisionErrorIsAFailedAttempt(t *testing.T) {
+	var provisions atomic.Int32
+
+	w := newProvisionedWSListener(nil, func() (string, error) {
+		provisions.Add(1)
+		return "", errors.New("provision failed")
+	}, time.Second)
+	w.handleFrame = func([]byte) {}
+
+	assert.False(t, w.connectAndListen(), "a provision error must not count as connected")
+	assert.Equal(t, int32(1), provisions.Load())
+	assert.False(t, w.WaitConnected(0), "connected must stay open when provisioning fails")
+}
+
+func TestWSListener_OnConnectedRunsBeforeConnectedCloses(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	// Atomics because the hook runs on the listener goroutine.
+	var hookRan, openDuringHook atomic.Bool
+
+	w := newProvisionedWSListener(nil, func() (string, error) {
+		return "ws" + strings.TrimPrefix(ts.URL, "http"), nil
+	}, time.Second)
+	w.handleFrame = func([]byte) {}
+	w.onConnected = func() error {
+		hookRan.Store(true)
+		openDuringHook.Store(!w.WaitConnected(0))
+		return nil
+	}
+	w.Start()
+	defer w.Stop()
+
+	require.True(t, w.WaitConnected(2*time.Second))
+	assert.True(t, hookRan.Load(), "onConnected must run on a successful dial")
+	assert.True(t, openDuringHook.Load(), "connected must not close before onConnected returns")
+}
+
+func TestWSListener_OnConnectedErrorIsAFailedAttempt(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	w := newProvisionedWSListener(nil, func() (string, error) {
+		return "ws" + strings.TrimPrefix(ts.URL, "http"), nil
+	}, time.Second)
+	w.handleFrame = func([]byte) {}
+	w.onConnected = func() error { return errors.New("subscribe rejected") }
+
+	assert.False(t, w.connectAndListen(), "an onConnected error must not count as connected")
+	assert.False(t, w.WaitConnected(0), "connected must stay open when onConnected fails")
 }

--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -15,7 +15,8 @@ var EventCmd = &cobra.Command{
 This command has moved to 'alpacon exec ls' and will be removed in a future
 release. It still works today and takes the same flags.
 
-The 'event' name is being repurposed for the Alpacon event channel.`,
+The 'event' name is being repurposed for the Alpacon event channel—see
+'alpacon event watch'.`,
 	Example: `  alpacon event
   alpacon event --tail 10 --server my-server --user admin`,
 	// Deprecated is deliberately unused: it makes IsAvailableCommand() false, dropping
@@ -28,7 +29,7 @@ func init() {
 }
 
 func runEvent(cmd *cobra.Command, _ []string) {
-	utils.CliWarning("'alpacon event' has moved to 'alpacon exec ls' and will be removed in a future release.")
+	utils.CliWarning("'alpacon event' has moved to 'alpacon exec ls' and will be removed in a future release. 'alpacon event watch' streams the event channel.")
 
 	exec.RunListFromFlags(cmd)
 }

--- a/cmd/event/render.go
+++ b/cmd/event/render.go
@@ -1,0 +1,84 @@
+package event
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/alpacax/alpacon-cli/utils"
+)
+
+const (
+	watchTimeFormat = "15:04:05"
+	watchFieldEmpty = "-"
+)
+
+// Payload contents differ per event type, so only sub_type is worth reading here.
+type eventFrame struct {
+	EventType string `json:"event_type"`
+	Payload   struct {
+		SubType string `json:"sub_type"`
+	} `json:"payload"`
+}
+
+// Writes nothing at all on failure, so stdout stays parseable. now and target are params
+// because frames carry no common timestamp and target belongs to the subscription.
+func renderEvent(w io.Writer, raw []byte, format, target string, now time.Time) error {
+	if format == utils.OutputFormatJSON {
+		var line bytes.Buffer
+		if err := json.Compact(&line, raw); err != nil {
+			return fmt.Errorf("skipped an unparseable event frame: %w", err)
+		}
+		_, err := fmt.Fprintf(w, "%s\n", line.Bytes())
+		return err
+	}
+
+	var frame eventFrame
+	if err := json.Unmarshal(raw, &frame); err != nil {
+		return fmt.Errorf("skipped an unparseable event frame: %w", err)
+	}
+	// Checked after stripping, which also catches an escape-only value and a bare JSON
+	// null: null unmarshals into the zero struct and would print as a row of dashes.
+	eventType := strip(frame.EventType)
+	if eventType == "" {
+		return errors.New("skipped an event frame carrying no event type")
+	}
+
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+		now.Format(watchTimeFormat),
+		eventType,
+		field(frame.Payload.SubType),
+		field(target),
+	)
+	return err
+}
+
+// A TTY and an agent's log receive this text verbatim. Line breaks and tabs become
+// spaces so a multi-line server error does not glue into one word, and format characters
+// go entirely: a bidi override could render "denied" as "approved".
+func strip(s string) string {
+	spaced := strings.Map(func(r rune) rune {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			return ' '
+		case unicode.Is(unicode.Cf, r):
+			return -1
+		default:
+			return r
+		}
+	}, s)
+	// Trimmed last so a value of only control bytes reads as absent, not as blank data.
+	return strings.TrimSpace(utils.StripControlChars(utils.StripANSIEscapes(spaced)))
+}
+
+func field(s string) string {
+	if stripped := strip(s); stripped != "" {
+		return stripped
+	}
+	return watchFieldEmpty
+}

--- a/cmd/event/render_test.go
+++ b/cmd/event/render_test.go
@@ -1,0 +1,120 @@
+package event
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderEvent_JSONIsOneLinePerFrameAndPreservesUnknownFields(t *testing.T) {
+	raw := []byte("{\n  \"event_type\": \"work_session\",\n  \"payload\": {\n    \"sub_type\": \"approved\",\n    \"brand_new_field\": 7\n  }\n}")
+
+	var buf bytes.Buffer
+	require.NoError(t, renderEvent(&buf, raw, utils.OutputFormatJSON, "ws-uuid", time.Now()))
+
+	out := buf.String()
+	assert.Equal(t, 1, bytes.Count([]byte(out), []byte("\n")), "one frame must produce exactly one line")
+	assert.JSONEq(t, string(raw), out)
+	assert.Contains(t, out, `"brand_new_field":7`, "a field the CLI does not know must survive")
+
+	// The assertions above are order-insensitive and would pass an unmarshal-into-map
+	// regression that alphabetizes keys; this one would not.
+	var want bytes.Buffer
+	require.NoError(t, json.Compact(&want, raw))
+	assert.Equal(t, want.String()+"\n", out, "JSON output must be an exact byte-for-byte compaction of raw, key order included")
+}
+
+func TestRenderEvent_TableHasFourFixedFields(t *testing.T) {
+	now := time.Date(2026, 7, 29, 13, 4, 5, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		raw    string
+		target string
+		want   string
+	}{
+		{
+			name:   "work session status event",
+			raw:    `{"event_type":"work_session","payload":{"category":"status","sub_type":"approved"}}`,
+			target: "ws-uuid",
+			want:   "13:04:05\twork_session\tapproved\tws-uuid\n",
+		},
+		{
+			name:   "payload without sub_type",
+			raw:    `{"event_type":"command_output","payload":{"command_id":"cmd","seq":0,"content":"x"}}`,
+			target: "cmd",
+			want:   "13:04:05\tcommand_output\t-\tcmd\n",
+		},
+		{
+			name:   "no target given",
+			raw:    `{"event_type":"notification","payload":{"sub_type":"created"}}`,
+			target: "",
+			want:   "13:04:05\tnotification\tcreated\t-\n",
+		},
+		{
+			name:   "empty payload",
+			raw:    `{"event_type":"servers_commit","payload":{}}`,
+			target: "",
+			want:   "13:04:05\tservers_commit\t-\t-\n",
+		},
+		{
+			name:   "format characters go and line breaks become spaces",
+			raw:    `{"event_type":"work_session","payload":{"sub_type":"appro\u202eved\nnext"}}`,
+			target: "ws-uuid",
+			want:   "13:04:05\twork_session\tapproved next\tws-uuid\n",
+		},
+		{
+			// The JSON escapes decode to a real ESC, tab, and BEL.
+			name:   "escapes and control bytes are stripped from server fields",
+			raw:    `{"event_type":"work_\u001b[31msession","payload":{"sub_type":"appro\tved\u0007"}}`,
+			target: "ws-uuid",
+			want:   "13:04:05\twork_session\tappro ved\tws-uuid\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			require.NoError(t, renderEvent(&buf, []byte(tt.raw), utils.OutputFormatTable, tt.target, now))
+			assert.Equal(t, tt.want, buf.String())
+		})
+	}
+}
+
+func TestRenderEvent_InvalidJSONWritesNothing(t *testing.T) {
+	for _, format := range []string{utils.OutputFormatTable, utils.OutputFormatJSON} {
+		t.Run(format, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := renderEvent(&buf, []byte("not json at all"), format, "ws-uuid", time.Now())
+
+			require.Error(t, err)
+			// stdout must stay parseable, which is the whole point of the command.
+			assert.Empty(t, buf.String())
+		})
+	}
+}
+
+// A bare JSON null unmarshals into the zero struct without error, so without the check
+// the table path would print it as a legitimate-looking row of dashes.
+func TestRenderEvent_TableRejectsAFrameWithNoEventType(t *testing.T) {
+	// The escape-only case pins that the check runs after stripping, not before.
+	for _, raw := range []string{
+		`null`,
+		`{"payload":{"sub_type":"approved"}}`,
+		`{"event_type":"\u001b[31m","payload":{}}`,
+		`{"event_type":"\n","payload":{}}`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := renderEvent(&buf, []byte(raw), utils.OutputFormatTable, "ws-uuid", time.Now())
+
+			require.Error(t, err)
+			assert.Empty(t, buf.String())
+		})
+	}
+}

--- a/cmd/event/watch.go
+++ b/cmd/event/watch.go
@@ -1,0 +1,92 @@
+package event
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	eventapi "github.com/alpacax/alpacon-cli/api/event"
+	"github.com/alpacax/alpacon-cli/client"
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+// Covers one dial (watchHandshakeTimeout in api/event) plus the subscribe that follows.
+const watchConnectTimeout = 15 * time.Second
+
+var watchCmd = &cobra.Command{
+	Use:   "watch --type TYPE [--target ID] [flags]",
+	Short: "Stream events from the Alpacon event channel",
+	Long: `Stream events from the Alpacon event channel until interrupted.
+
+One line is written to stdout per event; everything else goes to stderr, so the
+stream stays machine-readable when piped. With --output json each line is the
+server frame verbatim (NDJSON). The default table format prints four fixed
+fields: receive time, event type, sub type, and the target given by --target.
+
+The connection is re-established automatically. Events published while
+disconnected are lost—the event channel has no history to replay—and both
+reconnects and failing reconnects are reported on stderr.
+
+Run 'alpacon work-session ls' or the Alpacon console to find a target ID.`,
+	Example: `  alpacon event watch --type work_session --target a1b2c3d4-5678-abcd-ef01-234567890abc
+  alpacon event watch --type work_session --target a1b2c3d4-5678-abcd-ef01-234567890abc --output json
+  alpacon event watch --type notification`,
+	Args: cobra.NoArgs,
+	Run:  runWatch,
+}
+
+func init() {
+	watchCmd.Flags().String("type", "", "Event type to subscribe to, e.g. work_session or notification (required)")
+	watchCmd.Flags().String("target", "", "Target resource ID; omit where the server allows a subscription without one")
+
+	EventCmd.AddCommand(watchCmd)
+}
+
+func runWatch(cmd *cobra.Command, _ []string) {
+	eventType, _ := cmd.Flags().GetString("type")
+	target, _ := cmd.Flags().GetString("target")
+
+	if eventType == "" {
+		utils.CliErrorWithExit("--type is required.")
+	}
+
+	alpaconClient, err := client.NewAlpaconAPIClient()
+	if err != nil {
+		utils.CliErrorWithExit("Connection to Alpacon API failed: %s. Consider re-logging.", err)
+	}
+
+	watcher := eventapi.NewWatcher(alpaconClient, eventapi.EventType(eventType), target)
+	watcher.Start()
+	defer watcher.Stop()
+
+	if !watcher.WaitConnected(watchConnectTimeout) {
+		// A rejected subscription is not retried, so its message is the useful one.
+		// Stripped because the server wrote it and it lands in a terminal.
+		if subErr := watcher.Err(); subErr != nil {
+			utils.CliErrorWithExit("%s.", strip(subErr.Error()))
+		}
+		utils.CliErrorWithExit("Timed out connecting to the event channel after %s.", watchConnectTimeout)
+	}
+
+	utils.CliInfo("Watching %s events. Press Ctrl+C to stop.", eventType)
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	for {
+		select {
+		case <-sigChan:
+			return
+		case <-watcher.Reconnected():
+			utils.CliWarning("Reconnected to the event channel. Events published while disconnected were not delivered.")
+		case failErr := <-watcher.ReconnectFailed():
+			utils.CliWarning("Lost the event channel and still reconnecting: %s. No events are being delivered until it recovers.", strip(failErr.Error()))
+		case frame := <-watcher.Frames():
+			if err := renderEvent(os.Stdout, frame, utils.OutputFormat, target, time.Now()); err != nil {
+				utils.CliWarning("%s.", err)
+			}
+		}
+	}
+}

--- a/cmd/event/watch.go
+++ b/cmd/event/watch.go
@@ -16,14 +16,16 @@ import (
 const watchConnectTimeout = 15 * time.Second
 
 var watchCmd = &cobra.Command{
-	Use:   "watch --type TYPE [--target ID] [flags]",
+	Use:   "watch --type TYPE [--target TARGET_ID]",
 	Short: "Stream events from the Alpacon event channel",
 	Long: `Stream events from the Alpacon event channel until interrupted.
 
 One line is written to stdout per event; everything else goes to stderr, so the
 stream stays machine-readable when piped. With --output json each line is the
-server frame verbatim (NDJSON). The default table format prints four fixed
-fields: receive time, event type, sub type, and the target given by --target.
+server frame compacted to a single line (NDJSON)—whitespace is dropped, but
+every field and the server's key order survive, including fields this CLI does
+not know. The default table format prints four fixed fields: receive time,
+event type, sub type, and the target given by --target.
 
 The connection is re-established automatically. Events published while
 disconnected are lost—the event channel has no history to replay—and both

--- a/cmd/event/watch.go
+++ b/cmd/event/watch.go
@@ -76,6 +76,8 @@ func runWatch(cmd *cobra.Command, _ []string) {
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	// Runs before watcher.Stop, so a second Ctrl+C still kills a hung teardown.
+	defer signal.Stop(sigChan)
 
 	for {
 		select {

--- a/cmd/event/watch.go
+++ b/cmd/event/watch.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Covers one dial (watchHandshakeTimeout in api/event) plus the subscribe that follows.
+// Covers one provision + dial (watchHandshakeTimeout in api/event) plus the subscribe.
 const watchConnectTimeout = 15 * time.Second
 
 var watchCmd = &cobra.Command{


### PR DESCRIPTION
## Background

Half of the push-based notification #271 asks for, built on PR1 #287, PR2 #289, and PR3 #290.

The open question this PR had to settle first — event session expiry — changed its scope. An event channel token cannot be reused: the event server's check requires `opened_at IS NULL`, and since alpacon-server #2760 the token also carries a 60s TTL stamped at creation. The existing `wsListener` re-dialed that dead URL silently on a 30s backoff forever. Since a watch is meant to stay up for hours, a reconnect there means creating a new session and re-subscribing, so the command and that reprovisioning logic land together.

## What changed

| Commit | Change |
| --- | --- |
| `f277a01` | `provision` / `onConnected` / `onDialFailed` hooks and `readLimit` / `reconnectBaseDelay` fields on `wsListener` |
| `b3428e6` | `omitempty` on `EventSubscriptionRequest.TargetID` |
| `3619368` | `Watcher` — provisions a session per attempt, re-subscribes once connected |
| `2a7c9e8` | `renderEvent` — one line per frame |
| `2d05ddd` | `alpacon event watch`, and the deprecated `event` notice now points at it |
| `a5236e5` | review follow-up: usage line and the `--output json` help wording |
| `5a7087d` | review follow-up: `defer signal.Stop` on the watch signal channel |
| `30e1560` | review follow-up: a transient session-create failure retries instead of ending the command |
| `a64419e` | review follow-up: name the provision step in the connect-timeout comment |
| `671d4bf` | review follow-up: 408 and 429 leave the fatal session-create band |
| `f06bcad` | review follow-up: the test session-create failure body names its own status |

`--type` is required and is not validated locally: the server owns the type set, and PR3 pinned that a type the CLI has no constant for must still work. With `--output json` each line is the server frame compacted to a single line (NDJSON) — insignificant whitespace is dropped, but every field and the server's key order survive, including fields the CLI has no constant for; the table default prints four fixed fields — receive time, event type, sub type, and the target. stdout carries event lines only, everything else goes to stderr. `utils.PrintTable` is deliberately unused: it pages through `WriteToPager` and assumes a whole dataset.

`watch` does not interpret event types and stays up until SIGINT or SIGTERM. Terminal-state detection and the exit-code contract belong to PR5 (`wait`) and #253; this PR uses only 0 and 1. Per-decision rationale lives in each commit's Lore trailers.

## Safety

Server-supplied text reaches a TTY and an agent's log verbatim. Both frame fields and server error messages are stripped of ANSI escapes, control bytes, and Unicode format characters, and line breaks and tabs become spaces. A bidi override could otherwise render `denied` as `approved`, and a deleted newline would glue two server sentences into one word.

The WebSocket URL from the session response is validated with `url.Parse` before the dialer sees it. Letting the dialer fail on it yields a `*url.Error` that quotes the whole URL, and that URL carries a token that has not been consumed yet. Frames are capped at 1 MiB.

The `--output json` path is deliberately not sanitized, so C1 and DEL bytes pass through. That mode exists for lossless delivery to a machine consumer.

## Behavior changes

`connected` now closes after `onConnected` returns nil rather than right after the dial, so `WaitConnected` means connected and subscribed. The two existing listeners leave `onConnected` nil and are unaffected.

A failure before any successful subscribe is fatal: the watcher stops and exits 1 with the server's own message. Session creation is the exception, split by status — the request body is empty, so it cannot carry a caller mistake, and only a 4xx other than 408 and 429 proves retrying pointless. A 5xx, a 408, a 429, or a network error retries inside the connect window like a dial failure does. Failures after a first success are ordinary reconnect material, with the first failure of each outage announced once.

## Tests

```
gofmt -l .                                                     no output
go vet ./...                                                   pass
golangci-lint run ./...                                        0 issues
go test -race ./...                                            all packages pass
go test -race -shuffle=on -count=2 ./api/event/ ./cmd/event/    pass
```

Each of the eleven commits builds and vets independently in a throwaway worktree.

A review round found that `watch` called `signal.Notify` without a matching `signal.Stop`, unlike `cmd/tunnel/run.go:93` and `cmd/tunnel/tunnel.go:141`. Fixed in `5a7087d`. `api/websh/websh.go:220` has the same gap plus a `sigChan` goroutine that outlives the call, but it is not touched here — websh holds the terminal in raw mode, so changing its signal path needs its own verification.

Review also flagged that a pre-subscribe session-create failure was fatal while a dial failure in the same window was retried. Fixed in `30e1560`. `TestWatcher_SessionCreateFailureStopsAndSurfaces` asserted the old behavior on a 500 and would have kept passing for the wrong reason, so it was re-pointed at a 401 and joined by a retryable-status case. One consequence is left as is: a persistent 5xx now reports the connect timeout rather than the server's message, matching how a persistent pre-subscribe dial failure already behaves.

A follow-up round flagged that the resulting fatal band swallowed 408 and 429, the two 4xx that ask to be retried. Fixed in `671d4bf`, with the retryable case now table-driven over 502, 408, and 429 — the two new rows fail without the fix, so they are not passing for the wrong reason. `api/ftp/ftp.go:550` returns on any 4xx in the same way inside `cp`'s download retry loop. It is pre-existing and untouched here, and it needs more than the same two constants: `maxAttempts` reaches `fetchFromURLToFile` as 100 from `api/ftp/ftp.go:726` with a flat `time.Sleep(time.Second)`, so making 429 retryable there without changing the schedule would send 100 requests one second apart at a server that just asked for fewer. The event path is bounded instead by a doubling backoff under the 15s connect ceiling. That fix wants its own PR, with the backoff first.

Verified end to end against a local native stack — alpacon-server main `11e63ad9c` on :8000, event-server on :8082, backhaul-server, proxy-server, alpamon, Postgres 16, Redis:

- `notification` in table mode: `10:47:37	notification	probe	-`
- `work_session` in NDJSON: completing a session delivered `sub_type=completed` with `previous_status=active` and the full status payload
- `command_output` in NDJSON: `seq=0`, `content="hello-from-exec\n"`
- NDJSON is exactly one line per frame and preserves fields the CLI does not know
- Ctrl+C exits 0. A nonexistent target, an unknown `--type`, and a missing required target exit 1 immediately with `work_session_not_found`, `invalid_choice`, and `invalid_input` respectively, with no retry
- The channel row showed `token_created_at` plus a 60s TTL with `opened_at` set, confirming the token cannot be reused
- Killing and restarting the event server produced exactly one outage warning and one recovery warning, a new session row per attempt, and delivery resumed. The dial error carried only host:port, so no token leaked

Four types were not observed: `servers_commit` only fires on the first commit of a server that is not yet commissioned (`servers/api/views.py:299`), `sudo` runs inside websh's interactive MFA flow, and the four `cloud_*` types need a cloud account and a celery worker — the area #271 explicitly defers. `command_fin` and `command_reject` have no publisher in server code at all and exist only in the enum. Subscribing succeeds in every one of those cases.

## Known limitations

Once a work session reaches a terminal state the server deletes the subscription (`work_sessions/services.py:765`), so `watch` goes quiet rather than exiting. Events published while disconnected are lost, and if stdout stalls for over 60s the pong lapses and the connection is re-established.

`SudoListener` and `CommandOutputListener` stay on the static-URL constructor, so after a drop they re-dial a URL whose token can no longer be used and retry every 30s until `Stop`. Both were traced rather than assumed:

- `command_output` is covered. `streamSubscribed` runs a REST poller alongside the WebSocket, drains the remaining chunks over REST when the command finishes, and calls `Stop` there, so no output is lost and the retry loop is bounded by the command's lifetime. The only cost is that output during an outage arrives in a burst at the end.
- `sudo` has no equivalent fallback. The MFA request reaches the CLI only as a pushed event, and websh keeps the listener for the whole terminal session, so a drop mid-session means later `sudo` prompts never appear.

Neither is addressed here. Moving them onto provisioners changes websh and exec at runtime and needs its own verification, and the `sudo` case has not been reported in practice — so this is deliberately deferred and will be fixed if it comes up. Note commit `f277a01`'s `Directive` trailer calls it a follow-up, which predates this decision.

## Follow-ups

The server never deletes `EventSession` or `EventUserChannel` rows — there is no reaper, and DELETE only sets `closed_at` — so a long watch accumulates rows. That cannot be fixed in the CLI. Extending `utils.StripControlChars` to cover Cf runes would give websh and worksession rendering the same protection. Host validation on the server-supplied URL is pre-existing behavior, but this change exercises it in a permanent reconnect loop, which raises its priority.

Refs #271

## Checklist

- [x] `go test -race ./...` passes, golangci-lint reports 0 issues
- [x] Each of the eleven commits builds independently
- [x] Three event types received against a live local stack, with reconnect and exit codes measured
- [x] stdout/stderr separation and flag isolation confirmed on the binary

