### PR TITLE
fix(websh): disarm the interrupt handler when the read-only terminal ends

### DIFF
--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -218,6 +218,9 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	// Runs before the terminal restore and the close below, so a second Ctrl+C reaches
+	// the default disposition instead of the goroutine that already consumed the first.
+	defer signal.Stop(sigChan)
 	go func() {
 		<-sigChan
 		select {


### PR DESCRIPTION
## Background

`OpenReadOnlyTerminal` (`api/websh/websh.go:200`) backs `alpacon websh watch`. It arms `os.Interrupt` and `SIGTERM` with `signal.Notify` and never stops them.

This is the only `signal.Notify` in the repo without a matching `signal.Stop`. The five other sites — `cmd/tunnel/tunnel.go:142`, `cmd/tunnel/run.go:94`, `cmd/event/watch.go:80`, and both in `cmd/event/wait.go` — already pair them.

## Changes

Added `defer signal.Stop(sigChan)` immediately after the `Notify`.

The goroutine watching the channel does `<-sigChan` once and returns, so after the first Ctrl+C nothing is reading it. With the handler still armed, a second Ctrl+C lands in the buffered channel and is dropped rather than reaching the default terminate disposition — the user cannot interrupt the terminal restore and websocket close that follow.

Placement matters: the defer is registered after the `conn.Close` and `term.Restore` defers, so LIFO runs it first. Disarming after the teardown it protects would accomplish nothing.

Not using the goroutine-side `signal.Stop` shape from `cmd/event/wait.go:96` — that exists there because every exit path goes through `os.Exit`, which skips defers. This function returns normally.

## Testing

`go build ./...`, `go vet ./...`, `gofmt` clean. `go test -race ./api/websh/... ./cmd/websh/...` passes.

Signal handling in this function is not unit-testable without restructuring it, so there is no new test. The change is verified by reading the exit paths, not by execution.

## Checklist

- [x] Builds, vets, formats clean
- [x] Existing tests pass
- [ ] No test covers the behavior — see above