### PR TITLE
fix(ftp): retry a throttled download and back the retries off

### DIFF
--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -49,7 +49,7 @@ const (
 // backoffDelay returns initial doubled once per 0-based attempt, capped at limit.
 func backoffDelay(attempt int, initial, limit time.Duration) time.Duration {
 	d := initial
-	for i := 0; i < attempt; i++ {
+	for range attempt {
 		d *= pollBackoffFactor
 		if d >= limit {
 			return limit

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -31,25 +31,37 @@ const (
 	initialPollInterval = 250 * time.Millisecond
 	maxPollInterval     = 2 * time.Second
 	pollBackoffFactor   = 2
-	basePollTimeout     = 30 * time.Second
-	perFilePollTimeout  = 10 * time.Second
-	perMBPollTimeout    = 5 * time.Second
+
+	// Download retries back off to maxDownloadRetryDelay, chosen so the total wait over
+	// maxAttempts stays what the flat one-second retry gave while a brief blip recovers
+	// sooner.
+	initialDownloadRetryDelay = 250 * time.Millisecond
+	maxDownloadRetryDelay     = time.Second
+
+	basePollTimeout    = 30 * time.Second
+	perFilePollTimeout = 10 * time.Second
+	perMBPollTimeout   = 5 * time.Second
 
 	bulkUploadConcurrency = 4 // uploads transfer payload bytes, keep low
 	bulkPollConcurrency   = 8 // status polls are lightweight, allow more
 )
 
-// nextPollInterval returns the backoff delay for a 0-based poll attempt:
-// initialPollInterval doubled per attempt, capped at maxPollInterval.
-func nextPollInterval(attempt int) time.Duration {
-	d := initialPollInterval
+// backoffDelay returns initial doubled once per 0-based attempt, capped at limit.
+func backoffDelay(attempt int, initial, limit time.Duration) time.Duration {
+	d := initial
 	for i := 0; i < attempt; i++ {
 		d *= pollBackoffFactor
-		if d >= maxPollInterval {
-			return maxPollInterval
+		if d >= limit {
+			return limit
 		}
 	}
 	return d
+}
+
+// nextPollInterval returns the backoff delay for a 0-based poll attempt:
+// initialPollInterval doubled per attempt, capped at maxPollInterval.
+func nextPollInterval(attempt int) time.Duration {
+	return backoffDelay(attempt, initialPollInterval, maxPollInterval)
 }
 
 // alignedPollDelay returns the sleep before the next poll: the backoff for this
@@ -546,15 +558,17 @@ func fetchFromURLToFile(httpClient *http.Client, url, filePath string, maxAttemp
 		}
 		_ = resp.Body.Close()
 
-		// Client errors (4xx) will never succeed on retry
-		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		// Client errors (4xx) will never succeed on retry—except 408 and 429, which ask
+		// for exactly that. A throttled download otherwise fails on the first 429.
+		retryLater := resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests
+		if !retryLater && resp.StatusCode >= 400 && resp.StatusCode < 500 {
 			return 0, fmt.Errorf("download failed with client error: %d", resp.StatusCode)
 		}
 
 		if count == maxAttempts-1 {
 			return 0, fmt.Errorf("download failed after %d attempts (last status: %d)", maxAttempts, resp.StatusCode)
 		}
-		time.Sleep(time.Second)
+		time.Sleep(backoffDelay(count, initialDownloadRetryDelay, maxDownloadRetryDelay))
 	}
 
 	defer func() { _ = resp.Body.Close() }()

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1399,9 +1399,9 @@ func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var calls int32
+			var calls atomic.Int32
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				if atomic.AddInt32(&calls, 1) == 1 {
+				if calls.Add(1) == 1 {
 					w.WriteHeader(tt.firstStatus)
 					return
 				}
@@ -1414,15 +1414,15 @@ func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, int64(len("payload")), written)
-			assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "the status asks for a retry")
+			assert.Equal(t, int32(2), calls.Load(), "the status asks for a retry")
 		})
 	}
 }
 
 func TestFetchFromURLToFile_GivesUpOnAFatalClientError(t *testing.T) {
-	var calls int32
+	var calls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&calls, 1)
+		calls.Add(1)
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer ts.Close()
@@ -1431,7 +1431,7 @@ func TestFetchFromURLToFile_GivesUpOnAFatalClientError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "client error: 404")
-	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a 404 will be a 404 again")
+	assert.Equal(t, int32(1), calls.Load(), "a 404 will be a 404 again")
 }
 
 func TestBackoffDelay(t *testing.T) {

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1387,3 +1387,66 @@ func TestPollTransferStatus_TimesOut(t *testing.T) {
 	assert.False(t, success)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
 }
+
+func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		firstStatus int
+	}{
+		{name: "request timeout", firstStatus: http.StatusRequestTimeout},
+		{name: "too many requests", firstStatus: http.StatusTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if atomic.AddInt32(&calls, 1) == 1 {
+					w.WriteHeader(tt.firstStatus)
+					return
+				}
+				_, _ = w.Write([]byte("payload"))
+			}))
+			defer ts.Close()
+
+			path := filepath.Join(t.TempDir(), "out")
+			written, err := fetchFromURLToFile(ts.Client(), ts.URL, path, 3)
+
+			require.NoError(t, err)
+			assert.Equal(t, int64(len("payload")), written)
+			assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "the status asks for a retry")
+		})
+	}
+}
+
+func TestFetchFromURLToFile_GivesUpOnAFatalClientError(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	_, err := fetchFromURLToFile(ts.Client(), ts.URL, filepath.Join(t.TempDir(), "out"), 5)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client error: 404")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a 404 will be a 404 again")
+}
+
+func TestBackoffDelay(t *testing.T) {
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{attempt: 0, want: 250 * time.Millisecond},
+		{attempt: 1, want: 500 * time.Millisecond},
+		{attempt: 2, want: time.Second},
+		{attempt: 3, want: time.Second},
+		{attempt: 50, want: time.Second},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, backoffDelay(tt.attempt, initialDownloadRetryDelay, maxDownloadRetryDelay))
+	}
+}


### PR DESCRIPTION
## Background

`fetchFromURLToFile` (`api/ftp/ftp.go`) fetches the presigned download URL for `alpacon cp` and the bulk archive path. It rejected the whole 4xx range as unretryable:

```go
// Client errors (4xx) will never succeed on retry
if resp.StatusCode >= 400 && resp.StatusCode < 500 {
    return 0, fmt.Errorf("download failed with client error: %d", resp.StatusCode)
}
```

408 and 429 are the two that ask for exactly the retry this refuses. A throttled download fails on the first 429 rather than waiting it out. This is the same band `671d4bf` settled for the event session create; the download path was not updated with it.

The retry delay was also a flat `time.Sleep(time.Second)`, which is not a backoff — it hits a struggling server at a fixed rate regardless of how long it has been failing.

## Changes

408 and 429 now take the retry path. Every other 4xx still returns immediately.

The delay is exponential: 250ms, 500ms, then capped at one second. Both call sites pass `maxAttempts=100`, so the cap has to stay at one second or the worst-case total wait doubles — this keeps it where it was while letting a brief blip recover in a quarter of the time.

The shape already existed in this file as `nextPollInterval`. Extracted it as `backoffDelay(attempt, initial, limit)` and made `nextPollInterval` call it, rather than writing a second copy that differed only in two constants. `nextPollInterval` and `alignedPollDelay` behavior is unchanged, and their existing tests still pass.

## Not addressed

`Retry-After` is ignored. Honoring it means threading a header through a function that currently only sees the status, and no server path emits it today. Worth doing if a proxy or WAF starts setting it.

## Testing

`go build ./...`, `go vet ./...`, `gofmt` clean. `go test -race ./api/ftp/...` passes.

New tests against `httptest`:

- 408-then-200 and 429-then-200 both succeed on the second attempt
- 404 fails after exactly one request
- `backoffDelay` ramp and saturation

## Checklist

- [x] Builds, vets, formats clean
- [x] New behavior covered by tests
- [x] Existing poll-interval tests unaffected