### PR TITLE
fix(ftp): retry a throttled download and back the retries off

### DIFF
--- a/api/event/watcher.go
+++ b/api/event/watcher.go
@@ -3,7 +3,6 @@ package event
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"sync"
 	"time"
@@ -85,14 +84,10 @@ func (w *Watcher) Err() error {
 	return w.err
 }
 
-// The session request carries neither --type nor --target, so only a 4xx proves retrying
-// pointless—except 408 and 429, which ask for exactly that. Anything else gets the retry
-// window a dial failure already gets.
+// The session request carries neither --type nor --target, so only a fatal 4xx proves
+// retrying pointless. Anything else gets the retry window a dial failure already gets.
 func (w *Watcher) sessionCreateFailed(cause error) error {
-	status := utils.HTTPStatusCode(cause)
-	retryLater := status == http.StatusRequestTimeout || status == http.StatusTooManyRequests
-
-	if !retryLater && status >= http.StatusBadRequest && status < http.StatusInternalServerError {
+	if utils.IsFatalClientError(utils.HTTPStatusCode(cause)) {
 		return w.fail(cause)
 	}
 

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -33,11 +33,7 @@ const (
 	initialPollInterval = 250 * time.Millisecond
 	maxPollInterval     = 2 * time.Second
 
-	// A brief blip recovers sooner than the flat one-second retry did, while
-	// downloadMaxAttempts still spans roughly the same ~99s.
-	initialDownloadRetryDelay = 250 * time.Millisecond
-	maxDownloadRetryDelay     = time.Second
-	downloadMaxAttempts       = 100
+	downloadMaxAttempts = 100
 
 	// A server that answered "too many requests" is not persuaded by more of them,
 	// and without Retry-After the window is a guess—so this errs small.
@@ -53,6 +49,14 @@ const (
 
 	bulkUploadConcurrency = 4 // uploads transfer payload bytes, keep low
 	bulkPollConcurrency   = 8 // status polls are lightweight, allow more
+)
+
+// A brief blip recovers sooner than the flat one-second retry did, while
+// downloadMaxAttempts still spans roughly the same ~99s.
+// var, not const, so tests can shorten them.
+var (
+	initialDownloadRetryDelay = 250 * time.Millisecond
+	maxDownloadRetryDelay     = time.Second
 )
 
 // backoffDelay returns initial doubled once per 0-based attempt, capped at limit.

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -565,10 +565,7 @@ func fetchFromURLToFile(httpClient *http.Client, url, filePath string, maxAttemp
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxDrainedErrorBody))
 		_ = resp.Body.Close()
 
-		// Client errors (4xx) will never succeed on retry—except 408 and 429, which ask
-		// for exactly that.
-		retryLater := resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests
-		if !retryLater && resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusInternalServerError {
+		if utils.IsFatalClientError(resp.StatusCode) {
 			return 0, fmt.Errorf("download failed with client error: %d", resp.StatusCode)
 		}
 

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -570,7 +570,7 @@ func fetchFromURLToFile(httpClient *http.Client, url, filePath string, maxAttemp
 		// Client errors (4xx) will never succeed on retry—except 408 and 429, which ask
 		// for exactly that. A throttled download otherwise fails on the first 429.
 		retryLater := resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests
-		if !retryLater && resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		if !retryLater && resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusInternalServerError {
 			return 0, fmt.Errorf("download failed with client error: %d", resp.StatusCode)
 		}
 

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -49,7 +49,7 @@ const (
 // backoffDelay returns initial doubled once per 0-based attempt, capped at limit.
 func backoffDelay(attempt int, initial, limit time.Duration) time.Duration {
 	d := initial
-	for i := 0; i < attempt; i++ {
+	for range attempt {
 		d *= pollBackoffFactor
 		if d >= limit {
 			return limit

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -578,7 +578,7 @@ func fetchFromURLToFile(httpClient *http.Client, url, filePath string, maxAttemp
 			budget = min(budget, throttledMaxAttempts)
 		}
 		if count >= budget-1 {
-			return 0, fmt.Errorf("download failed after %d attempts (last status: %d)", budget, resp.StatusCode)
+			return 0, fmt.Errorf("download failed after %d attempts (last status: %d)", count+1, resp.StatusCode)
 		}
 		time.Sleep(backoffDelay(count, initialDownloadRetryDelay, maxDownloadRetryDelay))
 	}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -40,6 +40,10 @@ const (
 	initialDownloadRetryDelay = 250 * time.Millisecond
 	maxDownloadRetryDelay     = time.Second
 
+	// Cap on the error body drained before a retry, so a keep-alive connection can be
+	// reused without reading an unbounded body from a failing server.
+	maxDrainedErrorBody = 64 << 10
+
 	basePollTimeout    = 30 * time.Second
 	perFilePollTimeout = 10 * time.Second
 	perMBPollTimeout   = 5 * time.Second
@@ -558,6 +562,9 @@ func fetchFromURLToFile(httpClient *http.Client, url, filePath string, maxAttemp
 		if resp.StatusCode == http.StatusOK {
 			break
 		}
+		// Drain before closing: an unread body keeps net/http from reusing the
+		// connection, so every retry would open a new one.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxDrainedErrorBody))
 		_ = resp.Body.Close()
 
 		// Client errors (4xx) will never succeed on retry—except 408 and 429, which ask

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -206,7 +206,7 @@ func collectConcurrentFailures(count, limit int, fn func(int) string) []string {
 	failuresByIndex := make([]string, count)
 	sem := make(chan struct{}, limit)
 	var wg sync.WaitGroup
-	for i := 0; i < count; i++ {
+	for i := range count {
 		sem <- struct{}{}
 		wg.Add(1)
 		go func(index int) {
@@ -374,7 +374,7 @@ func UploadFile(ac *client.AlpaconClient, src []string, dest, username, groupnam
 	for i, filePath := range src {
 		f, err := os.Open(filePath)
 		if err != nil {
-			for j := 0; j < i; j++ {
+			for j := range i {
 				_ = files[j].Close()
 			}
 			return err
@@ -382,7 +382,7 @@ func UploadFile(ac *client.AlpaconClient, src []string, dest, username, groupnam
 		stat, err := f.Stat()
 		if err != nil {
 			_ = f.Close()
-			for j := 0; j < i; j++ {
+			for j := range i {
 				_ = files[j].Close()
 			}
 			return err
@@ -553,7 +553,7 @@ func fetchFromURLToFile(httpClient *http.Client, url, filePath string, maxAttemp
 	var resp *http.Response
 	var err error
 
-	for count := 0; count < maxAttempts; count++ {
+	for count := range maxAttempts {
 		resp, err = httpClient.Get(url)
 		if err != nil {
 			return 0, fmt.Errorf("network error while downloading: %w", err)

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -27,21 +27,19 @@ const (
 	downloadBulkAPIURL   = "/api/webftp/downloads/bulk/"
 	downloadStatusURL    = "/api/webftp/downloads/%s/status/"
 
-	// Shared by the poll interval and the download retry delay.
 	backoffFactor = 2
 
 	// Poll interval backs off exponentially up to maxPollInterval.
 	initialPollInterval = 250 * time.Millisecond
 	maxPollInterval     = 2 * time.Second
 
-	// Download retries back off to maxDownloadRetryDelay, so a brief blip recovers sooner
-	// while the 100-attempt ceiling still spans roughly the ~99s the flat one-second retry
-	// took.
+	// A brief blip recovers sooner than the flat one-second retry did, while the
+	// 100-attempt ceiling still spans roughly the same ~99s.
 	initialDownloadRetryDelay = 250 * time.Millisecond
 	maxDownloadRetryDelay     = time.Second
 
-	// Cap on the error body drained before a retry, so a keep-alive connection can be
-	// reused without reading an unbounded body from a failing server.
+	// Bounded so a keep-alive connection can be reused without reading an unbounded
+	// body from a failing server.
 	maxDrainedErrorBody = 64 << 10
 
 	basePollTimeout    = 30 * time.Second
@@ -54,7 +52,7 @@ const (
 
 // backoffDelay returns initial doubled once per 0-based attempt, capped at limit.
 func backoffDelay(attempt int, initial, limit time.Duration) time.Duration {
-	d := initial
+	d := min(initial, limit)
 	for range attempt {
 		d *= backoffFactor
 		if d >= limit {
@@ -64,8 +62,7 @@ func backoffDelay(attempt int, initial, limit time.Duration) time.Duration {
 	return d
 }
 
-// nextPollInterval returns the backoff delay for a 0-based poll attempt:
-// initialPollInterval doubled per attempt, capped at maxPollInterval.
+// nextPollInterval returns the backoff delay for a 0-based poll attempt.
 func nextPollInterval(attempt int) time.Duration {
 	return backoffDelay(attempt, initialPollInterval, maxPollInterval)
 }
@@ -562,13 +559,13 @@ func fetchFromURLToFile(httpClient *http.Client, url, filePath string, maxAttemp
 		if resp.StatusCode == http.StatusOK {
 			break
 		}
-		// Drain before closing: an unread body keeps net/http from reusing the
-		// connection, so every retry would open a new one.
+		// An unread body keeps net/http from reusing the connection, so every retry
+		// would open a new one.
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxDrainedErrorBody))
 		_ = resp.Body.Close()
 
 		// Client errors (4xx) will never succeed on retry—except 408 and 429, which ask
-		// for exactly that. A throttled download otherwise fails on the first 429.
+		// for exactly that.
 		retryLater := resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests
 		if !retryLater && resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusInternalServerError {
 			return 0, fmt.Errorf("download failed with client error: %d", resp.StatusCode)

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -34,9 +34,10 @@ const (
 	maxPollInterval     = 2 * time.Second
 
 	// A brief blip recovers sooner than the flat one-second retry did, while the
-	// 100-attempt ceiling still spans roughly the same ~99s.
+	// attempt ceiling still spans roughly the same ~99s.
 	initialDownloadRetryDelay = 250 * time.Millisecond
 	maxDownloadRetryDelay     = time.Second
+	downloadMaxAttempts       = 100
 
 	// Bounded so a keep-alive connection can be reused without reading an unbounded
 	// body from a failing server.
@@ -683,7 +684,7 @@ func downloadSingleFileWithResult(ac *client.AlpaconClient, remotePath, dest, se
 		return DownloadedFile{}, fmt.Errorf("%s", status.Result)
 	}
 
-	localPath, written, err := saveDownloadedURL(ac.HTTPClient, downloadResponse.DownloadURL, dest, remotePath, recursive, 100)
+	localPath, written, err := saveDownloadedURL(ac.HTTPClient, downloadResponse.DownloadURL, dest, remotePath, recursive, downloadMaxAttempts)
 	if err != nil {
 		return DownloadedFile{}, err
 	}
@@ -743,7 +744,7 @@ func downloadBulk(ac *client.AlpaconClient, remotePaths []string, dest, serverID
 		return err
 	}
 	defer func() { _ = utils.DeleteFile(zipPath) }()
-	written, err := fetchFromURLToFile(ac.HTTPClient, response.DownloadURL, zipPath, 100)
+	written, err := fetchFromURLToFile(ac.HTTPClient, response.DownloadURL, zipPath, downloadMaxAttempts)
 	if err != nil {
 		return fmt.Errorf("failed to save downloaded archive: %w", err)
 	}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -31,25 +31,37 @@ const (
 	initialPollInterval = 250 * time.Millisecond
 	maxPollInterval     = 2 * time.Second
 	pollBackoffFactor   = 2
-	basePollTimeout     = 30 * time.Second
-	perFilePollTimeout  = 10 * time.Second
-	perMBPollTimeout    = 5 * time.Second
+
+	// Download retries back off to maxDownloadRetryDelay, chosen so the total wait over
+	// maxAttempts stays what the flat one-second retry gave while a brief blip recovers
+	// sooner.
+	initialDownloadRetryDelay = 250 * time.Millisecond
+	maxDownloadRetryDelay     = time.Second
+
+	basePollTimeout    = 30 * time.Second
+	perFilePollTimeout = 10 * time.Second
+	perMBPollTimeout   = 5 * time.Second
 
 	bulkUploadConcurrency = 4 // uploads transfer payload bytes, keep low
 	bulkPollConcurrency   = 8 // status polls are lightweight, allow more
 )
 
-// nextPollInterval returns the backoff delay for a 0-based poll attempt:
-// initialPollInterval doubled per attempt, capped at maxPollInterval.
-func nextPollInterval(attempt int) time.Duration {
-	d := initialPollInterval
+// backoffDelay returns initial doubled once per 0-based attempt, capped at limit.
+func backoffDelay(attempt int, initial, limit time.Duration) time.Duration {
+	d := initial
 	for i := 0; i < attempt; i++ {
 		d *= pollBackoffFactor
-		if d >= maxPollInterval {
-			return maxPollInterval
+		if d >= limit {
+			return limit
 		}
 	}
 	return d
+}
+
+// nextPollInterval returns the backoff delay for a 0-based poll attempt:
+// initialPollInterval doubled per attempt, capped at maxPollInterval.
+func nextPollInterval(attempt int) time.Duration {
+	return backoffDelay(attempt, initialPollInterval, maxPollInterval)
 }
 
 // alignedPollDelay returns the sleep before the next poll: the backoff for this
@@ -546,15 +558,17 @@ func fetchFromURLToFile(httpClient *http.Client, url, filePath string, maxAttemp
 		}
 		_ = resp.Body.Close()
 
-		// Client errors (4xx) will never succeed on retry
-		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		// Client errors (4xx) will never succeed on retry—except 408 and 429, which ask
+		// for exactly that. A throttled download otherwise fails on the first 429.
+		retryLater := resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests
+		if !retryLater && resp.StatusCode >= 400 && resp.StatusCode < 500 {
 			return 0, fmt.Errorf("download failed with client error: %d", resp.StatusCode)
 		}
 
 		if count == maxAttempts-1 {
 			return 0, fmt.Errorf("download failed after %d attempts (last status: %d)", maxAttempts, resp.StatusCode)
 		}
-		time.Sleep(time.Second)
+		time.Sleep(backoffDelay(count, initialDownloadRetryDelay, maxDownloadRetryDelay))
 	}
 
 	defer func() { _ = resp.Body.Close() }()

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -39,6 +39,10 @@ const (
 	maxDownloadRetryDelay     = time.Second
 	downloadMaxAttempts       = 100
 
+	// A server that answered "too many requests" is not persuaded by ninety more of
+	// them. Without Retry-After the throttle window is a guess, so this errs small.
+	throttledMaxAttempts = 10
+
 	// The drain only buys connection reuse, and the shared client sets no timeout,
 	// so this bound is the retry loop's only defense against a stalled error body.
 	maxDrainedErrorBody = 8 << 10
@@ -569,8 +573,12 @@ func fetchFromURLToFile(httpClient *http.Client, url, filePath string, maxAttemp
 			return 0, fmt.Errorf("download failed with client error: %d", resp.StatusCode)
 		}
 
-		if count == maxAttempts-1 {
-			return 0, fmt.Errorf("download failed after %d attempts (last status: %d)", maxAttempts, resp.StatusCode)
+		budget := maxAttempts
+		if utils.IsRetryLaterStatus(resp.StatusCode) {
+			budget = min(budget, throttledMaxAttempts)
+		}
+		if count >= budget-1 {
+			return 0, fmt.Errorf("download failed after %d attempts (last status: %d)", budget, resp.StatusCode)
 		}
 		time.Sleep(backoffDelay(count, initialDownloadRetryDelay, maxDownloadRetryDelay))
 	}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -33,14 +33,14 @@ const (
 	initialPollInterval = 250 * time.Millisecond
 	maxPollInterval     = 2 * time.Second
 
-	// A brief blip recovers sooner than the flat one-second retry did, while the
-	// attempt ceiling still spans roughly the same ~99s.
+	// A brief blip recovers sooner than the flat one-second retry did, while
+	// downloadMaxAttempts still spans roughly the same ~99s.
 	initialDownloadRetryDelay = 250 * time.Millisecond
 	maxDownloadRetryDelay     = time.Second
 	downloadMaxAttempts       = 100
 
-	// A server that answered "too many requests" is not persuaded by ninety more of
-	// them. Without Retry-After the throttle window is a guess, so this errs small.
+	// A server that answered "too many requests" is not persuaded by more of them,
+	// and without Retry-After the window is a guess—so this errs small.
 	throttledMaxAttempts = 10
 
 	// The drain only buys connection reuse, and the shared client sets no timeout,

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -27,10 +27,12 @@ const (
 	downloadBulkAPIURL   = "/api/webftp/downloads/bulk/"
 	downloadStatusURL    = "/api/webftp/downloads/%s/status/"
 
+	// Shared by the poll interval and the download retry delay.
+	backoffFactor = 2
+
 	// Poll interval backs off exponentially up to maxPollInterval.
 	initialPollInterval = 250 * time.Millisecond
 	maxPollInterval     = 2 * time.Second
-	pollBackoffFactor   = 2
 
 	// Download retries back off to maxDownloadRetryDelay, chosen so the total wait over
 	// maxAttempts stays what the flat one-second retry gave while a brief blip recovers
@@ -50,7 +52,7 @@ const (
 func backoffDelay(attempt int, initial, limit time.Duration) time.Duration {
 	d := initial
 	for range attempt {
-		d *= pollBackoffFactor
+		d *= backoffFactor
 		if d >= limit {
 			return limit
 		}

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -39,9 +39,9 @@ const (
 	maxDownloadRetryDelay     = time.Second
 	downloadMaxAttempts       = 100
 
-	// Bounded so a keep-alive connection can be reused without reading an unbounded
-	// body from a failing server.
-	maxDrainedErrorBody = 64 << 10
+	// The drain only buys connection reuse, and the shared client sets no timeout,
+	// so this bound is the retry loop's only defense against a stalled error body.
+	maxDrainedErrorBody = 8 << 10
 
 	basePollTimeout    = 30 * time.Second
 	perFilePollTimeout = 10 * time.Second

--- a/api/ftp/ftp.go
+++ b/api/ftp/ftp.go
@@ -34,9 +34,9 @@ const (
 	initialPollInterval = 250 * time.Millisecond
 	maxPollInterval     = 2 * time.Second
 
-	// Download retries back off to maxDownloadRetryDelay, chosen so the total wait over
-	// maxAttempts stays what the flat one-second retry gave while a brief blip recovers
-	// sooner.
+	// Download retries back off to maxDownloadRetryDelay, so a brief blip recovers sooner
+	// while the 100-attempt ceiling still spans roughly the ~99s the flat one-second retry
+	// took.
 	initialDownloadRetryDelay = 250 * time.Millisecond
 	maxDownloadRetryDelay     = time.Second
 

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1434,6 +1434,37 @@ func TestFetchFromURLToFile_GivesUpOnAFatalClientError(t *testing.T) {
 	assert.Equal(t, int32(1), calls.Load(), "a 404 will be a 404 again")
 }
 
+func TestFetchFromURLToFile_StopsDrainingAStalledErrorBody(t *testing.T) {
+	stall := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(stall) }) }
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write(make([]byte, maxDrainedErrorBody+1))
+		w.(http.Flusher).Flush()
+		<-stall
+	}))
+	defer ts.Close()
+	defer release() // the handler holds the server open, so it has to run first
+
+	path := filepath.Join(t.TempDir(), "out")
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := fetchFromURLToFile(ts.Client(), ts.URL, path, 1)
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client error: 404")
+	case <-time.After(5 * time.Second):
+		release()
+		t.Fatal("the drain read past maxDrainedErrorBody and blocked on the stalled body")
+	}
+}
+
 func TestBackoffDelay(t *testing.T) {
 	tests := []struct {
 		attempt int

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1433,36 +1433,45 @@ func TestFetchFromURLToFile_RetriesRetryableStatuses(t *testing.T) {
 }
 
 func TestFetchFromURLToFile_StopsAtTheAttemptBudget(t *testing.T) {
-	var calls atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls.Add(1)
-		w.WriteHeader(http.StatusTooManyRequests)
-	}))
-	defer ts.Close()
+	tests := []struct {
+		name        string
+		maxAttempts int
+		wantCalls   int32
+		wantErr     string
+	}{
+		{
+			name:        "caller budget",
+			maxAttempts: 2,
+			wantCalls:   2,
+			wantErr:     "download failed after 2 attempts (last status: 429)",
+		},
+		{
+			name:        "throttle budget",
+			maxAttempts: downloadMaxAttempts,
+			wantCalls:   throttledMaxAttempts,
+			wantErr:     "download failed after 10 attempts (last status: 429)",
+		},
+	}
 
-	path := filepath.Join(t.TempDir(), "out")
-	_, err := fetchFromURLToFile(ts.Client(), ts.URL, path, 2)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(http.StatusTooManyRequests)
+			}))
+			defer ts.Close()
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "download failed after 2 attempts (last status: 429)")
-	assert.Equal(t, int32(2), calls.Load(), "the budget is spent, not exceeded")
-	_, statErr := os.Stat(path)
-	assert.True(t, os.IsNotExist(statErr))
-}
+			path := filepath.Join(t.TempDir(), "out")
+			_, err := fetchFromURLToFile(ts.Client(), ts.URL, path, tt.maxAttempts)
 
-func TestFetchFromURLToFile_SpendsASmallerBudgetOnAThrottle(t *testing.T) {
-	var calls atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls.Add(1)
-		w.WriteHeader(http.StatusTooManyRequests)
-	}))
-	defer ts.Close()
-
-	_, err := fetchFromURLToFile(ts.Client(), ts.URL, filepath.Join(t.TempDir(), "out"), downloadMaxAttempts)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "download failed after 10 attempts (last status: 429)")
-	assert.Equal(t, int32(throttledMaxAttempts), calls.Load(), "a throttle does not get the full download budget")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Equal(t, tt.wantCalls, calls.Load(), "the budget is spent, not exceeded")
+			_, statErr := os.Stat(path)
+			assert.True(t, os.IsNotExist(statErr))
+		})
+	}
 }
 
 func TestFetchFromURLToFile_StopsDrainingAStalledErrorBody(t *testing.T) {

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -777,22 +777,34 @@ func TestPollTransferStatus_Timeout(t *testing.T) {
 }
 
 func TestFetchFromURL_ClientErrorNoRetry(t *testing.T) {
-	var requestCount atomic.Int32
+	tests := []struct {
+		name    string
+		status  int
+		wantErr string
+	}{
+		{name: "forbidden", status: http.StatusForbidden, wantErr: "client error: 403"},
+		{name: "not found", status: http.StatusNotFound, wantErr: "client error: 404"},
+	}
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount.Add(1)
-		w.WriteHeader(http.StatusForbidden)
-	}))
-	defer ts.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestCount atomic.Int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requestCount.Add(1)
+				w.WriteHeader(tt.status)
+			}))
+			defer ts.Close()
 
-	dest := filepath.Join(t.TempDir(), "download.bin")
-	_, err := fetchFromURLToFile(ts.Client(), ts.URL, dest, 10)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "client error: 403")
-	// Should fail on first attempt, not retry
-	assert.Equal(t, int32(1), requestCount.Load())
-	_, statErr := os.Stat(dest)
-	assert.True(t, os.IsNotExist(statErr))
+			dest := filepath.Join(t.TempDir(), "download.bin")
+			_, err := fetchFromURLToFile(ts.Client(), ts.URL, dest, 10)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Equal(t, int32(1), requestCount.Load(), "a fatal client error fails the same way on retry")
+			_, statErr := os.Stat(dest)
+			assert.True(t, os.IsNotExist(statErr))
+		})
+	}
 }
 
 func TestFetchFromURLToFile_ReadErrorKeepsExistingFile(t *testing.T) {
@@ -1417,21 +1429,6 @@ func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {
 			assert.Equal(t, int32(2), calls.Load(), "the status asks for a retry")
 		})
 	}
-}
-
-func TestFetchFromURLToFile_GivesUpOnAFatalClientError(t *testing.T) {
-	var calls atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls.Add(1)
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer ts.Close()
-
-	_, err := fetchFromURLToFile(ts.Client(), ts.URL, filepath.Join(t.TempDir(), "out"), 5)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "client error: 404")
-	assert.Equal(t, int32(1), calls.Load(), "a 404 will be a 404 again")
 }
 
 func TestFetchFromURLToFile_StopsDrainingAStalledErrorBody(t *testing.T) {

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1450,3 +1450,8 @@ func TestBackoffDelay(t *testing.T) {
 		assert.Equal(t, tt.want, backoffDelay(tt.attempt, initialDownloadRetryDelay, maxDownloadRetryDelay))
 	}
 }
+
+func TestBackoffDelay_CapsAnInitialAlreadyOverTheLimit(t *testing.T) {
+	assert.Equal(t, time.Second, backoffDelay(0, 5*time.Second, time.Second))
+	assert.Equal(t, time.Second, backoffDelay(3, 5*time.Second, time.Second))
+}

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1450,6 +1450,21 @@ func TestFetchFromURLToFile_StopsAtTheAttemptBudget(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr))
 }
 
+func TestFetchFromURLToFile_SpendsASmallerBudgetOnAThrottle(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	_, err := fetchFromURLToFile(ts.Client(), ts.URL, filepath.Join(t.TempDir(), "out"), downloadMaxAttempts)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "download failed after 10 attempts (last status: 429)")
+	assert.Equal(t, int32(throttledMaxAttempts), calls.Load(), "a throttle does not get the full download budget")
+}
+
 func TestFetchFromURLToFile_StopsDrainingAStalledErrorBody(t *testing.T) {
 	stall := make(chan struct{})
 	var releaseOnce sync.Once

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1399,9 +1399,9 @@ func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var calls int32
+			var calls atomic.Int32
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				if atomic.AddInt32(&calls, 1) == 1 {
+				if calls.Add(1) == 1 {
 					w.WriteHeader(tt.firstStatus)
 					return
 				}
@@ -1414,15 +1414,15 @@ func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, int64(len("payload")), written)
-			assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "the status asks for a retry")
+			assert.Equal(t, int32(2), calls.Load(), "the status asks for a retry")
 		})
 	}
 }
 
 func TestFetchFromURLToFile_GivesUpOnAFatalClientError(t *testing.T) {
-	var calls int32
+	var calls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&calls, 1)
+		calls.Add(1)
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer ts.Close()
@@ -1431,7 +1431,7 @@ func TestFetchFromURLToFile_GivesUpOnAFatalClientError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "client error: 404")
-	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a 404 will be a 404 again")
+	assert.Equal(t, int32(1), calls.Load(), "a 404 will be a 404 again")
 }
 
 func TestBackoffDelay(t *testing.T) {

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -24,6 +24,14 @@ import (
 
 func boolPtr(b bool) *bool { return &b }
 
+// swapDownloadRetryDelays keeps the retry assertions off the production backoff,
+// which sleeps ~8s per exhausted budget.
+func swapDownloadRetryDelays(initial, max time.Duration) func() {
+	oi, om := initialDownloadRetryDelay, maxDownloadRetryDelay
+	initialDownloadRetryDelay, maxDownloadRetryDelay = initial, max
+	return func() { initialDownloadRetryDelay, maxDownloadRetryDelay = oi, om }
+}
+
 func createTestZip(t *testing.T, files map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
@@ -1433,6 +1441,8 @@ func TestFetchFromURLToFile_RetriesRetryableStatuses(t *testing.T) {
 }
 
 func TestFetchFromURLToFile_StopsAtTheAttemptBudget(t *testing.T) {
+	defer swapDownloadRetryDelays(time.Millisecond, 2*time.Millisecond)()
+
 	tests := []struct {
 		name        string
 		maxAttempts int
@@ -1536,7 +1546,7 @@ func TestBackoffDelay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, backoffDelay(tt.attempt, initialDownloadRetryDelay, maxDownloadRetryDelay))
+			assert.Equal(t, tt.want, backoffDelay(tt.attempt, 250*time.Millisecond, time.Second))
 		})
 	}
 }

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1436,20 +1436,37 @@ func TestFetchFromURLToFile_StopsAtTheAttemptBudget(t *testing.T) {
 	tests := []struct {
 		name        string
 		maxAttempts int
+		statusFor   func(call int32) int
 		wantCalls   int32
 		wantErr     string
 	}{
 		{
 			name:        "caller budget",
 			maxAttempts: 2,
+			statusFor:   func(int32) int { return http.StatusTooManyRequests },
 			wantCalls:   2,
 			wantErr:     "download failed after 2 attempts (last status: 429)",
 		},
 		{
 			name:        "throttle budget",
 			maxAttempts: downloadMaxAttempts,
+			statusFor:   func(int32) int { return http.StatusTooManyRequests },
 			wantCalls:   throttledMaxAttempts,
 			wantErr:     "download failed after 10 attempts (last status: 429)",
+		},
+		{
+			// The throttle budget collapses below the attempts already spent, so the
+			// loop has to stop on the first 429 and count what it made, not the budget.
+			name:        "throttle budget after other failures",
+			maxAttempts: downloadMaxAttempts,
+			statusFor: func(call int32) int {
+				if call <= throttledMaxAttempts {
+					return http.StatusBadGateway
+				}
+				return http.StatusTooManyRequests
+			},
+			wantCalls: throttledMaxAttempts + 1,
+			wantErr:   "download failed after 11 attempts (last status: 429)",
 		},
 	}
 
@@ -1457,8 +1474,7 @@ func TestFetchFromURLToFile_StopsAtTheAttemptBudget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var calls atomic.Int32
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				calls.Add(1)
-				w.WriteHeader(http.StatusTooManyRequests)
+				w.WriteHeader(tt.statusFor(calls.Add(1)))
 			}))
 			defer ts.Close()
 

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -228,7 +228,7 @@ func TestExecuteBulkUpload_UploadsConcurrently(t *testing.T) {
 	go func() {
 		errCh <- executeBulkUpload(ac, request, files, sizes)
 	}()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case <-uploadsEntered:
 		case <-time.After(2 * time.Second):
@@ -288,7 +288,7 @@ func TestExecuteBulkUpload_PollsConcurrently(t *testing.T) {
 	go func() {
 		errCh <- executeBulkUpload(ac, request, files, sizes)
 	}()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case <-pollsEntered:
 		case <-time.After(2 * time.Second):
@@ -1290,9 +1290,9 @@ func TestPollTransferStatus_BacksOffThenSucceeds(t *testing.T) {
 	// With adaptive backoff the two waits are 250ms + 500ms = 750ms, far below
 	// the old fixed 2s+2s = 4s. Assert both the poll count and a loose upper
 	// bound that the old fixed interval could not have met.
-	var calls int32
+	var calls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&calls, 1)
+		n := calls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		if n < 3 {
 			_ = json.NewEncoder(w).Encode(TransferStatusResponse{Success: nil})
@@ -1311,7 +1311,7 @@ func TestPollTransferStatus_BacksOffThenSucceeds(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, success)
 	assert.Equal(t, "done", message)
-	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+	assert.Equal(t, int32(3), calls.Load())
 	// Lower bound proves the two waits actually backed off (250ms+500ms);
 	// loose upper bound proves it beat the old fixed 2s+2s without being
 	// flaky under slow CI scheduling.
@@ -1322,9 +1322,9 @@ func TestPollTransferStatus_BacksOffThenSucceeds(t *testing.T) {
 func TestPollTransferStatus_RetriesWhileInProgress(t *testing.T) {
 	// Retry keys off the "webftp_transfer_in_progress" payload, not the 422
 	// status: PollTransferStatus must back off and retry, not treat it as fatal.
-	var calls int32
+	var calls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&calls, 1)
+		n := calls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		if n < 3 {
 			w.WriteHeader(http.StatusUnprocessableEntity)
@@ -1342,15 +1342,15 @@ func TestPollTransferStatus_RetriesWhileInProgress(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, success)
 	assert.Equal(t, "done", message)
-	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+	assert.Equal(t, int32(3), calls.Load())
 }
 
 func TestPollTransferStatus_FatalErrorNoRetry(t *testing.T) {
 	// A non-in-progress error (e.g. 403) is fatal: return immediately without
 	// polling again.
-	var calls int32
+	var calls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
+		calls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "permission denied"})
@@ -1363,16 +1363,16 @@ func TestPollTransferStatus_FatalErrorNoRetry(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.False(t, success)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "fatal error must not be retried")
+	assert.Equal(t, int32(1), calls.Load(), "fatal error must not be retried")
 }
 
 func TestPollTransferStatus_TimesOut(t *testing.T) {
 	// Server never completes (success=null). With a timeout below the initial
 	// poll interval, the deadline check breaks before the first sleep, so a
 	// single poll happens and the timeout error is returned.
-	var calls int32
+	var calls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
+		calls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(TransferStatusResponse{Success: nil})
 	}))
@@ -1385,7 +1385,7 @@ func TestPollTransferStatus_TimesOut(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timed out")
 	assert.False(t, success)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	assert.Equal(t, int32(1), calls.Load())
 }
 
 func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1400,13 +1400,14 @@ func TestPollTransferStatus_TimesOut(t *testing.T) {
 	assert.Equal(t, int32(1), calls.Load())
 }
 
-func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {
+func TestFetchFromURLToFile_RetriesRetryableStatuses(t *testing.T) {
 	tests := []struct {
 		name        string
 		firstStatus int
 	}{
 		{name: "request timeout", firstStatus: http.StatusRequestTimeout},
 		{name: "too many requests", firstStatus: http.StatusTooManyRequests},
+		{name: "bad gateway", firstStatus: http.StatusBadGateway},
 	}
 
 	for _, tt := range tests {
@@ -1426,9 +1427,27 @@ func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, int64(len("payload")), written)
-			assert.Equal(t, int32(2), calls.Load(), "the status asks for a retry")
+			assert.Equal(t, int32(2), calls.Load(), "the status is retryable")
 		})
 	}
+}
+
+func TestFetchFromURLToFile_StopsAtTheAttemptBudget(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	path := filepath.Join(t.TempDir(), "out")
+	_, err := fetchFromURLToFile(ts.Client(), ts.URL, path, 2)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "download failed after 2 attempts (last status: 429)")
+	assert.Equal(t, int32(2), calls.Load(), "the budget is spent, not exceeded")
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr))
 }
 
 func TestFetchFromURLToFile_StopsDrainingAStalledErrorBody(t *testing.T) {

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1464,18 +1464,21 @@ func TestFetchFromURLToFile_StopsDrainingAStalledErrorBody(t *testing.T) {
 
 func TestBackoffDelay(t *testing.T) {
 	tests := []struct {
+		name    string
 		attempt int
 		want    time.Duration
 	}{
-		{attempt: 0, want: 250 * time.Millisecond},
-		{attempt: 1, want: 500 * time.Millisecond},
-		{attempt: 2, want: time.Second},
-		{attempt: 3, want: time.Second},
-		{attempt: 50, want: time.Second},
+		{name: "no doubling yet", attempt: 0, want: 250 * time.Millisecond},
+		{name: "one double", attempt: 1, want: 500 * time.Millisecond},
+		{name: "reaches the cap", attempt: 2, want: time.Second},
+		{name: "past the cap", attempt: 3, want: time.Second},
+		{name: "far past the cap", attempt: 50, want: time.Second},
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.want, backoffDelay(tt.attempt, initialDownloadRetryDelay, maxDownloadRetryDelay))
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, backoffDelay(tt.attempt, initialDownloadRetryDelay, maxDownloadRetryDelay))
+		})
 	}
 }
 

--- a/api/ftp/ftp_test.go
+++ b/api/ftp/ftp_test.go
@@ -1387,3 +1387,66 @@ func TestPollTransferStatus_TimesOut(t *testing.T) {
 	assert.False(t, success)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
 }
+
+func TestFetchFromURLToFile_RetriesRetryableClientErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		firstStatus int
+	}{
+		{name: "request timeout", firstStatus: http.StatusRequestTimeout},
+		{name: "too many requests", firstStatus: http.StatusTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if atomic.AddInt32(&calls, 1) == 1 {
+					w.WriteHeader(tt.firstStatus)
+					return
+				}
+				_, _ = w.Write([]byte("payload"))
+			}))
+			defer ts.Close()
+
+			path := filepath.Join(t.TempDir(), "out")
+			written, err := fetchFromURLToFile(ts.Client(), ts.URL, path, 3)
+
+			require.NoError(t, err)
+			assert.Equal(t, int64(len("payload")), written)
+			assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "the status asks for a retry")
+		})
+	}
+}
+
+func TestFetchFromURLToFile_GivesUpOnAFatalClientError(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	_, err := fetchFromURLToFile(ts.Client(), ts.URL, filepath.Join(t.TempDir(), "out"), 5)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client error: 404")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a 404 will be a 404 again")
+}
+
+func TestBackoffDelay(t *testing.T) {
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{attempt: 0, want: 250 * time.Millisecond},
+		{attempt: 1, want: 500 * time.Millisecond},
+		{attempt: 2, want: time.Second},
+		{attempt: 3, want: time.Second},
+		{attempt: 50, want: time.Second},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, backoffDelay(tt.attempt, initialDownloadRetryDelay, maxDownloadRetryDelay))
+	}
+}

--- a/utils/error.go
+++ b/utils/error.go
@@ -71,10 +71,14 @@ func HTTPStatusCode(err error) int {
 	return 0
 }
 
-// IsFatalClientError reports whether a 4xx will fail the same way on retry—408 and 429
-// ask for exactly that retry, so they are not fatal.
+// IsRetryLaterStatus reports whether a 4xx is asking to be retried rather than refusing.
+func IsRetryLaterStatus(status int) bool {
+	return status == http.StatusRequestTimeout || status == http.StatusTooManyRequests
+}
+
+// IsFatalClientError reports whether a 4xx will fail the same way on retry.
 func IsFatalClientError(status int) bool {
-	if status == http.StatusRequestTimeout || status == http.StatusTooManyRequests {
+	if IsRetryLaterStatus(status) {
 		return false
 	}
 	return status >= http.StatusBadRequest && status < http.StatusInternalServerError

--- a/utils/error.go
+++ b/utils/error.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 )
 
@@ -68,6 +69,15 @@ func HTTPStatusCode(err error) int {
 		}
 	}
 	return 0
+}
+
+// IsFatalClientError reports whether a 4xx will fail the same way on retry—408 and 429
+// ask for exactly that retry, so they are not fatal.
+func IsFatalClientError(status int) bool {
+	if status == http.StatusRequestTimeout || status == http.StatusTooManyRequests {
+		return false
+	}
+	return status >= http.StatusBadRequest && status < http.StatusInternalServerError
 }
 
 func ParseErrorResponse(err error) (string, string) {

--- a/utils/error_test.go
+++ b/utils/error_test.go
@@ -126,24 +126,26 @@ func TestWorkSessionConstants(t *testing.T) {
 	assert.Equal(t, 3, ExitCodeWorkSessionDenied)
 }
 
-func TestIsFatalClientError(t *testing.T) {
+func TestClientErrorBand(t *testing.T) {
 	tests := []struct {
-		name   string
-		status int
-		want   bool
+		name           string
+		status         int
+		wantFatal      bool
+		wantRetryLater bool
 	}{
-		{name: "not found", status: http.StatusNotFound, want: true},
-		{name: "forbidden", status: http.StatusForbidden, want: true},
-		{name: "request timeout", status: http.StatusRequestTimeout, want: false},
-		{name: "too many requests", status: http.StatusTooManyRequests, want: false},
-		{name: "server error", status: http.StatusInternalServerError, want: false},
-		{name: "ok", status: http.StatusOK, want: false},
-		{name: "no status carried", status: 0, want: false},
+		{name: "not found", status: http.StatusNotFound, wantFatal: true},
+		{name: "forbidden", status: http.StatusForbidden, wantFatal: true},
+		{name: "request timeout", status: http.StatusRequestTimeout, wantRetryLater: true},
+		{name: "too many requests", status: http.StatusTooManyRequests, wantRetryLater: true},
+		{name: "server error", status: http.StatusInternalServerError},
+		{name: "ok", status: http.StatusOK},
+		{name: "no status carried", status: 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, IsFatalClientError(tt.status))
+			assert.Equal(t, tt.wantFatal, IsFatalClientError(tt.status))
+			assert.Equal(t, tt.wantRetryLater, IsRetryLaterStatus(tt.status))
 		})
 	}
 }

--- a/utils/error_test.go
+++ b/utils/error_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -123,6 +124,28 @@ func TestWorkSessionConstants(t *testing.T) {
 	assert.Equal(t, "work_session_server_not_allowed", WorkSessionServerNotAllowed)
 	assert.Equal(t, "work_session_assignee_mismatch", WorkSessionAssigneeMismatch)
 	assert.Equal(t, 3, ExitCodeWorkSessionDenied)
+}
+
+func TestIsFatalClientError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		want   bool
+	}{
+		{name: "not found", status: http.StatusNotFound, want: true},
+		{name: "forbidden", status: http.StatusForbidden, want: true},
+		{name: "request timeout", status: http.StatusRequestTimeout, want: false},
+		{name: "too many requests", status: http.StatusTooManyRequests, want: false},
+		{name: "server error", status: http.StatusInternalServerError, want: false},
+		{name: "ok", status: http.StatusOK, want: false},
+		{name: "no status carried", status: 0, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsFatalClientError(tt.status))
+		})
+	}
 }
 
 func TestServerBusyExitCode(t *testing.T) {


### PR DESCRIPTION
## Background

`fetchFromURLToFile` (`api/ftp/ftp.go`) fetches the presigned download URL for `alpacon cp` and the bulk archive path. It rejected the whole 4xx range as unretryable:

```go
// Client errors (4xx) will never succeed on retry
if resp.StatusCode >= 400 && resp.StatusCode < 500 {
    return 0, fmt.Errorf("download failed with client error: %d", resp.StatusCode)
}
```

408 and 429 are the two that ask for exactly the retry this refuses. A throttled download fails on the first 429 rather than waiting it out. This is the same band `671d4bf` settled for the event session create; the download path was not updated with it.

The retry delay was also a flat `time.Sleep(time.Second)`, which is not a backoff — it hits a struggling server at a fixed rate regardless of how long it has been failing.

## Changes

| Commit | Change |
| --- | --- |
| `02bd577` | 408 and 429 take the retry path; the flat one-second sleep becomes an exponential backoff |
| `2cdf1af` | modernize the new loop and its test counters |
| `47bbbb4` | `pollBackoffFactor` becomes `backoffFactor`, now that both callers share it |
| `78ec29d` | drain the error body before closing it, so a retry reuses the connection |
| `7a5b0f4` | scope the retry-budget comment to the caller it actually holds for |
| `bc582e9` | the retry check spans the band by `http.Status*` constant, not `400` and `500` |
| `220f116` | finish modernizing the two files this branch touched |
| `ba6f42a` | `backoffDelay` clamps a seed that already exceeds its limit |
| `c2a9788` | the attempt ceiling both call sites pass becomes `downloadMaxAttempts` |
| `0bd8d1c` | the error-body drain shrinks from 64 KiB to 8 KiB |
| `14aa221` | the fatal-4xx check both retry loops copied moves to `utils.IsFatalClientError` |
| `6e42210` | a throttled download stops spending the full retry budget |
| `e6e5af2` | the exhaustion error reports the attempts made, not the budget |
| `a517331`, `8970b87`, `d4750af`, `e1d1f88`, `ccfc8d4`, `ddc52dd` | tests: fold the fatal-4xx cases into one table, name the backoff subtests, cover the 5xx retry and both attempt budgets, and take the budget test off the production backoff |
| `c4a91ed` | keep the retry-delay comments free of the constants below them |

408 and 429 now take the retry path. Every other 4xx still returns immediately.

The delay is exponential: 250ms, 500ms, then capped at one second. A brief blip recovers in a quarter of the time the flat sleep took, and `downloadMaxAttempts = 100` still spans roughly the same ~99s as before for the classes that keep the full budget.

The shape already existed in this file as `nextPollInterval`. Extracted it as `backoffDelay(attempt, initial, limit)` and made `nextPollInterval` call it, rather than writing a second copy that differed only in two constants. `nextPollInterval` and `alignedPollDelay` behavior is unchanged, and their existing tests still pass.

A 429 does not draw that full budget. `throttledMaxAttempts = 10` caps the retry-later class (408 and 429) at ten requests over about 7.75s, instead of a hundred over about 98s. A server that answered "too many requests" is not persuaded by more of them, and without `Retry-After` the right window is a guess — so the cap errs small. The budget is `min(maxAttempts, throttledMaxAttempts)` evaluated per response, which means it can collapse below the attempts already spent: a run that draws 5xx for fifty attempts and then a 429 stops on that 429 and reports fifty-one, not ten.

A non-200 response is drained before it is closed. An unread body keeps `net/http` from reusing the connection, so under throttling every retry would open a new one — the opposite of what backing off is for. The drain is bounded at 8 KiB (`maxDrainedErrorBody`). The bound is a time defense, not a memory one: `client/client.go:50` builds the shared client with no `Timeout`, so an error body that stalls mid-read would block the retry loop indefinitely, and this bound is the only thing that stops it.

`utils.IsFatalClientError` and `utils.IsRetryLaterStatus` now hold the band. `api/ftp/ftp.go` and `api/event/watcher.go` were each spelling out `status >= 400 && status < 500` with their own exemptions, which is the part that drifts. `watcher.go` drops its `net/http` import entirely as a result, and `IsFatalClientError(0)` keeps its old behavior for an error carrying no status.

`backoffDelay` clamps its seed with `min(initial, limit)`. The cap previously applied only inside the doubling loop, so attempt 0 returned `initial` verbatim and the helper did not keep the guarantee its doc states. Neither caller passes such a pair today, so no runtime behavior changes; clamping the seed rather than the result preserves the early return that stops the doubling from overflowing at a large attempt count.

`initialDownloadRetryDelay` and `maxDownloadRetryDelay` are `var`, not `const`, so the attempt-budget test can swap in millisecond values and restore them. That test otherwise spends its entire runtime in `time.Sleep`: 16.80s of the package's 24.4s, none of it in an assertion. `api/event/event.go:30` already handles the same problem the same way.

The modernize commits are confined to the two files this branch already touches: counted `for` loops become `for range`, and the test counters that still used `atomic.AddInt32` / `atomic.LoadInt32` move to `atomic.Int32`, which every other counter in that file already used. The rest of the package is left for #279.

## Not addressed

`Retry-After` is ignored. Honoring it means threading a header through a function that currently only sees the status, and no server path emits it today. `Watcher.sessionCreateFailed` in `api/event/watcher.go` has the same gap, so closing it is a decision about both call sites rather than a local fix. `6e42210` carries a `Directive` trailer recording that `throttledMaxAttempts` is the value a parsed `Retry-After` should feed.

`http.Client.Timeout` is unset on the shared client, which is the real fix for a stalled error body. It also bounds the success-path read in `SaveStreamAtomic`, so its value is a decision about every API call the CLI makes — not something a download-retry fix should settle. The 8 KiB drain bound is the local containment until then.

`503 SlowDown` keeps the full `downloadMaxAttempts` budget. It is S3's own throttle signal, so the narrowing in `6e42210` lands on the proxy/WAF 429 while the storage backend's throttle still draws about a hundred requests. That is pre-existing behavior this branch did not change, and the fix is the same deadline conversion the `Directive` trailer points at: `100` was originally a 100-second budget expressed as a count (`ac13e7e`, next to a since-deleted "may timeout if it exceeds 100 seconds" warning), and this branch is what broke the one-attempt-equals-one-second identity that made the count mean a duration.

## Review

Copilot raised two findings; both were valid and are fixed. The undrained error body on the non-200 path was flagged as connection churn under throttling, now that the loop can run many times — fixed in `78ec29d`. `backoffDelay` was flagged for documenting a cap it did not apply at attempt 0 — fixed in `ba6f42a`.

@geunwoonoh raised six in round 1, all addressed:

| Finding | Resolution |
| --- | --- |
| the error-body drain blocks with no time bound | `0bd8d1c` — 64 KiB to 8 KiB, and the comment names time rather than memory as the exposure |
| a 429 draws the full 100-attempt budget | `6e42210` — `throttledMaxAttempts = 10` |
| the fatal-4xx band is duplicated across two retry loops | `14aa221` — `utils.IsFatalClientError` |
| `100` is a magic literal | `c2a9788` — `downloadMaxAttempts` |
| a new fatal-4xx test duplicates an existing one | `a517331` — folded in as a row |
| the backoff table needs `t.Run`, and 5xx and exhaustion are uncovered | `8970b87`, `d4750af`, `e1d1f88` |

`6e42210` introduced a defect of its own: the exhaustion error printed the budget, which shrinks to `throttledMaxAttempts` when the last response is a 429, so a run that spent fifty attempts on 5xx reported ten. Fixed in `e6e5af2`.

Round 2 approved with three non-blocking suggestions; the two that touch code are done. `e6e5af2` had no test that could distinguish it — both existing rows used a 429-only server, where the printed budget and the attempt count are numerically identical. `ccfc8d4` adds a row that serves 502 ten times and then a 429; reverting `count+1` to `budget` fails it, and swapping `count >= budget-1` for `==` fails it with a nil error after the loop runs to exhaustion and hands a closed body to `SaveStreamAtomic`. `ddc52dd` then takes that row and the existing one off the production backoff.

## Testing

```
gofmt -l .                       no output
go vet ./...                     pass
go build ./...                   pass
golangci-lint run ./...          0 issues
go test -race -count=1 ./...     38 packages ok
```

`api/ftp` runs in 7.8s. It was 24.4s before `ddc52dd`, against 7.46s before this branch.

New tests against `httptest`:

- 408, 429, and 502 each retried once, then 200
- 404 and 403 each fail after exactly one request, leaving no file behind
- the caller budget, the throttle budget, and a throttle budget that collapses below the attempts already spent
- an error body that stalls after `maxDrainedErrorBody` bytes returns rather than blocking
- `backoffDelay` ramp and saturation, plus a seed already over the limit
- `utils.IsFatalClientError` and `utils.IsRetryLaterStatus` across 404, 403, 408, 429, 500, 200, and a missing status

## Checklist

- [x] Builds, vets, formats clean
- [x] New behavior covered by tests
- [x] Existing poll-interval tests unaffected
