### PR TITLE
fix(websh): disarm the interrupt handler when the read-only terminal ends

### DIFF
--- a/api/websh/websh.go
+++ b/api/websh/websh.go
@@ -210,14 +210,12 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 	}
 	defer func() { _ = wsClient.conn.Close() }()
 
-	oldState, err := checkTerminal()
-	if err != nil {
-		utils.CliErrorWithExit("failed to set up terminal: %v", err)
-	}
-	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
-
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	// Registered before the term.Restore defer so LIFO runs it after: a signal
+	// arriving mid-teardown lands in the buffered channel instead of killing the
+	// process with the terminal still in raw mode.
+	defer signal.Stop(sigChan)
 	go func() {
 		<-sigChan
 		select {
@@ -225,6 +223,12 @@ func OpenReadOnlyTerminal(ac *client.AlpaconClient, sessionResponse SessionRespo
 		default:
 		}
 	}()
+
+	oldState, err := checkTerminal()
+	if err != nil {
+		utils.CliErrorWithExit("failed to set up terminal: %v", err)
+	}
+	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 
 	// In raw mode Ctrl+C is 0x03 — detect it to exit
 	go func() {


### PR DESCRIPTION
## Background

`OpenReadOnlyTerminal` (`api/websh/websh.go:200`) backs `alpacon websh watch`. It arms `os.Interrupt` and `SIGTERM` with `signal.Notify` and never stops them.

This is the only production `signal.Notify` in the repo without a matching `signal.Stop`. The three other sites — `cmd/tunnel/tunnel.go:141`, `cmd/tunnel/run.go:93`, and `cmd/event/watch.go:78` — already pair them. (`cmd/tunnel/run_test.go:271` also calls `Notify` without `Stop`, but it is a test subprocess whose every exit path is `os.Exit`, which skips defers anyway.)

## Changes

`defer signal.Stop(sigChan)` after the `Notify`, plus moving the signal setup above `checkTerminal` so the defer ordering is right.

**This is hygiene, not a user-visible bug fix.** The goroutine watching the channel does `<-sigChan` once and returns, so with the handler still armed, a second `SIGTERM` arriving between the return and the end of the deferred teardown would land in the buffered channel and be dropped rather than terminating the process. That window is microseconds wide, and reaching it takes two external `kill`s — the tty's Ctrl+C is not one of these signals, because `checkTerminal` puts the terminal in raw mode and Ctrl+C arrives as the byte `0x03` for the separate stdin goroutine to handle.

So the justification is cost, not impact: one line, and the site stops being the odd one out.

### Defer ordering

The `Stop` is registered **before** the `term.Restore` defer, so LIFO runs it **after**. Registering it last instead — the obvious placement — would disarm the handler at the top of the unwind, restoring the default terminate disposition while the terminal is still in raw mode. A signal landing in that window would kill the process before `term.Restore` runs and leave the user's shell needing `stty sane`, which is a window the pre-change code did not have: the armed handler absorbed the signal and teardown finished.

`cmd/event/watch.go:78` orders it the other way and says why in a comment — its teardown is `watcher.Stop()`, a network/goroutine unwind that can genuinely hang, so staying killable beats finishing cleanly. Here the teardown is a `tcsetattr` and a socket close; neither hangs, and `term.Restore` is the one that must not be skipped. Same reasoning, opposite conclusion, so the code carries a comment either way.

The signal setup stays **below** the websocket dial: arming earlier would make a hung handshake uninterruptible for the dialer's 45s timeout.

## Testing

`go build ./...`, `go vet ./...`, `gofmt` clean. `go test -race ./api/websh/... ./cmd/websh/...` passes.

No new test. The behavior needs a PTY, a fake websocket server, and a subprocess to receive real signals, and the window involved is the microseconds of teardown — not something a deterministic test can pin down. For a one-line hygiene change that bar is not worth clearing; verified by reading the exit paths instead.

## Checklist

- [x] Builds, vets, formats clean
- [x] Existing tests pass
- [ ] No test covers the behavior — see above
