### PR TITLE
feat(exec): guide users past the inline-credential gate

### DIFF
--- a/cmd/exec/credential_hint_test.go
+++ b/cmd/exec/credential_hint_test.go
@@ -1,0 +1,213 @@
+package exec
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	osexec "os/exec"
+	"testing"
+
+	"github.com/alpacax/alpacon-cli/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsCommandInlineCredentialError covers the pure code-matching helper: it
+// must fire only on utils.CommandInlineCredential, never on other codes, a nil
+// err, or a plain error without a code.
+func TestIsCommandInlineCredentialError(t *testing.T) {
+	t.Run("true when the error carries the inline-credential code", func(t *testing.T) {
+		err := errors.New("code: " + utils.CommandInlineCredential + "; source: command")
+		assert.True(t, isCommandInlineCredentialError(err))
+	})
+
+	t.Run("false for a different code", func(t *testing.T) {
+		err := errors.New("code: " + utils.WorkSessionRequired + "; source: command")
+		assert.False(t, isCommandInlineCredentialError(err))
+	})
+
+	t.Run("false for a plain error without a code", func(t *testing.T) {
+		assert.False(t, isCommandInlineCredentialError(errors.New("boom")))
+	})
+
+	t.Run("false for nil", func(t *testing.T) {
+		assert.False(t, isCommandInlineCredentialError(nil))
+	})
+}
+
+// TestCredentialInlineHint asserts the hint points at --env and never echoes a
+// credential value (there is nothing to echo—it's a fixed string—but this
+// guards against a future edit that starts interpolating the rejected line).
+func TestCredentialInlineHint(t *testing.T) {
+	hint := credentialInlineHint()
+	assert.Contains(t, hint, "--env")
+	assert.Contains(t, hint, "Hint:")
+	assert.NotContains(t, hint, "hunter2", "hint must never echo a credential value")
+}
+
+// newInlineCredentialDenialServer returns a test server that resolves one
+// server and rejects the command submission with the alpacon-server
+// inline-credential gate (command_inline_credential, ADR 0037).
+func newInlineCredentialDenialServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-1","name":"prod"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/events/commands/":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"code": "command_inline_credential", "source": "command"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestExecInlineCredentialDenialExits1WithJSONErrorCode drives the real exec
+// command through the inline-credential gate under --output json and asserts
+// the envelope carries the server's error_code with a plain (non-special)
+// exit code 1—this refusal is not a WorkSession gate or a pending approval.
+func TestExecInlineCredentialDenialExits1WithJSONErrorCode(t *testing.T) {
+	ts := newInlineCredentialDenialServer()
+	defer ts.Close()
+
+	home := t.TempDir()
+	writeExecCommandTestConfig(t, home, ts.URL)
+
+	helper := osexec.Command(
+		os.Args[0],
+		"-test.run=^TestExecCommandWorkSessionGateHelperProcess$",
+		"--",
+		"exec-worksession-helper",
+		"--output",
+		"json",
+		"prod",
+		"--",
+		"mysql",
+		"-pSecret",
+	)
+	helper.Env = append(os.Environ(),
+		"GO_WANT_EXEC_WORKSESSION_HELPER=1",
+		"ALPACON_WORK_SESSION=",
+		"HOME="+home,
+	)
+	var stdout, stderr bytes.Buffer
+	helper.Stdout = &stdout
+	helper.Stderr = &stderr
+
+	err := helper.Run()
+	require.Error(t, err)
+	var exitErr *osexec.ExitError
+	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	assert.Equal(t, 1, exitErr.ExitCode(), "inline-credential refusal uses the general failure exit code, not a dedicated one")
+	assert.Empty(t, stdout.String())
+
+	var envelope struct {
+		OK        bool   `json:"ok"`
+		ExitCode  int    `json:"exit_code"`
+		ErrorCode string `json:"error_code"`
+		Message   string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(stderr.Bytes(), &envelope), "stderr: %s", stderr.String())
+	assert.False(t, envelope.OK)
+	assert.Equal(t, 1, envelope.ExitCode)
+	assert.Equal(t, utils.CommandInlineCredential, envelope.ErrorCode)
+	assert.NotContains(t, stderr.String(), "-pSecret", "the rejected command line must never be echoed back")
+}
+
+// TestExecInlineCredentialDenialTablePrintsHint drives the same denial in the
+// default table output and asserts the human-facing error + hint, and that the
+// rejected command line is never echoed.
+func TestExecInlineCredentialDenialTablePrintsHint(t *testing.T) {
+	ts := newInlineCredentialDenialServer()
+	defer ts.Close()
+
+	home := t.TempDir()
+	writeExecCommandTestConfig(t, home, ts.URL)
+
+	helper := osexec.Command(
+		os.Args[0],
+		"-test.run=^TestExecCommandWorkSessionGateHelperProcess$",
+		"--",
+		"exec-worksession-helper",
+		"prod",
+		"--",
+		"mysql",
+		"-pSecret",
+	)
+	helper.Env = append(os.Environ(),
+		"GO_WANT_EXEC_WORKSESSION_HELPER=1",
+		"ALPACON_WORK_SESSION=",
+		"HOME="+home,
+	)
+	var stdout, stderr bytes.Buffer
+	helper.Stdout = &stdout
+	helper.Stderr = &stderr
+
+	err := helper.Run()
+	require.Error(t, err)
+	var exitErr *osexec.ExitError
+	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Empty(t, stdout.String())
+
+	out := stderr.String()
+	assert.Contains(t, out, "credential", "should explain the refusal reason")
+	assert.Contains(t, out, "Hint:")
+	assert.Contains(t, out, "--env")
+	assert.NotContains(t, out, "-pSecret", "the rejected command line must never be echoed back")
+}
+
+// TestExecNonInlineCredentialErrorFallsThroughUnchanged is a non-regression
+// check: a submission failure with a different (or no) error code must still
+// hit the pre-existing generic failure path (plain "Error: ..." line, no
+// credential hint), not the new branch.
+func TestExecNonInlineCredentialErrorFallsThroughUnchanged(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/servers/servers/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":"srv-1","name":"prod"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/events/commands/":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"detail": "some other rejection"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	home := t.TempDir()
+	writeExecCommandTestConfig(t, home, ts.URL)
+
+	helper := osexec.Command(
+		os.Args[0],
+		"-test.run=^TestExecCommandWorkSessionGateHelperProcess$",
+		"--",
+		"exec-worksession-helper",
+		"prod",
+		"id",
+	)
+	helper.Env = append(os.Environ(),
+		"GO_WANT_EXEC_WORKSESSION_HELPER=1",
+		"ALPACON_WORK_SESSION=",
+		"HOME="+home,
+	)
+	var stdout, stderr bytes.Buffer
+	helper.Stdout = &stdout
+	helper.Stderr = &stderr
+
+	err := helper.Run()
+	require.Error(t, err)
+	var exitErr *osexec.ExitError
+	require.True(t, errors.As(err, &exitErr), "expected child process exit error, got %T", err)
+	assert.Equal(t, 1, exitErr.ExitCode())
+
+	out := stderr.String()
+	assert.Contains(t, out, "some other rejection")
+	assert.NotContains(t, out, "Hint:", "unrelated errors must not surface the credential hint")
+	assert.NotContains(t, out, "--env")
+}

--- a/cmd/exec/run.go
+++ b/cmd/exec/run.go
@@ -23,6 +23,10 @@ import (
 // whose own output prints "(SUDO_RISK_DENIED)" from forging a hint.
 const sudoDenialLinePrefix = "Alpacon denied this sudo command"
 
+// commandInlineCredentialMessage is the exec-facing error line for the
+// alpacon-server inline-credential gate (utils.CommandInlineCredential, ADR 0037).
+const commandInlineCredentialMessage = "server rejected this command—the command line carries a credential, which would land in the audit log in plaintext"
+
 // approvalWaitPollInterval throttles the --wait re-attempt loop—slower than the MFA poll (api/mfa/mfa.go) since each tick re-runs the command; a var so tests can shorten it.
 var approvalWaitPollInterval = 5 * time.Second
 
@@ -82,6 +86,28 @@ func sudoDenialHint(output string) string {
 		}
 	}
 	return ""
+}
+
+// isCommandInlineCredentialError reports whether err carries the alpacon-server
+// inline-credential gate code (utils.CommandInlineCredential, ADR 0037): the
+// submitted command line itself contained a credential (e.g. a -p/--password
+// flag, a KEY=VALUE secret such as PGPASSWORD=..., or a user:pass@host
+// connection string), so the server refused the command before it ever ran
+// rather than record it in the audit log in plaintext.
+func isCommandInlineCredentialError(err error) bool {
+	code, _ := utils.ParseErrorResponse(err)
+	return code == utils.CommandInlineCredential
+}
+
+// credentialInlineHint returns the actionable guidance printed alongside
+// commandInlineCredentialMessage. It never echoes the rejected command
+// line—only fixed guidance naming --env—so it cannot leak the credential it is
+// warning about.
+func credentialInlineHint() string {
+	return fmt.Sprintf(
+		"%s move the secret to --env instead (its value is read from your shell, not the command line, and is never recorded):\n"+
+			"  alpacon exec --env=SECRET_NAME db-server -- <command>\n",
+		utils.Yellow("Hint:"))
 }
 
 // hasSudoPresenceDenial reports whether output carries the non-interactive sudo
@@ -318,6 +344,15 @@ func HandleCommandResult(err error) {
 		var clientTimeout *event.ClientTimeoutError
 		if errors.As(err, &clientTimeout) {
 			fmt.Fprint(os.Stderr, clientTimeoutLine())
+			os.Exit(1)
+		}
+		if isCommandInlineCredentialError(err) {
+			if utils.OutputFormat == utils.OutputFormatJSON {
+				utils.CliErrorEnvelopeWithExit("command", err, "%s.", commandInlineCredentialMessage)
+				return
+			}
+			fmt.Fprintf(os.Stderr, "%s: %s.\n", utils.Red("Error"), commandInlineCredentialMessage)
+			fmt.Fprint(os.Stderr, credentialInlineHint())
 			os.Exit(1)
 		}
 		utils.CliErrorWithExit("%s", err)

--- a/utils/error.go
+++ b/utils/error.go
@@ -14,6 +14,13 @@ const (
 	// ServerBusyWithUserWork: disruptive action refused; --force overrides it.
 	ServerBusyWithUserWork = "server_busy_with_user_work"
 
+	// CommandInlineCredential: alpacon-server refused a command because its command
+	// line carries a credential (e.g. a -p/--password flag, a KEY=VALUE secret such
+	// as PGPASSWORD=..., or a user:pass@host connection string), which would
+	// otherwise be recorded in the audit log in plaintext. Move the secret to
+	// --env instead. See alpacon-server ADR 0037 (Refs alpacax/alpacon-server#2745).
+	CommandInlineCredential = "command_inline_credential"
+
 	// WorkSession gate codes (returned by alpacon-server work_sessions/services.py)
 	WorkSessionRequired         = "work_session_required"
 	WorkSessionNotUsable        = "work_session_not_usable"


### PR DESCRIPTION
## 배경

alpacon-server에 인라인 credential 게이트가 머지되어(ADR 0037), 명령줄에 credential이 실린 명령(`mysql -pSecret`, `PGPASSWORD=...` 같은 KEY=VALUE secret, `postgresql://user:pw@host` connection string 등)은 `POST /api/events/commands/`가 400 `{"code": "command_inline_credential"}`로 거부합니다.

기존 CLI는 이 코드를 몰라서 `parseAPIErrorPayload`의 필드-나열 폴백이 메시지를 `"code: command_inline_credential"`로 만들고, 최종적으로 `Error: failed to execute command on 'X' server: code: command_inline_credential`만 뜨고 끝났습니다. 사용자가 뭘 어떻게 고쳐야 하는지 안내가 전혀 없었습니다.

## 변경 사항

- `utils.CommandInlineCredential` 상수를 기존 에러 코드 상수들(`AuthMFARequired`, `WorkSession*` 등) 옆에 추가 (`utils/error.go`)
- `cmd/exec/run.go`의 `HandleCommandResult`에서 `utils.ParseErrorResponse(err)`로 이 코드를 감지하면:
  - **테이블 모드**: 기존 sudo denial 힌트와 같은 문체로 `Error: ...` + `Hint: --env로 옮기라`는 안내 + 예시 한 줄 출력 (원 명령줄은 절대 echo하지 않음 — KEY만 예시로 보여줌)
  - **JSON 모드(`--output json`)**: `utils.CliErrorEnvelopeWithExit`를 사용해 `error_code: "command_inline_credential"`이 envelope에 실리도록 함
- exit code는 기존 일반 실패와 동일하게 **1** 유지 (전용 exit code 없음)
- 매칭되지 않는 다른 코드는 기존 경로(`CliErrorWithExit`) 그대로 무회귀

## 실제 출력 예시

테이블 모드:
```
Error: server rejected this command—the command line carries a credential, which would land in the audit log in plaintext.
Hint: move the secret to --env instead (its value is read from your shell, not the command line, and is never recorded):
  alpacon exec --env=SECRET_NAME db-server -- <command>
```

JSON 모드 (stderr):
```json
{
  "ok": false,
  "exit_code": 1,
  "error_code": "command_inline_credential",
  "message": "server rejected this command—the command line carries a credential, which would land in the audit log in plaintext.",
  "context": {
    "operation": "command"
  }
}
```

## 테스트

- `cmd/exec/credential_hint_test.go` 신규: 코드 매칭 시 힌트/envelope 출력 검증(테이블+JSON), 미매칭 시 기존 경로 무회귀 검증, 두 케이스 모두 원 명령줄(`-pSecret`)이 stderr에 echo되지 않음을 확인
- `gofmt -l .` 클린, `go vet ./...` 통과, `go test -race ./...` 전체 통과

## 후속 논의

`credential_exposure_acknowledged` 같은 "알면서도 강행" 플래그는 이번 PR에 포함하지 않았습니다. 필요성 논의 후 별도 PR로 진행합니다.

Refs alpacax/alpacon-server#2745